### PR TITLE
`impg stats`: emit more statistics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -435,6 +435,13 @@ where
 }
 
 fn print_stats(impg: &Impg) {
-    println!("Number of sequences: {}", impg.seq_index.len());
-    println!("Number of overlaps: {}", impg.trees.values().map(|tree| tree.len()).sum::<usize>());
+    // Basic stats
+    let num_sequences = impg.seq_index.len();
+    let total_sequence_length: usize = (0..num_sequences as u32)
+        .filter_map(|id| impg.seq_index.get_len_from_id(id))
+        .sum();
+    let num_overlaps = impg.trees.values().map(|tree| tree.len()).sum::<usize>();
+    println!("Number of sequences: {}", num_sequences);
+    println!("Total sequence length: {} bp", total_sequence_length);
+    println!("Number of overlaps: {}", num_overlaps);
 }


### PR DESCRIPTION
```shell
impg stats -p all-vs-all.subset.paf.gz
                                                                                                                                   
  Number of sequences: 38363                                                                                                                                                                                                                                                                  
  Total sequence length: 1403180408323 bp                                
  Number of overlaps: 57607843                                           
  
  Mean overlaps per sequence: 1878.56                                    
  Median overlaps per sequence: 214.00                                   
  
  Top sequences by number of overlaps:                                   
  1. NA20129#2#CM092117.1: 53460 overlaps                                
  2. HG03784#1#CM094171.1: 48854 overlaps                                
  3. NA21309#1#CM092106.1: 48735 overlaps                                
  4. NA20346#1#JBIRDR010000009.1: 47387 overlaps                         
  5. NA19835#1#CM094021.1: 45077 overlaps 