### PR TITLE
Cigar parsing speedup

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -678,17 +678,15 @@ fn project_target_range_through_alignment(
 
 fn parse_cigar_to_delta(cigar: &str) -> Result<Vec<CigarOp>, ParseErr> {
     let mut ops = Vec::new();
-    let mut num_buf = String::new();
+    let mut len: i32 = 0;
 
     for c in cigar.chars() {
         if c.is_ascii_digit() {
-            num_buf.push(c);
+            len = len*10 + (c as i32 - '0' as i32);
         } else {
-            let len = num_buf.parse::<i32>().map_err(|_| ParseErr::InvalidCigarFormat)?;
-            num_buf.clear(); // Reset the buffer for the next operation
-            // raise any error from the cigar op parsing
             let op = CigarOp::new(len, c);
             ops.push(op);
+            len = 0;
         }
     }
 


### PR DESCRIPTION
According to `perf`, a good portion of runtime was spent converting slices of `str` to `i32` in the `parse_cigar_to_delta` function. 

Note that this PR gets rid of the check which makes sure that the number parses correctly (`num_buf.parse::<i32>().map_err(|_| ParseErr::InvalidCigarFormat)?`). As we are already checking if each character is a digit, I don't think there's any way that `num_buf` would throw anyways (unless `parse` throws if there are leading zeros, I am not sure...). 

**Benchmarks**
Input:
```
> du -sh $PAF
78G     test-data/primates16.20231205_wfmash-v0.12.5.paf
```

Command (the `.impg` index was precomputed).
```
./target/release/impg partition --paf-file $PAF --sequence-prefix chm13#1 --window-size 1000000 -t 1
```

Main branch:
```
User time (seconds): 1081.02
System time (seconds): 61.03
Percent of CPU this job got: 97%
Elapsed (wall clock) time (h:mm:ss or m:ss): 19:29.24
```

This PR:
```
User time (seconds): 598.06
System time (seconds): 46.71
Percent of CPU this job got: 95%
Elapsed (wall clock) time (h:mm:ss or m:ss): 11:12.87
```