### PR TITLE
Compare paf index timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To compile and install `impg` from source, you'll need a recent rust build toolc
 ## Authors
 
 Erik Garrison <erik.garrison@gmail.com>
+Andrea Guarracino <aguarra1@uthsc.edu>
 Bryce Kille <brycekille@gmail.com>
 
 ## License


### PR DESCRIPTION
Fixes #11 by a warning if the PAF file has a more recent modification timestamp than the `.impg` index file.

Feel free to change the warning message.