### PR TITLE
do not explore the same ranges multiple times in `query_transitive`

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -313,7 +313,6 @@ impl Impg {
 
                             // Add non-overlapping portions to visited and stack
                             for (new_start, new_end) in new_ranges {
-                                //println!("\t\tnew {}:{}-{}", self.seq_index.get_name(metadata.query_id).unwrap(), new_start, new_end);
                                 ranges.push((new_start, new_end));
                                 stack.push((metadata.query_id, new_start, new_end));
                             }

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -233,7 +233,7 @@ impl Impg {
                     &metadata.get_cigar_ops(&self.paf_file, self.paf_gzi_index.as_ref())
                 );
 
-                if !adjusted_cigar.is_empty() {
+                if adjusted_query_start < adjusted_query_end && !adjusted_cigar.is_empty() {
                     let adjusted_interval = (
                         Interval {
                             first: adjusted_query_start,
@@ -287,7 +287,7 @@ impl Impg {
                         &metadata.get_cigar_ops(&self.paf_file, self.paf_gzi_index.as_ref())
                     );
 
-                    if !adjusted_cigar.is_empty() {
+                    if adjusted_query_start < adjusted_query_end && !adjusted_cigar.is_empty() {
                         let adjusted_interval = (
                             Interval {
                                 first: adjusted_query_start,


### PR DESCRIPTION
This significantly reduces execution times when running transitive queries on pangenomes. Duplicated outputs are still emitted, but it is not a big problem. It will addressed later.