### PR TITLE
`impg partition`: add option to make BFS transitive queries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ enum Args {
         #[clap(long, value_parser)]
         min_identity: Option<f64>,
 
+        /// Enable transitive queries with breadth-first search (faster, but returns more overlapping results)
+        #[clap(long, action)]
+        transitive_bfs: bool,
+
         /// Maximum recursion depth for transitive overlaps (0 for no limit)
         #[clap(short = 'm', long, value_parser, default_value_t = 2)]
         max_depth: u16,
@@ -185,6 +189,7 @@ fn main() -> io::Result<()> {
             window_size,
             merge_distance,
             min_identity,
+            transitive_bfs,
             max_depth,
             min_transitive_len,
             min_distance_between_ranges,
@@ -205,6 +210,7 @@ fn main() -> io::Result<()> {
                 min_identity,
                 min_missing_size,
                 min_boundary_distance,
+                transitive_bfs,
                 max_depth,
                 min_transitive_len,
                 min_distance_between_ranges,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -199,7 +199,7 @@ pub fn partition_alignments(
             // Query overlaps for current window
             //let query_start = Instant::now();
             let mut overlaps = if transitive_bfs {
-                impg.query_transitive(
+                impg.query_transitive_bfs(
                 seq_id,
                 start,
                 end,
@@ -211,7 +211,7 @@ pub fn partition_alignments(
                 min_identity,
             )
             } else {
-                impg.query_transitive_bfs(
+                impg.query_transitive(
                     seq_id,
                     start,
                     end,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -18,6 +18,7 @@ pub fn partition_alignments(
     min_identity: Option<f64>,
     min_missing_size: i32,
     min_boundary_distance: i32,
+    transitive_bfs: bool,
     max_depth: u16,
     min_transitive_len: i32,
     min_distance_between_ranges: i32,
@@ -197,7 +198,8 @@ pub fn partition_alignments(
 
             // Query overlaps for current window
             //let query_start = Instant::now();
-            let mut overlaps = impg.query_transitive(
+            let mut overlaps = if transitive_bfs {
+                impg.query_transitive(
                 seq_id,
                 start,
                 end,
@@ -207,7 +209,20 @@ pub fn partition_alignments(
                 min_distance_between_ranges,
                 false, // Don't store CIGAR strings during partitioning
                 min_identity,
-            );
+            )
+            } else {
+                impg.query_transitive_bfs(
+                    seq_id,
+                    start,
+                    end,
+                    Some(&masked_regions),
+                    max_depth,
+                    min_transitive_len,
+                    min_distance_between_ranges,
+                    false, // Don't store CIGAR strings during partitioning
+                    min_identity,
+                )
+            };
             //let query_time = query_start.elapsed();
             debug!("  Collected {} query overlaps", overlaps.len());
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -302,7 +302,7 @@ pub fn partition_alignments(
                 };
                 //let calc_time = calc_start.elapsed();
 
-                info!("  Wrote partition {} with {} regions: {} bp this partition ({}), {} bp total ({}) - (query {}:{}-{}, len: {})", 
+                info!("  Wrote partition{}.bed with {} regions: {} bp this partition ({}), {} bp total ({}) - (query {}:{}-{}, len: {})", 
                     partition_num,
                     num_regions,
                     current_partition_length,   // Current partition size in bp


### PR DESCRIPTION
Transitive Breadth-First Search (BFS) queries are better parallelizable.