### PR TITLE
`impq query`: reduce memory usage with BED format output

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -512,14 +512,18 @@ impl Impg {
                             return; // Skip this result
                         }
                     }
-                    
+
                     let adjusted_interval = (
                         Interval {
                             first: adjusted_query_start,
                             last: adjusted_query_end,
                             metadata: metadata.query_id,
                         },
-                        if store_cigar { adjusted_cigar } else { Vec::new() },
+                        if store_cigar {
+                            adjusted_cigar
+                        } else {
+                            Vec::new()
+                        },
                         Interval {
                             first: adjusted_target_start,
                             last: adjusted_target_end,
@@ -656,14 +660,18 @@ impl Impg {
                                     return None; // Skip this result
                                 }
                             }
-                                                        
+
                             Some((
                                 Interval {
                                     first: adjusted_query_start,
                                     last: adjusted_query_end,
                                     metadata: metadata.query_id,
                                 },
-                                if store_cigar { adjusted_cigar } else { Vec::new() },
+                                if store_cigar {
+                                    adjusted_cigar
+                                } else {
+                                    Vec::new()
+                                },
                                 Interval {
                                     first: adjusted_target_start,
                                     last: adjusted_target_end,
@@ -883,16 +891,23 @@ impl Impg {
                                         {
                                             // Check gap-compressed identity if threshold is provided
                                             if let Some(threshold) = min_gap_compressed_identity {
-                                                if calculate_gap_compressed_identity(&adjusted_cigar) < threshold {
+                                                if calculate_gap_compressed_identity(
+                                                    &adjusted_cigar,
+                                                ) < threshold
+                                                {
                                                     return; // Skip this result
                                                 }
                                             }
-                                       
+
                                             local_results.push((
                                                 metadata.query_id,
                                                 adjusted_query_start,
                                                 adjusted_query_end,
-                                                if store_cigar { adjusted_cigar } else { Vec::new() },
+                                                if store_cigar {
+                                                    adjusted_cigar
+                                                } else {
+                                                    Vec::new()
+                                                },
                                                 adjusted_target_start,
                                                 adjusted_target_end,
                                                 *current_target_id,
@@ -1179,20 +1194,20 @@ fn parse_cigar_to_delta(cigar: &str) -> Result<Vec<CigarOp>, ParseErr> {
 }
 
 fn calculate_gap_compressed_identity(cigar_ops: &[CigarOp]) -> f64 {
-    let (matches, mismatches, insertions, deletions) = cigar_ops.iter().fold(
-        (0i32, 0i32, 0i32, 0i32),
-        |(m, mm, i, d), op| {
-            let len = op.len();
-            match op.op() {
-                'M' | '=' => (m + len, mm, i, d),  // Assume 'M' represents matches
-                'X' => (m, mm + len, i, d),
-                'I' => (m, mm, i + 1, d),
-                'D' => (m, mm, i, d + 1),
-                _ => (m, mm, i, d),
-            }
-        },
-    );
-    
+    let (matches, mismatches, insertions, deletions) =
+        cigar_ops
+            .iter()
+            .fold((0i32, 0i32, 0i32, 0i32), |(m, mm, i, d), op| {
+                let len = op.len();
+                match op.op() {
+                    'M' | '=' => (m + len, mm, i, d), // Assume 'M' represents matches
+                    'X' => (m, mm + len, i, d),
+                    'I' => (m, mm, i + 1, d),
+                    'D' => (m, mm, i, d + 1),
+                    _ => (m, mm, i, d),
+                }
+            });
+
     let total = matches + mismatches + insertions + deletions;
     if total == 0 {
         0.0

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -448,7 +448,14 @@ impl Impg {
         Self::from_multi_paf_and_serializable(&[paf_file.to_string()], serializable)
     }
 
-    pub fn query(&self, target_id: u32, range_start: i32, range_end: i32, min_gap_compressed_identity: Option<f64>) -> Vec<AdjustedInterval> {
+    pub fn query(
+        &self,
+        target_id: u32,
+        range_start: i32,
+        range_end: i32,
+        store_cigar: bool,
+        min_gap_compressed_identity: Option<f64>,
+    ) -> Vec<AdjustedInterval> {
         let mut results = Vec::new();
         // Add the input range to the results
         results.push((
@@ -457,7 +464,11 @@ impl Impg {
                 last: range_end,
                 metadata: target_id,
             },
-            vec![CigarOp::new(range_end - range_start, '=')],
+            if store_cigar {
+                vec![CigarOp::new(range_end - range_start, '=')]
+            } else {
+                Vec::new()
+            },
             Interval {
                 first: range_start,
                 last: range_end,
@@ -508,7 +519,7 @@ impl Impg {
                             last: adjusted_query_end,
                             metadata: metadata.query_id,
                         },
-                        adjusted_cigar,
+                        if store_cigar { adjusted_cigar } else { Vec::new() },
                         Interval {
                             first: adjusted_target_start,
                             last: adjusted_target_end,

--- a/src/main.rs
+++ b/src/main.rs
@@ -658,7 +658,7 @@ fn perform_query(
             max_depth,
             min_transitive_len,
             min_distance_between_ranges,
-            false,
+            true,
             min_identity,
         )
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,11 +520,8 @@ fn generate_multi_index(
     let serializable = impg.to_serializable();
     let file = File::create(index_file)?;
     let writer = BufWriter::new(file);
-    bincode::serialize_into(writer, &serializable).map_err(|e| {
-        io::Error::other(
-            format!("Failed to serialize index: {:?}", e),
-        )
-    })?;
+    bincode::serialize_into(writer, &serializable)
+        .map_err(|e| io::Error::other(format!("Failed to serialize index: {:?}", e)))?;
 
     Ok(impg)
 }
@@ -665,7 +662,13 @@ fn perform_query(
             min_identity,
         )
     } else {
-        impg.query(target_id, target_start, target_end, store_cigar, min_identity)
+        impg.query(
+            target_id,
+            target_start,
+            target_end,
+            store_cigar,
+            min_identity,
+        )
     }
 }
 
@@ -1134,7 +1137,7 @@ fn merge_consecutive_cigar_ops(cigar: &mut Vec<CigarOp>) {
     if cigar.len() <= 1 {
         return;
     }
-    
+
     let mut write_idx = 0;
     for read_idx in 1..cigar.len() {
         if cigar[write_idx].op() == cigar[read_idx].op() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,7 @@ fn main() -> io::Result<()> {
                     &impg,
                     &target_name,
                     target_range,
+                    output_format == "paf" || output_format == "bedpe", // Store CIGAR for PAF/BEDPE output
                     min_identity,
                     transitive,
                     transitive_bfs,
@@ -261,6 +262,7 @@ fn main() -> io::Result<()> {
                         &impg,
                         &target_name,
                         target_range,
+                        output_format == "paf" || output_format == "bedpe", // Store CIGAR for PAF/BEDPE output
                         min_identity,
                         transitive,
                         transitive_bfs,
@@ -614,6 +616,7 @@ fn perform_query(
     impg: &Impg,
     target_name: &str,
     target_range: (i32, i32),
+    store_cigar: bool,
     min_identity: Option<f64>,
     transitive: bool,
     transitive_bfs: bool,
@@ -646,7 +649,7 @@ fn perform_query(
             max_depth,
             min_transitive_len,
             min_distance_between_ranges,
-            true,
+            store_cigar,
             min_identity,
         )
     } else if transitive_bfs {
@@ -658,11 +661,11 @@ fn perform_query(
             max_depth,
             min_transitive_len,
             min_distance_between_ranges,
-            true,
+            store_cigar,
             min_identity,
         )
     } else {
-        impg.query(target_id, target_start, target_end, min_identity)
+        impg.query(target_id, target_start, target_end, store_cigar, min_identity)
     }
 }
 


### PR DESCRIPTION
There is no need to store CIGAR strings when BED format is required, saving memory.