### PR TITLE
Parallelization and a bit less memory usage

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -302,22 +302,22 @@ impl Impg {
     ) -> Result<Self, ParseErr> {
         // Use par_iter to process the files in parallel and collect both pieces of information
         let (paf_files, paf_gzi_indices): (Vec<String>, Vec<Option<bgzf::gzi::Index>>) = records_by_file
-        .par_iter()
-        .map(|(_, paf_file)| {
-            let paf_gzi_index = if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
-                let paf_gzi_file = paf_file.to_owned() + ".gzi";
-                Some(
-                    bgzf::gzi::read(paf_gzi_file.clone())
-                        .unwrap_or_else(|_| panic!("Could not open {}", paf_gzi_file)),
-                )
-            } else {
-                None
-            };
-            
-            // Return both values as a tuple
-            (paf_file.clone(), paf_gzi_index)
-        })
-        .unzip(); // Separate the tuples into two vectors
+            .par_iter()
+            .map(|(_, paf_file)| {
+                let paf_gzi_index = if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
+                    let paf_gzi_file = paf_file.to_owned() + ".gzi";
+                    Some(
+                        bgzf::gzi::read(paf_gzi_file.clone())
+                            .unwrap_or_else(|_| panic!("Could not open {}", paf_gzi_file)),
+                    )
+                } else {
+                    None
+                };
+                
+                // Return both values as a tuple
+                (paf_file.clone(), paf_gzi_index)
+            })
+            .unzip(); // Separate the tuples into two vectors
 
         let intervals: FxHashMap<u32, Vec<Interval<QueryMetadata>>> = records_by_file
             .par_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,14 +374,15 @@ fn load_multi_index(paf_files: &[String], custom_index: Option<&str>) -> io::Res
     let index_file_ts = index_file_metadata.modified().ok();
     
     if let Some(index_ts) = index_file_ts {
-        for paf_file in paf_files {
-            let paf_file_metadata = std::fs::metadata(paf_file)?;
-            if let Ok(paf_file_ts) = paf_file_metadata.modified() {
-                if paf_file_ts > index_ts {
-                    warn!("WARNING:\tPAF file {} has been modified since impg index creation.", paf_file);
+        paf_files.par_iter().for_each(|paf_file| {
+            if let Ok(paf_file_metadata) = std::fs::metadata(paf_file) {
+                if let Ok(paf_file_ts) = paf_file_metadata.modified() {
+                    if paf_file_ts > index_ts {
+                        warn!("WARNING:\tPAF file {} has been modified since impg index creation.", paf_file);
+                    }
                 }
             }
-        }
+        });
     }
 
     let file = File::open(index_file)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,6 +718,7 @@ fn print_stats(impg: &Impg) {
     // Basic stats
     let num_sequences = impg.seq_index.len();
     let total_sequence_length: usize = (0..num_sequences as u32)
+        .into_par_iter()
         .filter_map(|id| impg.seq_index.get_len_from_id(id))
         .sum();
     let num_overlaps = impg.trees.values().map(|tree| tree.len()).sum::<usize>();
@@ -736,7 +737,10 @@ fn print_stats(impg: &Impg) {
 
     if !entries.is_empty() {
         // Calculate mean and median overlaps
-        let sum: usize = entries.iter().map(|(_, count)| count).sum();
+        let sum: usize = entries
+            .par_iter()
+            .map(|(_, count)| count)
+            .sum();
         let mean = sum as f64 / entries.len() as f64;
 
         let median = if entries.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,7 @@ fn generate_multi_index(paf_files: &[String], num_threads: NonZeroUsize, custom_
     // Process PAF files in parallel using Rayon
     let records_by_file: Vec<_> = (0..paf_files.len())
         .into_par_iter()
-        .map(|file_index| -> io::Result<(Vec<PafRecord>, String, u32)> {
+        .map(|file_index| -> io::Result<(Vec<PafRecord>, String)> {
             let paf_file = &paf_files[file_index];
             
             // Increment the counter and get the new value atomically
@@ -439,7 +439,7 @@ fn generate_multi_index(paf_files: &[String], num_threads: NonZeroUsize, custom_
                 )
             })?;
             
-            Ok((records, paf_file.clone(), file_index as u32))
+            Ok((records, paf_file.clone()))
         })
         .collect::<Result<Vec<_>, _>>()?;  // Propagate any errors
     

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -147,8 +147,8 @@ pub fn partition_alignments(
             }
         }
 
-        for (seq_id, start, end) in windows.iter() {
-            let chrom = impg.seq_index.get_name(*seq_id).unwrap();
+        for (seq_id, start, end) in windows.drain(..) {
+            let chrom = impg.seq_index.get_name(seq_id).unwrap();
 
             if debug {
                 debug!(
@@ -197,9 +197,9 @@ pub fn partition_alignments(
             // Query overlaps for current window
             //let query_start = Instant::now();
             let mut overlaps = impg.query_transitive(
-                *seq_id,
-                *start,
-                *end,
+                seq_id,
+                start,
+                end,
                 Some(&masked_regions),
                 max_depth,
                 min_transitive_len,
@@ -313,9 +313,6 @@ pub fn partition_alignments(
                 );
             }
         }
-
-        // Clear existing windows but keep the allocation
-        windows.clear();
 
         //let window_start = Instant::now();
         select_and_window_sequences(


### PR DESCRIPTION
This saves about ~3 GB more than https://github.com/pangenome/impg/pull/60 in the current test with 8284 PAF files from the HPRCv2 pangenome. Overall, the peak memory usage for IMPG index generation drops from ~50 GB to ~33 GB.