### PR TITLE
Merge overlapping/contiguous ranges to visit in `query_transitive` to strongly improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -112,6 +112,8 @@ pub struct SerializableInterval {
     metadata: QueryMetadata,
 }
 
+// Align ranges to cache line boundary for better memory access
+#[repr(align(64))]
 #[derive(Debug, Default, Clone)]
 pub struct SortedRanges {
     pub ranges: Vec<(i32, i32)>

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -384,14 +384,14 @@ impl Impg {
             .map(|(&k, v)| (k, (*v).clone()))
             .collect()
         } else {
-            FxHashMap::default()
+            FxHashMap::with_capacity_and_hasher(self.seq_index.len(), Default::default())
         };
         // Initialize first visited range for target_id if not already present
         visited_ranges.entry(target_id)
             .or_default()
             .insert((range_start, range_end));
 
-        while let Some((current_target_id, current_target_start, current_target_end)) = stack.pop() {
+                while let Some((current_target_id, current_target_start, current_target_end)) = stack.pop() {
             if let Some(tree) = self.trees.get(&current_target_id) {
                 tree.query(current_target_start, current_target_end, |interval| {
                     let metadata = &interval.metadata;


### PR DESCRIPTION
In yeast, this results in an improvement of about 2 orders of magnitude in execution time and 1 order of magnitude in memory usage, with equivalent results (identical results after `bedtools sort | bedtools merge` them).

Essentially, we avoid repeating lots of work.