### PR TITLE
Do not store CIGAR strings during partitioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,11 +58,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys",
 ]
 
@@ -95,9 +96,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -105,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -277,9 +278,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -289,9 +290,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -332,6 +333,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "proc-macro2"
@@ -445,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "utf8parse"

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -786,7 +786,7 @@ mod tests {
         let target_range = (100, 200);
         let record = (100, 200, 0, 100, Strand::Forward);
         let cigar_ops = vec![CigarOp::new(100, '=')];
-        let result = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let result = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
 
         assert_eq!(result, (0, 100, cigar_ops.clone(), 100, 200));
     }
@@ -796,7 +796,7 @@ mod tests {
         let target_range = (100, 200);
         let record = (100, 200, 0, 100, Strand::Reverse);
         let cigar_ops = vec![CigarOp::new(100, '=')];
-        let result = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let result = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
 
         assert_eq!(result, (100, 0, cigar_ops.clone(), 100, 200));
     }
@@ -813,15 +813,15 @@ mod tests {
         ];
         let base = (0, 100, 50, 200, Strand::Forward);
         {
-            let result = project_target_range_through_alignment((0, 100), base, &cigar_ops).unwrap();
+            let result = project_target_range_through_alignment((0, 100), base, &cigar_ops, true).unwrap();
             assert_eq!(result, (50, 200, cigar_ops.clone(), 0, 100));
         }
         {
-            let result = project_target_range_through_alignment((50, 55), base, &cigar_ops).unwrap();
+            let result = project_target_range_through_alignment((50, 55), base, &cigar_ops, true).unwrap();
             assert_eq!(result, (100, 105, vec![CigarOp::new(5, '=')], 50, 55));
         }
         {
-            let result = project_target_range_through_alignment((50, 64), base, &cigar_ops).unwrap();
+            let result = project_target_range_through_alignment((50, 64), base, &cigar_ops, true).unwrap();
             assert_eq!(result, (100, 114, vec![CigarOp::new(14, '=')], 50, 64));
         }
         // We no longer output empty target ranges
@@ -830,7 +830,7 @@ mod tests {
         //     assert_eq!(result, (115, 165, vec![CigarOp::new(50, 'I')], 65, 65));
         // }
         {
-            let result = project_target_range_through_alignment((50, 65), base, &cigar_ops).unwrap();
+            let result = project_target_range_through_alignment((50, 65), base, &cigar_ops, true).unwrap();
             let cigar_ops = vec![
                 CigarOp::new(15, '='),
                 CigarOp::new(50, 'I')
@@ -838,7 +838,7 @@ mod tests {
             assert_eq!(result, (100, 165, cigar_ops, 50, 65));
         }
         {
-            let result = project_target_range_through_alignment((50, 66), base, &cigar_ops).unwrap();
+            let result = project_target_range_through_alignment((50, 66), base, &cigar_ops, true).unwrap();
             let cigar_ops = vec![
                 CigarOp::new(15, '='),
                 CigarOp::new(50, 'I'),
@@ -847,7 +847,7 @@ mod tests {
             assert_eq!(result, (100, 166, cigar_ops, 50, 66));
         }
         {
-            let result = project_target_range_through_alignment((70, 95), base, &cigar_ops).unwrap();
+            let result = project_target_range_through_alignment((70, 95), base, &cigar_ops, true).unwrap();
             assert_eq!(result, (170, 195, vec![CigarOp::new(25, '=')], 70, 95));
         }
     }
@@ -858,7 +858,7 @@ mod tests {
         let target_range = (100, 200);
         let record = (100, 200, 100, 200, Strand::Forward);
         let cigar_ops = vec![CigarOp::new(100, '=')];
-        let (query_start, query_end, cigar, target_start, target_end) = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let (query_start, query_end, cigar, target_start, target_end) = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
         assert_eq!((query_start, query_end, cigar, target_start, target_end), (100, 200, vec![CigarOp::new(100, '=')], 100, 200));
     }
 
@@ -868,7 +868,7 @@ mod tests {
         let target_range = (100, 200);
         let record = (100, 200, 100, 200, Strand::Reverse);
         let cigar_ops = vec![CigarOp::new(100, '=')];
-        let (query_start, query_end, cigar, target_start, target_end) = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let (query_start, query_end, cigar, target_start, target_end) = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
         assert_eq!((query_start, query_end, cigar, target_start, target_end), (200, 100, vec![CigarOp::new(100, '=')], 100, 200)); // Adjust for reverse calculation
     }
 
@@ -882,7 +882,7 @@ mod tests {
             CigarOp::new(10, 'I'), // Insertion
             CigarOp::new(50, '='), // Match
         ];
-        let (start, end, cigar, _, _) = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let (start, end, cigar, _, _) = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
         assert_eq!((start, end, cigar), (50, 160, cigar_ops));
     }
 
@@ -896,7 +896,7 @@ mod tests {
             CigarOp::new(10, 'D'), // Deletion
             CigarOp::new(40, '='), // Match
         ];
-        let (start, end, cigar, _, _) = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let (start, end, cigar, _, _) = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
         assert_eq!((start, end, cigar), (50, 140, cigar_ops));
     }
 
@@ -911,7 +911,7 @@ mod tests {
             CigarOp::new(10, 'I'), // 150, 250
             CigarOp::new(40, '='), // 150, 250
         ];
-        let (start, end, cigar, _, _) = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let (start, end, cigar, _, _) = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
         let cigar_ops = vec![
             CigarOp::new(10, 'D'), // 150, 260
             CigarOp::new(10, 'I'), // 150, 250
@@ -934,7 +934,7 @@ mod tests {
             CigarOp::new(10, 'I'), // Insertion in query
             CigarOp::new(10, '='), // Match
         ];
-        let (query_start, query_end, cigar, target_start, target_end) = project_target_range_through_alignment(target_range, record, &cigar_ops).unwrap();
+        let (query_start, query_end, cigar, target_start, target_end) = project_target_range_through_alignment(target_range, record, &cigar_ops, true).unwrap();
         assert_eq!((query_start, query_end, cigar, target_start, target_end), (0, 10, vec![CigarOp::new(10, '=')], 0, 10));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ fn perform_query(
         panic!("Target range end ({}) exceeds the target sequence length ({})", target_end, target_length);
     }
     if transitive {
-        impg.query_transitive(target_id, target_start, target_end, None, max_depth, min_transitive_region_size, min_distance_between_ranges)
+        impg.query_transitive(target_id, target_start, target_end, None, max_depth, min_transitive_region_size, min_distance_between_ranges, true)
     } else {
         impg.query(target_id, target_start, target_end)
     }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -92,7 +92,7 @@ pub fn partition_alignments(
     info!("Partitioning");
 
     while !windows.is_empty() {
-        for (seq_id, start, end) in windows.iter() {     
+        for (seq_id, start, end) in windows.iter() {
             let chrom = impg.seq_index.get_name(*seq_id).unwrap();
 
             if debug {
@@ -124,7 +124,7 @@ pub fn partition_alignments(
             }
 
             // Query overlaps for current window
-            let query_start = Instant::now();
+            //let query_start = Instant::now();
             let mut overlaps = impg.query_transitive(
                 *seq_id, *start, *end, 
                 Some(&masked_regions),
@@ -253,7 +253,7 @@ fn subtract_masked_regions(
 ) -> Vec<(Interval<u32>, Vec<CigarOp>, Interval<u32>)> {
     let mut result = Vec::new();
 
-    for (query_interval, cigar, target_interval) in overlaps.drain(..) {       
+    for (query_interval, _, target_interval) in overlaps.drain(..) {       
         // Get masked regions for this sequence
         if let Some(masks) = masked_regions.get(&query_interval.metadata) {
             let (start, end) = if query_interval.first <= query_interval.last {
@@ -311,11 +311,11 @@ fn subtract_masked_regions(
                     metadata: target_interval.metadata,
                 };
 
-                result.push((new_query, cigar.clone(), new_target));
+                result.push((new_query, Vec::new(), new_target));
             }
         } else {
             // No masks for this sequence - keep original interval
-            result.push((query_interval, cigar, target_interval));
+            result.push((query_interval, Vec::new(), target_interval));
         }
     }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -124,8 +124,13 @@ pub fn partition_alignments(
             }
 
             // Query overlaps for current window
-            //let query_start = Instant::now();
-            let mut overlaps = impg.query_transitive(*seq_id, *start, *end, Some(&masked_regions), max_depth, min_transitive_region_size, min_distance_between_ranges);
+            let query_start = Instant::now();
+            let mut overlaps = impg.query_transitive(
+                *seq_id, *start, *end, 
+                Some(&masked_regions),
+                max_depth, min_transitive_region_size, min_distance_between_ranges,
+                false  // Don't store CIGAR strings during partitioning
+            );
             //let query_time = query_start.elapsed();
             debug!("  Collected {} query overlaps", overlaps.len());
 


### PR DESCRIPTION
This reduces memory usage by ~200X. Runtimes also improves a bit.

```
impg partition -p /scratch/impg/HPRCy1-vs-primate16.paf --window-size 1000000000 --sequence-prefix chm13 -v 1 --max-depth 20 --min-transitive-region-size 500 --min-distance-between-ranges 10 --min-mask-proximity 5000

# Before
Elapsed (wall clock) time (h:mm:ss or m:ss): 6:25:16
Maximum resident set size (kbytes): 157327720
[2025-01-29T03:07:27Z INFO  impg::partition] Partitioned into 31798 regions

# Aftert
Elapsed (wall clock) time (h:mm:ss or m:ss): 5:21:42
Maximum resident set size (kbytes): 766196
[2025-02-02T02:09:41Z INFO  impg::partition] Partitioned into 31798 regions

