### PR TITLE
Fix invalid results in output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impg"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -233,20 +233,22 @@ impl Impg {
                     &metadata.get_cigar_ops(&self.paf_file, self.paf_gzi_index.as_ref())
                 );
 
-                let adjusted_interval = (
-                    Interval {
-                        first: adjusted_query_start,
-                        last: adjusted_query_end,
-                        metadata: metadata.query_id
-                    },
-                    adjusted_cigar,
-                    Interval {
-                        first: adjusted_target_start,
-                        last: adjusted_target_end,
-                        metadata: 0
-                    }
-                );
-                results.push(adjusted_interval);
+                if !adjusted_cigar.is_empty() {
+                    let adjusted_interval = (
+                        Interval {
+                            first: adjusted_query_start,
+                            last: adjusted_query_end,
+                            metadata: metadata.query_id
+                        },
+                        adjusted_cigar,
+                        Interval {
+                            first: adjusted_target_start,
+                            last: adjusted_target_end,
+                            metadata: 0
+                        }
+                    );
+                    results.push(adjusted_interval);
+                }
             });
         }
         results
@@ -282,20 +284,22 @@ impl Impg {
                         &metadata.get_cigar_ops(&self.paf_file, self.paf_gzi_index.as_ref())
                     );
 
-                    let adjusted_interval = (
-                        Interval {
-                            first: adjusted_query_start,
-                            last: adjusted_query_end,
-                            metadata: metadata.query_id
-                        },
-                        adjusted_cigar,
-                        Interval {
-                            first: adjusted_target_start,
-                            last: adjusted_target_end,
-                            metadata: 0
-                        }
-                    );
-                    results.push(adjusted_interval);
+                    if !adjusted_cigar.is_empty() {
+                        let adjusted_interval = (
+                            Interval {
+                                first: adjusted_query_start,
+                                last: adjusted_query_end,
+                                metadata: metadata.query_id
+                            },
+                            adjusted_cigar,
+                            Interval {
+                                first: adjusted_target_start,
+                                last: adjusted_target_end,
+                                metadata: 0
+                            }
+                        );
+                        results.push(adjusted_interval);
+                    }                    
 
                     if metadata.query_id != current_target {
                         let todo_range = (metadata.query_id, adjusted_query_start, adjusted_query_end);


### PR DESCRIPTION
This fixes an annoying bug that has been strangely hidden for a long time that affects all output formats. When a target range is not found in a query, no results should be emitted. By not doing any checks on the results, a lot of invalid ranges were returned (wrong ranges, ranges with length 0, or empty projected CIGAR strings).

I report an example with the PAF format as output that shows also the wrong target ranges (outside the interval used to query the alignments):

```shell
# number of wrong results
impg -p chr6.y1.s10p95.paf -r grch38#chr6:31972057-32055418 -P | grep 'cg:Z:$' -c     
28092

# number of valid results
impg -p chr6.y1.s10p95.paf -r grch38#chr6:31972057-32055418 -P | grep 'cg:Z:$' -cv
232

# A few invalid results
impg -p chr6.y1.s10p95.paf -r grch38#chr6:31972057-32055418 -P | grep 'cg:Z:$' | head | column -t     
HG03579#2#JAGYVT010000047.1  26762912  15990000  16040000  +  grch38#chr6  170805979  15961422  16011615  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG02080#1#JAHEOW010000032.1  56349618  15980000  16030000  +  grch38#chr6  170805979  15961437  16011454  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
NA18906#2#JAHEON010000095.1  24213007  15940000  15990000  +  grch38#chr6  170805979  15962138  16012310  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG01071#2#JAHBCE010000081.1  25027143  15930000  15980000  +  grch38#chr6  170805979  15962428  16012508  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG03486#1#JAHEOQ010000114.1  19325645  0         8340000   +  grch38#chr6  170805979  15962549  16012596  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG01952#2#JAHAMD010000016.1  59464697  15980000  16030000  +  grch38#chr6  170805979  15962782  16012783  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG02723#2#JAHEOT010000038.1  23679014  10940000  10990000  +  grch38#chr6  170805979  15962796  16012895  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG00438#1#JAHBCB010000067.1  24808650  15980000  16030000  +  grch38#chr6  170805979  15963320  16013504  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG02559#2#JAGYVJ010000064.1  59272483  15940000  15990000  +  grch38#chr6  170805979  15963723  16013901  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
HG02486#2#JAGYVL010000026.1  60776310  15850000  15900000  +  grch38#chr6  170805979  15963767  16013866  0  0  255  gi:f:NaN  bi:f:NaN  cg:Z:
```