### PR TITLE
Pangenome partitioning

### DIFF
--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+PAF=$1
+FASTA_FAI=$2
+AVG_WINDOW_SIZE=$3
+SAMPLE=$4
+
+grep $SAMPLE $FASTA_FAI -w -m 1 | awk -v OFS='\t' '{print($1,"0",$2)}' > $SAMPLE.bed
+bedtools makewindows -b $SAMPLE.bed -w $AVG_WINDOW_SIZE > windows.bed
+
+MASK_BED=mask.bed
+touch $MASK_BED
+
+MISSING_BED=missing.bed
+cut -f 1,2 $PAF | sort | uniq | awk -v OFS='\t' '{print($1,"0",$2,".",".","+")}' > $MISSING_BED
+
+num=0
+while [ -s windows.bed ]; do
+    echo "Processing new window set..."
+
+    cat windows.bed | while read REGION; do
+        REGION2=$(echo $REGION | sed 's/\t/:/' | sed 's/\t/-/')
+        echo Partition $num - $REGION
+
+        # Get partition
+        impg -p $PAF -r $REGION2 -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct > partition$num.tmp.bed
+
+        # Apply mask
+        bedtools subtract -a partition$num.tmp.bed -b $MASK_BED -s > partition$num.bed
+
+        # Update mask
+        cat partition$num.bed $MASK_BED | bedtools sort > $num.bed
+        bedtools merge -i $num.bed -s -c 4,5,6 -o distinct > $num.mask.bed
+        cp $num.mask.bed $MASK_BED
+
+        # Update missing
+        bedtools subtract -a $MISSING_BED -b partition$num.bed -s > $num.missing.bed
+        cp $num.missing.bed $MISSING_BED
+
+        # Cleanup
+        rm partition$num.tmp.bed $num.bed $num.merge.bed $num.missing.bed
+
+        num=$((num + 1))
+    done
+
+    # Check if there are any missing regions not covered by mask
+    bedtools subtract -a $MISSING_BED -b $MASK_BED -s > $num.remaining.bed
+    
+    if [ ! -s $num.remaining.bed ]; then
+        # If no remaining regions, we're done
+        ###rm $num.remaining.bed
+        break
+    fi
+
+    # Take longest missing range and create new windows
+    awk -v OFS='\t' '{print($0,$3-$2)}' $num.remaining.bed | sort -k 7,7nr | cut -f 1-6 | head -n 1 > $num.new.bed
+    bedtools makewindows -b $num.new.bed -w $AVG_WINDOW_SIZE > windows.bed
+    
+    # Cleanup
+    rm $num.remaining.bed $num.new.bed
+done
+
+rm windows.bed

--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -40,7 +40,7 @@ while [ -s $WINDOWS_BED ]; do
         REGION_FORMATTED="${chrom}:${start}-${end}"
 
         echo "Processing partition $num, region $REGION_FORMATTED..."
-        impg -p $PAF -r $REGION_FORMATTED -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct > partition$num.tmp.bed
+        impg -p $PAF -r $REGION_FORMATTED -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct -d 5000 > partition$num.tmp.bed
 
         # Apply mask
         bedtools subtract -a partition$num.tmp.bed -b $MASK_BED -s > partition$num.bed

--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -45,19 +45,25 @@ while [ -s $WINDOWS_BED ]; do
         # Apply mask
         bedtools subtract -a partition$num.tmp.bed -b $MASK_BED -s > partition$num.bed
 
-        # Update masked regions
-        cat partition$num.bed $MASK_BED | bedtools sort > $num.bed
-        bedtools merge -i $num.bed -s -c 4,5,6 -o distinct > $num.mask.bed
-        cp $num.mask.bed $MASK_BED
+        # Check if the partition is not empty
+        if [ -s partition$num.bed ]; then
 
-         # Update missing regions
-        bedtools subtract -a $MISSING_BED -b partition$num.bed -s > $num.missing.bed
-        cp $num.missing.bed $MISSING_BED
+            # Update masked regions
+            cat partition$num.bed $MASK_BED | bedtools sort > $num.bed
+            bedtools merge -i $num.bed -s -c 4,5,6 -o distinct > $num.mask.bed
+            cp $num.mask.bed $MASK_BED
 
-        # Cleanup
-        rm partition$num.tmp.bed $num.bed $num.mask.bed $num.missing.bed
+            # Update missing regions
+            bedtools subtract -a $MISSING_BED -b partition$num.bed -s > $num.missing.bed
+            cp $num.missing.bed $MISSING_BED
 
-        num=$((num + 1))
+            # Cleanup
+            rm partition$num.tmp.bed $num.bed $num.mask.bed $num.missing.bed
+
+            num=$((num + 1))
+        else
+            rm partition$num.tmp.bed partition$num.bed
+        fi
     done < $WINDOWS_BED
 
     # Check if there are any missing regions not covered by mask

--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -51,9 +51,8 @@ while [ -s "$WINDOWS_BED" ]; do
             echo "-- Processing partition $num"
 
             # Update masked regions
-            cat "partition$num.bed" "$MASK_BED" | bedtools sort > "$num.bed"
-            bedtools merge -i "$num.bed" -s -c 4,5,6 -o distinct > "$num.mask.bed"
-            cp "$num.mask.bed" "$MASK_BED"
+            cat "partition$num.bed" "$MASK_BED" | bedtools sort > "$num.mask.bed"
+            bedtools merge -i "$num.mask.bed" -s -c 4,5,6 -o distinct > "$MASK_BED"
 
             # Update missing regions
             bedtools subtract -a "$MISSING_BED" -b "partition$num.bed" -s > "$num.missing.bed"
@@ -77,4 +76,4 @@ while [ -s "$WINDOWS_BED" ]; do
 done
 
 # Cleanup
-rm -f "$SAMPLE.bed" "$WINDOWS_BED" "$MASK_BED" "$MISSING_BED" "partition[0-9]*.tmp.bed"" [0-9]*.{remaining,new}.bed"
+rm -f "$SAMPLE.bed" "$WINDOWS_BED" "$MASK_BED" "$MISSING_BED" partition[0-9]*.tmp.bed [0-9]*.{mask,missing,remaining,new}.bed

--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -1,58 +1,73 @@
 #!/bin/bash
 
+# Exit on error, undefined variables, and pipe failures
+set -euo pipefail
+
+# Check if all required arguments are provided
+if [ $# -ne 4 ]; then
+    echo "Usage: $0 <paf_file> <fasta_index> <window_size> <sample_name>"
+    exit 1
+fi
+
+# Input parameters
 PAF=$1
 FASTA_FAI=$2
 AVG_WINDOW_SIZE=$3
 SAMPLE=$4
 
+# Create initial bed file for the sample
 grep $SAMPLE $FASTA_FAI -w -m 1 | awk -v OFS='\t' '{print($1,"0",$2)}' > $SAMPLE.bed
 bedtools makewindows -b $SAMPLE.bed -w $AVG_WINDOW_SIZE > windows.bed
 
+# Prepare mask file
 MASK_BED=mask.bed
 touch $MASK_BED
 
+# Create initial missing regions file
 MISSING_BED=missing.bed
 cut -f 1,2 $PAF | sort | uniq | awk -v OFS='\t' '{print($1,"0",$2,".",".","+")}' > $MISSING_BED
 
+# Initialize partition counter
 num=0
+
+# Process windows until no missing regions remain
 while [ -s windows.bed ]; do
     echo "Processing new window set..."
 
-    cat windows.bed | while read REGION; do
-        REGION2=$(echo $REGION | sed 's/\t/:/' | sed 's/\t/-/')
-        echo Partition $num - $REGION
+    while IFS=$'\t' read -r chrom start end; do
+        # Get partition, sort, and merge to avoid duplicates
+        REGION_FORMATTED="${chrom}:${start}-${end}"
 
-        # Get partition
-        impg -p $PAF -r $REGION2 -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct > partition$num.tmp.bed
+        echo "Processing partition $num, region $REGION_FORMATTED..."
+        impg -p $PAF -r $REGION_FORMATTED -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct > partition$num.tmp.bed
 
         # Apply mask
         bedtools subtract -a partition$num.tmp.bed -b $MASK_BED -s > partition$num.bed
 
-        # Update mask
+        # Update masked regions
         cat partition$num.bed $MASK_BED | bedtools sort > $num.bed
         bedtools merge -i $num.bed -s -c 4,5,6 -o distinct > $num.mask.bed
         cp $num.mask.bed $MASK_BED
 
-        # Update missing
+         # Update missing regions
         bedtools subtract -a $MISSING_BED -b partition$num.bed -s > $num.missing.bed
         cp $num.missing.bed $MISSING_BED
 
         # Cleanup
-        rm partition$num.tmp.bed $num.bed $num.merge.bed $num.missing.bed
+        rm partition$num.tmp.bed $num.bed $num.mask.bed $num.missing.bed
 
         num=$((num + 1))
-    done
+    done < windows.bed
 
     # Check if there are any missing regions not covered by mask
     bedtools subtract -a $MISSING_BED -b $MASK_BED -s > $num.remaining.bed
-    
     if [ ! -s $num.remaining.bed ]; then
         # If no remaining regions, we're done
-        ###rm $num.remaining.bed
+        rm $num.remaining.bed
         break
     fi
 
-    # Take longest missing range and create new windows
+    # Create new windows from longest remaining region
     awk -v OFS='\t' '{print($0,$3-$2)}' $num.remaining.bed | sort -k 7,7nr | cut -f 1-6 | head -n 1 > $num.new.bed
     bedtools makewindows -b $num.new.bed -w $AVG_WINDOW_SIZE > windows.bed
     

--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -2,6 +2,7 @@
 
 # Exit on error, undefined variables, and pipe failures
 set -euo pipefail
+#set -x # for debugging
 
 # Check if all required arguments are provided
 if [ $# -ne 4 ]; then
@@ -17,69 +18,63 @@ SAMPLE=$4
 
 # Prepare initial windows
 WINDOWS_BED=windows.bed
-grep $SAMPLE $FASTA_FAI -w -m 1 | awk -v OFS='\t' '{print($1,"0",$2)}' > $SAMPLE.bed
-bedtools makewindows -b $SAMPLE.bed -w $AVG_WINDOW_SIZE > $WINDOWS_BED
+grep $SAMPLE "$FASTA_FAI" -w -m 1 | awk -v OFS='\t' '{print($1,"0",$2)}' > "$SAMPLE.bed"
+bedtools makewindows -b "$SAMPLE.bed" -w "$AVG_WINDOW_SIZE" > "$WINDOWS_BED"
 
 # Prepare mask file
 MASK_BED=mask.bed
-cat /dev/null > $MASK_BED
+cat /dev/null > "$MASK_BED"
 
 # Create initial missing regions file
 MISSING_BED=missing.bed
-cut -f 1,2 $PAF | sort | uniq | awk -v OFS='\t' '{print($1,"0",$2,".",".","+")}' > $MISSING_BED
+cut -f 1,2 "$PAF" | sort | uniq | awk -v OFS='\t' '{print($1,"0",$2,".",".","+")}' > "$MISSING_BED"
 
 # Initialize partition counter
 num=0
 
 # Process windows until no missing regions remain
-while [ -s $WINDOWS_BED ]; do
-    echo "Processing new window set..."
+while [ -s "$WINDOWS_BED" ]; do
+    echo "Processing new window set"
 
     while IFS=$'\t' read -r chrom start end; do
         # Get partition, sort, and merge to avoid duplicates
         REGION_FORMATTED="${chrom}:${start}-${end}"
 
-        echo "Processing partition $num, region $REGION_FORMATTED..."
-        impg -p $PAF -r $REGION_FORMATTED -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct -d 5000 > partition$num.tmp.bed
+        echo "-- Querying region $REGION_FORMATTED"
+        impg -p "$PAF" -r "$REGION_FORMATTED" -x | bedtools sort | bedtools merge -s -c 4,5,6 -o distinct -d 10000 > "partition$num.tmp.bed"
 
         # Apply mask
-        bedtools subtract -a partition$num.tmp.bed -b $MASK_BED -s > partition$num.bed
+        bedtools subtract -a "partition$num.tmp.bed" -b "$MASK_BED" -s > "partition$num.bed"
 
         # Check if the partition is not empty
-        if [ -s partition$num.bed ]; then
+        if [ -s "partition$num.bed" ]; then
+            echo "-- Processing partition $num"
 
             # Update masked regions
-            cat partition$num.bed $MASK_BED | bedtools sort > $num.bed
-            bedtools merge -i $num.bed -s -c 4,5,6 -o distinct > $num.mask.bed
-            cp $num.mask.bed $MASK_BED
+            cat "partition$num.bed" "$MASK_BED" | bedtools sort > "$num.bed"
+            bedtools merge -i "$num.bed" -s -c 4,5,6 -o distinct > "$num.mask.bed"
+            cp "$num.mask.bed" "$MASK_BED"
 
             # Update missing regions
-            bedtools subtract -a $MISSING_BED -b partition$num.bed -s > $num.missing.bed
-            cp $num.missing.bed $MISSING_BED
-
-            # Cleanup
-            rm partition$num.tmp.bed $num.bed $num.mask.bed $num.missing.bed
+            bedtools subtract -a "$MISSING_BED" -b "partition$num.bed" -s > "$num.missing.bed"
+            cp "$num.missing.bed" "$MISSING_BED"
 
             num=$((num + 1))
-        else
-            rm partition$num.tmp.bed partition$num.bed
         fi
     done < $WINDOWS_BED
 
     # Check if there are any missing regions not covered by mask
-    bedtools subtract -a $MISSING_BED -b $MASK_BED -s > $num.remaining.bed
-    if [ ! -s $num.remaining.bed ]; then
+    bedtools subtract -a "$MISSING_BED" -b "$MASK_BED" -s > "$num.remaining.bed"
+    if [ ! -s "$num.remaining.bed" ]; then
         # If no remaining regions, we're done
-        rm $num.remaining.bed
         break
     fi
 
     # Create new windows from longest remaining region
-    awk -v OFS='\t' '{print($0,$3-$2)}' $num.remaining.bed | sort -k 7,7nr | cut -f 1-6 | head -n 1 > $num.new.bed
-    bedtools makewindows -b $num.new.bed -w $AVG_WINDOW_SIZE > $WINDOWS_BED
-    
-    # Cleanup
-    rm $num.remaining.bed $num.new.bed
+    awk -v OFS='\t' 'BEGIN{max_len=0} {len=$3-$2; if(len>max_len){max_len=len; line=$0}} END{print line}' "$num.remaining.bed" > "$num.new.bed"
+
+    bedtools makewindows -b "$num.new.bed" -w "$AVG_WINDOW_SIZE" > "$WINDOWS_BED"
 done
 
-rm $SAMPLE.bed $WINDOWS_BED $MASK_BED $MISSING_BED
+# Cleanup
+rm -f "$SAMPLE.bed" "$WINDOWS_BED" "$MASK_BED" "$MISSING_BED" "partition[0-9]*.tmp.bed"" [0-9]*.{remaining,new}.bed"

--- a/scripts/partitioning.sh
+++ b/scripts/partitioning.sh
@@ -18,7 +18,7 @@ SAMPLE=$4
 
 # Prepare initial windows
 WINDOWS_BED=windows.bed
-grep $SAMPLE "$FASTA_FAI" -w -m 1 | awk -v OFS='\t' '{print($1,"0",$2)}' > "$SAMPLE.bed"
+grep $SAMPLE "$FASTA_FAI" -w | awk -v OFS='\t' '{print($1,"0",$2)}' > "$SAMPLE.bed"
 bedtools makewindows -b "$SAMPLE.bed" -w "$AVG_WINDOW_SIZE" > "$WINDOWS_BED"
 
 # Prepare mask file

--- a/scripts/plot_partitioning_stats.R
+++ b/scripts/plot_partitioning_stats.R
@@ -1,0 +1,138 @@
+library(tidyverse)
+library(ggplot2)
+library(stringr)
+library(patchwork)  # For combining plots
+options(scipen=10000)
+
+# Function to read and process a single BED file
+process_bed_file <- function(file_path) {
+  # Extract partition number from filename
+  partition_num <- as.numeric(str_extract(basename(file_path), "\\d+"))
+  
+  # Read BED file
+  bed_data <- read_tsv(file_path, 
+                       col_names = c("name", "start", "end", "score", "strand", "orientation"),
+                       col_types = "ciiccc")
+  
+  # Calculate interval lengths
+  bed_data <- bed_data %>%
+    mutate(length = end - start)
+  
+  # Extract sample and haplotype information
+  bed_data <- bed_data %>%
+    mutate(
+      sample = str_extract(name, "^[^#]+"),
+      haplotype = str_extract(name, "^[^#]+#([^#]+)#", group = 1)
+    ) %>%
+    mutate(
+      haplotype = paste0(sample, "#", haplotype)
+    )
+  
+  # Add partition information
+  bed_data$partition <- partition_num
+  
+  return(bed_data)
+}
+
+# Modified function to create the sample/haplotype count plot
+create_count_plot <- function(data) {
+  counts <- data %>%
+    group_by(partition) %>%
+    summarize(
+      sample_count = n_distinct(sample),
+      haplotype_count = n_distinct(haplotype)
+    ) %>%
+    pivot_longer(
+      cols = c(sample_count, haplotype_count),
+      names_to = "count_type",
+      values_to = "count"
+    )
+  
+  ggplot(counts, aes(x = partition, y = count, fill = count_type)) +
+    geom_bar(stat = "identity", position = "dodge") +
+    scale_fill_manual(
+      values = c("sample_count" = "#2E86C1", "haplotype_count" = "#E74C3C"),
+      labels = c("Samples", "Haplotypes")
+    ) +
+    # Add more x-axis ticks
+    scale_x_continuous(breaks = function(x) seq(floor(min(x)), ceiling(max(x)), by = 1)) +
+    # Add more y-axis ticks
+    scale_y_continuous(breaks = function(x) seq(0, ceiling(max(x)), by = 2)) +
+    theme_minimal() +
+    labs(
+      title = "Sample and Haplotype Counts by Partition",
+      x = "Partition Number",
+      y = "Count",
+      fill = "Type"
+    ) +
+    theme(
+      plot.title = element_text(hjust = 0.5),
+      legend.position = "bottom",
+      axis.text.x = element_text(angle = 45, hjust = 1),
+      panel.grid.minor = element_line(color = "gray90")
+    )
+}
+
+# Modified function to create the sequence length plot
+create_length_plot <- function(data) {
+  lengths <- data %>%
+    group_by(partition) %>%
+    summarize(total_length = sum(length) / 1e6)  # Convert to megabases
+  
+  ggplot(lengths, aes(x = partition, y = total_length)) +
+    geom_bar(stat = "identity", fill = "#27AE60") +
+    # Add more x-axis ticks
+    scale_x_continuous(breaks = function(x) seq(floor(min(x)), ceiling(max(x)), by = 1)) +
+    # Format y-axis in megabases with comma separator
+    scale_y_continuous(
+      breaks = function(x) pretty(c(0, x), n = 10),
+      labels = function(x) format(x, big.mark = ",", scientific = FALSE)
+    ) +
+    theme_minimal() +
+    labs(
+      title = "Total Sequence Length by Partition",
+      x = "Partition Number",
+      y = "Total Length (Mb)",  # Updated to show Mb
+      caption = "Values shown in megabases (Mb)"
+    ) +
+    theme(
+      plot.title = element_text(hjust = 0.5),
+      axis.text.x = element_text(angle = 45, hjust = 1),
+      panel.grid.minor = element_line(color = "gray90")
+    )
+}
+
+
+
+directory <- '/home/guarracino/Desktop/Garrison/impg/aaa'
+
+# List all partition BED files
+bed_files <- list.files(directory, pattern = "partition\\d+\\.bed$", full.names = TRUE)
+
+# Process each file and combine results
+all_data <- map_df(bed_files, process_bed_file)
+
+
+# Create plots
+count_plot <- create_count_plot(all_data)
+length_plot <- create_length_plot(all_data)
+
+# Save plots
+#ggsave("partition_counts.pdf", count_plot, width = 10, height = 6)
+#ggsave("partition_lengths.pdf", length_plot, width = 10, height = 6)
+
+# Combine plots using patchwork
+combined_plot <- count_plot / length_plot +
+  plot_layout(heights = c(1, 1)) +
+  plot_annotation(
+    title = "Partition Analysis",
+    theme = theme(plot.title = element_text(hjust = 0.5, size = 16))
+  )
+
+# Save combined plot
+ggsave("partition_analysis.pdf", combined_plot, width = 12, height = 10)
+
+
+
+
+

--- a/scripts/plot_partitioning_stats.R
+++ b/scripts/plot_partitioning_stats.R
@@ -51,7 +51,7 @@ create_sample_plot <- function(data) {
       limits = c(0, NA),
       expand = expansion(mult = c(0, 0.05))
     ) +
-    theme_minimal() +
+    #theme_minimal() +
     labs(
       title = "Sample Counts by Partition",
       x = "Partition Number",
@@ -59,7 +59,7 @@ create_sample_plot <- function(data) {
     ) +
     theme(
       plot.title = element_text(hjust = 0.5),
-      axis.text.x = element_text(angle = 90, hjust = 1),
+      axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, size = 5),
       panel.grid.minor = element_line(color = "gray90")
     )
 }
@@ -80,7 +80,7 @@ create_haplotype_plot <- function(data) {
       limits = c(0, NA),
       expand = expansion(mult = c(0, 0.05))
     ) +
-    theme_minimal() +
+    #theme_minimal() +
     labs(
       title = "Haplotype Counts by Partition",
       x = "Partition Number",
@@ -88,7 +88,7 @@ create_haplotype_plot <- function(data) {
     ) +
     theme(
       plot.title = element_text(hjust = 0.5),
-      axis.text.x = element_text(angle = 90, hjust = 1),
+      axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, size = 5),
       panel.grid.minor = element_line(color = "gray90")
     )
 }
@@ -110,7 +110,7 @@ create_length_plot <- function(data) {
       limits = c(0, NA),
       expand = expansion(mult = c(0, 0.05))
     ) +
-    theme_minimal() +
+    #theme_minimal() +
     labs(
       title = "Total Sequence Length by Partition",
       x = "Partition Number",
@@ -118,7 +118,7 @@ create_length_plot <- function(data) {
     ) +
     theme(
       plot.title = element_text(hjust = 0.5),
-      axis.text.x = element_text(angle = 90, hjust = 1),
+      axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, size = 5),
       panel.grid.minor = element_line(color = "gray90")
     )
 }
@@ -145,7 +145,7 @@ combined_plot <- sample_plot / haplotype_plot / length_plot +
   )
 
 # Save combined plot
-ggsave("partition_analysis.pdf", combined_plot, width = 30, height = 12)
+ggsave("partition_analysis.pdf", combined_plot, width = 26, height = 12)
 
 
 # Read chromosome data
@@ -157,8 +157,6 @@ chr_data <- read_tsv("/home/guarracino/Desktop/Garrison/impg/scerevisiae8.chromo
 all_data_with_chr <- all_data %>%
   left_join(chr_data, by = "name")
 
-data=all_data_with_chr %>%
-  filter(partition == '95')
 create_chromosome_composition_plot <- function(data) {
   # Calculate the total length per chromosome per partition
   chr_composition <- data %>%
@@ -179,7 +177,7 @@ create_chromosome_composition_plot <- function(data) {
       expand = expansion(mult = c(0, 0.05))
     ) +
     scale_fill_viridis_d(option = "turbo") +  # Use viridis color palette
-    theme_minimal() +
+    #theme_minimal() +
     labs(
       title = "Chromosome Composition by Partition",
       x = "Partition Number",


### PR DESCRIPTION
This introduces a greedy algorithm to partition pangenomes into more manageable chunks that will go into `seqwish`/`pggb` for "explicit" pangenome graph building. It builds on top of the latest fixes and changes in `impg` to correctly query pangenome alignment (#23, #24, #27) and make transitive queries possible (#25, #26) and in a reasonable amount of time (#28). The algorithm is implemented as a `bash` script for simpler future exploration before re-implementing several steps to achieve better performance.

This also adds an `R` script to get a (still not super nice, but good enough) visualization of pangenome partitioning statistics that will help judge its quality. Here is an example on the yeast pangenome:

![partition_analysis](https://github.com/user-attachments/assets/9356f1e5-a659-4b0a-90ee-390fff264f42)
![partition_analysis chr-composition](https://github.com/user-attachments/assets/a8cba405-8a43-4ef8-84bf-96da5c9c06e9)
