### PR TITLE
Fix condition for `query_transitive`

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -302,7 +302,7 @@ impl Impg {
 
                         if metadata.query_id != current_target {
                             let todo_range = (metadata.query_id, adjusted_query_start, adjusted_query_end);
-                            if !visited.insert(todo_range) {
+                            if visited.insert(todo_range) {
                                 stack.push(todo_range);
                             }
                         }


### PR DESCRIPTION
This allows you to transitively collect all ranges aligned to the specified target range.

For example, in this implicit graph, we miss the alignment between `SGDref#1#chrXVI` (target) and `S288C#1#chrXVI` (query):
![scerevisiae8 chrXVI hack paf](https://github.com/user-attachments/assets/777e5101-e64b-4eea-9b55-d8a1fa812d1d)

```
impg -p x.paf  -r SGDref#1#chrXVI:20000-30000 | bedtools sort | bedtools merge
SGDref#1#chrXVI	20000	30000
SK1#1#chrXVI	22204	32216
```

But it can be collected now by requesting a transitive closure of the matches (`-x/--transitive`).

```
impg -p scerevisiae8.chrXVI.hack.paf  -r SGDref#1#chrXVI:20000-30000 -x | bedtools sort | bedtools merge
S288C#1#chrXVI	20246	30246
SGDref#1#chrXVI	20000	30000
SK1#1#chrXVI	22204	32216
```