### PR TITLE
Lower memory usage during IMPG index creationg

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -1360,13 +1360,11 @@ mod tests {
         let target_id = seq_index.get_or_insert_id("t1", Some(200));
         let reader = BufReader::new(&paf_data[..]);
         let expected_records = vec![
-            PafRecord {
+            PartialPafRecord {
                 query_id: query_id,
-                query_length: 100,
                 query_start: 10,
                 query_end: 20,
                 target_id: target_id,
-                target_length: 200,
                 target_start: 30,
                 target_end: 40,
                 strand_and_cigar_offset: 45, // Forward strand

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -1,4 +1,4 @@
-use crate::paf::{PafRecord, ParseErr, Strand};
+use crate::paf::{PartialPafRecord, ParseErr, Strand};
 use crate::seqidx::SequenceIndex;
 use coitrees::{BasicCOITree, Interval, IntervalTree};
 use log::debug;
@@ -297,7 +297,7 @@ pub struct Impg {
 
 impl Impg {
     pub fn from_multi_paf_records(
-        records_by_file: &[(Vec<PafRecord>, String)],
+        records_by_file: &[(Vec<PartialPafRecord>, String)],
         seq_index: SequenceIndex
     ) -> Result<Self, ParseErr> {
         // Use par_iter to process the files in parallel and collect both pieces of information

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::io::{self, BufReader, BufWriter};
 use std::num::NonZeroUsize;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use crate::paf::PafRecord;
+use crate::paf::PartialPafRecord;
 use rayon::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -425,7 +425,7 @@ fn generate_multi_index(paf_files: &[String], num_threads: NonZeroUsize, custom_
     // Process PAF files in parallel using Rayon
     let records_by_file: Vec<_> = (0..paf_files.len())
         .into_par_iter()
-        .map(|file_index| -> io::Result<(Vec<PafRecord>, String)> {
+        .map(|file_index| -> io::Result<(Vec<PartialPafRecord>, String)> {
             let paf_file = &paf_files[file_index];
             
             // Increment the counter and get the new value atomically

--- a/src/paf.rs
+++ b/src/paf.rs
@@ -136,16 +136,14 @@ mod tests {
         // IDs should be 0 and 1 as they're the first entries in the SequenceIndex
         let query_id = seq_index.get_id("seq1").unwrap();
         let target_id = seq_index.get_id("seq2").unwrap();
-        
+
         assert_eq!(
             record,
             PartialPafRecord {
                 query_id,
-                query_length: 100,
                 query_start: 0,
                 query_end: 100,
                 target_id,
-                target_length: 100,
                 target_start: 0,
                 target_end: 100,
                 // If no cigar, then the offset is just the length of the line and cigar_bytes=0


### PR DESCRIPTION
This saves other ~4GB of RAM to the ones saved in https://github.com/pangenome/impg/pull/61 and https://github.com/pangenome/impg/pull/60, so we go from ~55 to ~29GB in the current test with 8284 PAF files from the HPRCv2 pangenome.