### PR TITLE
Add a forest map to enable lazy tree loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
 dependencies = [
  "jobserver",
  "libc",

--- a/src/forest_map.rs
+++ b/src/forest_map.rs
@@ -46,7 +46,6 @@ impl ForestMap {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
-
 }
 
 impl Default for ForestMap {

--- a/src/forest_map.rs
+++ b/src/forest_map.rs
@@ -75,7 +75,7 @@ impl ForestMap {
 
     /// Generate forest map filename based on the index filename
     pub fn get_forest_map_filename(index_filename: &str) -> String {
-        format!("{}.forest", index_filename)
+        format!("{}.map", index_filename)
     }
 }
 

--- a/src/forest_map.rs
+++ b/src/forest_map.rs
@@ -2,14 +2,14 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 /// Forest map entry: target_id -> tree_offset in the serialized IMPG index
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ForestMapEntry {
-    pub target_id: u32,
-    pub tree_offset: u64,
+#[derive(Serialize, Deserialize)]
+struct ForestMapEntry {
+    target_id: u32,
+    tree_offset: u64,
 }
 
 /// Forest map structure containing mappings from target_id to tree offsets
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ForestMap {
     pub entries: FxHashMap<u32, u64>,
 }
@@ -30,26 +30,5 @@ impl ForestMap {
     /// Get the tree offset for a target_id
     pub fn get_tree_offset(&self, target_id: u32) -> Option<u64> {
         self.entries.get(&target_id).copied()
-    }
-
-    /// Check if the forest map contains a target_id
-    pub fn contains_target(&self, target_id: u32) -> bool {
-        self.entries.contains_key(&target_id)
-    }
-
-    /// Get the number of entries in the forest map
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    /// Check if the forest map is empty
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-}
-
-impl Default for ForestMap {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/forest_map.rs
+++ b/src/forest_map.rs
@@ -1,0 +1,86 @@
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+/// Forest map entry: target_id -> tree_offset in the serialized IMPG index
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForestMapEntry {
+    pub target_id: u32,
+    pub tree_offset: u64,
+}
+
+/// Forest map structure containing mappings from target_id to tree offsets
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForestMap {
+    pub entries: FxHashMap<u32, u64>,
+}
+
+impl ForestMap {
+    /// Create a new empty forest map
+    pub fn new() -> Self {
+        Self {
+            entries: FxHashMap::default(),
+        }
+    }
+
+    /// Add a target_id -> tree_offset mapping
+    pub fn add_entry(&mut self, target_id: u32, tree_offset: u64) {
+        self.entries.insert(target_id, tree_offset);
+    }
+
+    /// Get the tree offset for a target_id
+    pub fn get_tree_offset(&self, target_id: u32) -> Option<u64> {
+        self.entries.get(&target_id).copied()
+    }
+
+    /// Check if the forest map contains a target_id
+    pub fn contains_target(&self, target_id: u32) -> bool {
+        self.entries.contains_key(&target_id)
+    }
+
+    /// Get the number of entries in the forest map
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check if the forest map is empty
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Save the forest map to a file
+    pub fn save_to_file(&self, file_path: &str) -> std::io::Result<()> {
+        let file = File::create(file_path)?;
+        let mut writer = BufWriter::new(file);
+        bincode::serde::encode_into_std_write(self, &mut writer, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(format!("Failed to serialize forest map: {:?}", e)))?;
+        Ok(())
+    }
+
+    /// Load the forest map from a file
+    pub fn load_from_file(file_path: &str) -> std::io::Result<Self> {
+        let file = File::open(file_path)?;
+        let mut reader = BufReader::new(file);
+        let forest_map: ForestMap =
+            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Failed to deserialize forest map: {:?}", e),
+                    )
+                })?;
+        Ok(forest_map)
+    }
+
+    /// Generate forest map filename based on the index filename
+    pub fn get_forest_map_filename(index_filename: &str) -> String {
+        format!("{}.forest", index_filename)
+    }
+}
+
+impl Default for ForestMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/forest_map.rs
+++ b/src/forest_map.rs
@@ -1,7 +1,5 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::{BufReader, BufWriter};
 
 /// Forest map entry: target_id -> tree_offset in the serialized IMPG index
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,34 +47,6 @@ impl ForestMap {
         self.entries.is_empty()
     }
 
-    /// Save the forest map to a file
-    pub fn save_to_file(&self, file_path: &str) -> std::io::Result<()> {
-        let file = File::create(file_path)?;
-        let mut writer = BufWriter::new(file);
-        bincode::serde::encode_into_std_write(self, &mut writer, bincode::config::standard())
-            .map_err(|e| std::io::Error::other(format!("Failed to serialize forest map: {:?}", e)))?;
-        Ok(())
-    }
-
-    /// Load the forest map from a file
-    pub fn load_from_file(file_path: &str) -> std::io::Result<Self> {
-        let file = File::open(file_path)?;
-        let mut reader = BufReader::new(file);
-        let forest_map: ForestMap =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("Failed to deserialize forest map: {:?}", e),
-                    )
-                })?;
-        Ok(forest_map)
-    }
-
-    /// Generate forest map filename based on the index filename
-    pub fn get_forest_map_filename(index_filename: &str) -> String {
-        format!("{}.map", index_filename)
-    }
 }
 
 impl Default for ForestMap {

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -506,8 +506,8 @@ impl Impg {
     ) -> Option<Arc<BasicCOITree<QueryMetadata, u32>>> {
         // First check if tree is already in memory
         if let Some(tree) = self.trees.read().unwrap().get(&target_id) {
-            // Get a clone of the Arc<tree> (incrementing the reference count, so cheap) to use in the query
-            // We clone to avoid holding the RwLock for the duration of the query
+            // Get a clone of the Arc<tree> (incrementing the reference count, a cheap operation)
+            // We clone to avoid holding the RwLock for the duration of the operation using the tree
 
             return Some(Arc::clone(tree));
         }
@@ -759,8 +759,6 @@ impl Impg {
 
             let prec_num_results = results.len();
 
-            // Get a clone of the Arc<tree> (incrementing the reference count, so cheap) to use in the query
-            // We clone to avoid holding the RwLock for the duration of the query
             // Get or load the tree - if None, no overlaps exist for this target
             if let Some(tree) = self.get_or_load_tree(current_target_id) {
                 // Collect intervals first to process them in parallel

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -571,7 +571,7 @@ impl Impg {
     }
 
     /// Ensure a tree is loaded in memory, loading it from disk if necessary
-    fn ensure_tree_loaded(&self, target_id: u32) -> std::io::Result<bool> {
+    pub fn ensure_tree_loaded(&self, target_id: u32) -> std::io::Result<bool> {
         if self.trees.read().unwrap().contains_key(&target_id) {
             Ok(true) // Tree already loaded
         } else {

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -148,9 +148,9 @@ type TreeMap = FxHashMap<u32, Arc<BasicCOITree<QueryMetadata, u32>>>;
 
 #[derive(Serialize, Deserialize)]
 pub struct SerializableInterval {
-    pub first: i32,
-    pub last: i32,
-    pub metadata: QueryMetadata,
+    first: i32,
+    last: i32,
+    metadata: QueryMetadata,
 }
 
 #[derive(Default, Clone)]

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -508,22 +508,16 @@ impl Impg {
         }
     }
 
-    /// Ensure a tree is loaded in memory, loading it from disk if necessary
-    pub fn ensure_tree_loaded(&self, target_id: u32) -> std::io::Result<bool> {
-        if self.trees.read().unwrap().contains_key(&target_id) {
-            Ok(true) // Tree already loaded
-        } else {
-            self.load_tree_from_disk(target_id)
-        }
-    }
-
     /// Get a tree from memory or load it from disk if necessary
-    /// Returns None if the tree doesn't exist (which is valid - not all sequences have overlaps)
-    // Get a clone of the Arc<tree> (incrementing the reference count, so cheap) to use in the query
-    // We clone to avoid holding the RwLock for the duration of the query
-    fn get_or_load_tree(&self, target_id: u32) -> Option<Arc<BasicCOITree<QueryMetadata, u32>>> {
+    pub fn get_or_load_tree(
+        &self,
+        target_id: u32,
+    ) -> Option<Arc<BasicCOITree<QueryMetadata, u32>>> {
         // First check if tree is already in memory
         if let Some(tree) = self.trees.read().unwrap().get(&target_id) {
+            // Get a clone of the Arc<tree> (incrementing the reference count, so cheap) to use in the query
+            // We clone to avoid holding the RwLock for the duration of the query
+
             return Some(Arc::clone(tree));
         }
 

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -515,18 +515,20 @@ impl Impg {
         // PASS 2: Build forest map with calculated offsets
         let mut forest_map = ForestMap::new();
         
-        
-        // Add entries to get actual size
+        // First, fill with fake "worst case" offsets to get accurate size estimate
+        let fake_offset = u64::MAX; // Largest possible offset for maximum serialization size
         for (target_id, _) in &tree_data_vec {
-            forest_map.add_entry(*target_id, 0); // Placeholder offset
+            forest_map.add_entry(*target_id, fake_offset);
         }
-        let forest_map_actual_size = bincode::serde::encode_to_vec(&forest_map, bincode::config::standard())
+        
+        // Get forest map size with worst-case offsets
+        let forest_map_size = bincode::serde::encode_to_vec(&forest_map, bincode::config::standard())
             .map_err(|e| std::io::Error::other(format!("Failed to encode forest map: {:?}", e)))?
             .len() as u64;
         
-        // Clear and rebuild with correct offsets
+        // Now clear and rebuild with real offsets
         forest_map = ForestMap::new();
-        let mut current_offset = forest_map_actual_size + seq_index_data.len() as u64;
+        let mut current_offset = forest_map_size + seq_index_data.len() as u64;
         
         for (target_id, tree_data) in &tree_data_vec {
             forest_map.add_entry(*target_id, current_offset);

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -475,11 +475,11 @@ impl Impg {
             // Reconstruct the tree
             let tree = BasicCOITree::new(
                 intervals
-                    .iter()
+                    .into_iter()
                     .map(|interval| Interval {
                         first: interval.first,
                         last: interval.last,
-                        metadata: interval.metadata.clone(),
+                        metadata: interval.metadata, // Move instead of clone
                     })
                     .collect::<Vec<_>>()
                     .as_slice(),
@@ -504,7 +504,7 @@ impl Impg {
         &self,
         target_id: u32,
     ) -> Option<Arc<BasicCOITree<QueryMetadata, u32>>> {
-        // First check if tree is already in memory
+        // First check if the tree is already in memory
         if let Some(tree) = self.trees.read().unwrap().get(&target_id) {
             // Get a clone of the Arc<tree> (incrementing the reference count, a cheap operation)
             // We clone to avoid holding the RwLock for the duration of the operation using the tree

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -285,10 +285,10 @@ impl SortedRanges {
 pub struct Impg {
     pub trees: RwLock<TreeMap>,
     pub seq_index: SequenceIndex,
-    paf_files: Vec<String>, // List of all PAF files
+    paf_files: Vec<String>,                         // List of all PAF files
     paf_gzi_indices: Vec<Option<bgzf::gzi::Index>>, // Corresponding GZI indices
-    pub forest_map: ForestMap,  // Forest map for lazy loading
-    index_file_path: String, // Path to the index file for lazy loading
+    pub forest_map: ForestMap,                      // Forest map for lazy loading
+    index_file_path: String,                        // Path to the index file for lazy loading
 }
 
 impl Impg {
@@ -460,7 +460,9 @@ impl Impg {
             let mut reader = BufReader::new(file);
             let (loaded_target_id, intervals): (u32, Vec<SerializableInterval>) =
                 bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
-                    .unwrap_or_else(|_| panic!("Failed to deserialize tree for target {}", target_id));
+                    .unwrap_or_else(|_| {
+                        panic!("Failed to deserialize tree for target {}", target_id)
+                    });
 
             // Verify we loaded the correct tree
             if loaded_target_id != target_id {

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -408,6 +408,37 @@ impl Impg {
         }
     }
 
+    /// Load IMPG from embedded forest map format (single file with forest map at beginning)
+    pub fn load_from_embedded_forest_map<R: std::io::Read>(
+        mut reader: R,
+        paf_files: &[String],
+        index_file_path: String,
+    ) -> std::io::Result<Self> {
+        // Read forest map from beginning of file
+        let forest_map: ForestMap = bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Failed to deserialize forest map: {:?}", e),
+            ))?;
+        
+        // Read sequence index
+        let seq_index: SequenceIndex = bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Failed to deserialize sequence index: {:?}", e),
+            ))?;
+        
+        // Skip tree count (we don't need it for lazy loading)
+        let _tree_count: u32 = bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Failed to deserialize tree count: {:?}", e),
+            ))?;
+        
+        // Create IMPG instance with forest map for lazy loading
+        Ok(Self::with_forest_map(paf_files, seq_index, forest_map, index_file_path))
+    }
+
     /// Serialize the IMPG index to a writer and create a forest map
     pub fn serialize_with_forest_map<W: std::io::Write>(
         &self,
@@ -455,6 +486,78 @@ impl Impg {
         }
         
         Ok(forest_map)
+    }
+
+    /// Serialize the IMPG index with forest map embedded at the beginning (single file)
+    pub fn serialize_with_embedded_forest_map<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::io::Result<()> {
+        let trees = self.trees.read().unwrap();
+        
+        // PASS 1: Calculate all sizes without writing
+        let seq_index_data = bincode::serde::encode_to_vec(&self.seq_index, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(format!("Failed to encode sequence index: {:?}", e)))?;
+        
+        let tree_count_data = bincode::serde::encode_to_vec(&(trees.len() as u32), bincode::config::standard())
+            .map_err(|e| std::io::Error::other(format!("Failed to encode tree count: {:?}", e)))?;
+        
+        // Calculate sizes for all trees
+        let mut tree_data_vec = Vec::new();
+        for (&target_id, tree) in trees.iter() {
+            let intervals: Vec<SerializableInterval> = tree
+                .iter()
+                .map(|interval| SerializableInterval {
+                    first: interval.first,
+                    last: interval.last,
+                    metadata: interval.metadata.clone(),
+                })
+                .collect();
+            
+            let tree_data = bincode::serde::encode_to_vec(&(target_id, intervals), bincode::config::standard())
+                .map_err(|e| std::io::Error::other(format!("Failed to encode tree for target {}: {:?}", target_id, e)))?;
+            
+            tree_data_vec.push((target_id, tree_data));
+        }
+        
+        // PASS 2: Build forest map with calculated offsets
+        let mut forest_map = ForestMap::new();
+        
+        
+        // Add entries to get actual size
+        for (target_id, _) in &tree_data_vec {
+            forest_map.add_entry(*target_id, 0); // Placeholder offset
+        }
+        let forest_map_actual_size = bincode::serde::encode_to_vec(&forest_map, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(format!("Failed to encode forest map: {:?}", e)))?
+            .len() as u64;
+        
+        // Clear and rebuild with correct offsets
+        forest_map = ForestMap::new();
+        let mut current_offset = forest_map_actual_size + seq_index_data.len() as u64 + tree_count_data.len() as u64;
+        
+        for (target_id, tree_data) in &tree_data_vec {
+            forest_map.add_entry(*target_id, current_offset);
+            current_offset += tree_data.len() as u64;
+        }
+        
+        // Write forest map first
+        let forest_map_data = bincode::serde::encode_to_vec(&forest_map, bincode::config::standard())
+            .map_err(|e| std::io::Error::other(format!("Failed to encode final forest map: {:?}", e)))?;
+        writer.write_all(&forest_map_data)?;
+        
+        // Write the sequence index
+        writer.write_all(&seq_index_data)?;
+        
+        // Write the tree count
+        writer.write_all(&tree_count_data)?;
+        
+        // Write all trees
+        for (_, tree_data) in tree_data_vec {
+            writer.write_all(&tree_data)?;
+        }
+        
+        Ok(())
     }
 
     /// Load a specific tree from disk using the forest map

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -460,9 +460,7 @@ impl Impg {
             let mut reader = BufReader::new(file);
             let (loaded_target_id, intervals): (u32, Vec<SerializableInterval>) =
                 bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
-                    .expect(
-                        format!("Failed to deserialize tree for target {}", target_id).as_str(),
-                    );
+                    .unwrap_or_else(|_| panic!("Failed to deserialize tree for target {}", target_id));
 
             // Verify we loaded the correct tree
             if loaded_target_id != target_id {

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -10,13 +10,14 @@ use serde::{Deserialize, Serialize};
 use std::cmp::{max, min};
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::sync::Arc;
 use std::sync::RwLock;
 
 /// Parse a CIGAR string into a vector of CigarOp
 // Note that the query_delta is negative for reverse strand alignments
 #[derive(Debug, Clone, PartialEq)]
 pub struct CigarOp {
-    pub val: u32,
+    val: u32,
 }
 
 impl CigarOp {
@@ -142,12 +143,11 @@ impl QueryMetadata {
     }
 }
 
-use std::sync::Arc;
 pub type AdjustedInterval = (Interval<u32>, Vec<CigarOp>, Interval<u32>);
 type TreeMap = FxHashMap<u32, Arc<BasicCOITree<QueryMetadata, u32>>>;
 
 #[derive(Serialize, Deserialize)]
-pub struct SerializableInterval {
+struct SerializableInterval {
     first: i32,
     last: i32,
     metadata: QueryMetadata,
@@ -285,10 +285,10 @@ impl SortedRanges {
 pub struct Impg {
     pub trees: RwLock<TreeMap>,
     pub seq_index: SequenceIndex,
-    pub paf_files: Vec<String>, // List of all PAF files
-    pub paf_gzi_indices: Vec<Option<bgzf::gzi::Index>>, // Corresponding GZI indices
+    paf_files: Vec<String>, // List of all PAF files
+    paf_gzi_indices: Vec<Option<bgzf::gzi::Index>>, // Corresponding GZI indices
     pub forest_map: ForestMap,  // Forest map for lazy loading
-    pub index_file_path: String, // Path to the index file for lazy loading
+    index_file_path: String, // Path to the index file for lazy loading
 }
 
 impl Impg {

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -428,6 +428,12 @@ impl Impg {
                 format!("Failed to deserialize sequence index: {:?}", e),
             ))?;
         
+        // Skip tree count (we don't need it for lazy loading)
+        let _tree_count: u32 = bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Failed to deserialize tree count: {:?}", e),
+            ))?;
         
         // Create IMPG instance with forest map for lazy loading
         Ok(Self::with_forest_map(paf_files, seq_index, forest_map, index_file_path))
@@ -493,6 +499,8 @@ impl Impg {
         let seq_index_data = bincode::serde::encode_to_vec(&self.seq_index, bincode::config::standard())
             .map_err(|e| std::io::Error::other(format!("Failed to encode sequence index: {:?}", e)))?;
         
+        let tree_count_data = bincode::serde::encode_to_vec(&(trees.len() as u32), bincode::config::standard())
+            .map_err(|e| std::io::Error::other(format!("Failed to encode tree count: {:?}", e)))?;
         
         // Calculate sizes for all trees
         let mut tree_data_vec = Vec::new();
@@ -526,7 +534,7 @@ impl Impg {
         
         // Clear and rebuild with correct offsets
         forest_map = ForestMap::new();
-        let mut current_offset = forest_map_actual_size + seq_index_data.len() as u64;
+        let mut current_offset = forest_map_actual_size + seq_index_data.len() as u64 + tree_count_data.len() as u64;
         
         for (target_id, tree_data) in &tree_data_vec {
             forest_map.add_entry(*target_id, current_offset);
@@ -541,6 +549,8 @@ impl Impg {
         // Write the sequence index
         writer.write_all(&seq_index_data)?;
         
+        // Write the tree count
+        writer.write_all(&tree_count_data)?;
         
         // Write all trees
         for (_, tree_data) in tree_data_vec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // lib.rs
 pub mod faidx;
+pub mod forest_map;
 pub mod graph;
 pub mod impg;
 pub mod paf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1104,7 +1104,7 @@ fn load_multi_index(paf_files: &[String], custom_index: Option<&str>) -> io::Res
             index_file,
         ))
     } else {
-        info!("No forest map found. Loading full index into memory.");
+        info!("No forest map found. Loading full index.");
         
         // Load full index into memory
         let file = File::open(&index_file)?;
@@ -1181,7 +1181,7 @@ fn load_multi_index(paf_files: &[String], custom_index: Option<&str>) -> io::Res
         
         // Try to save forest map for future use (optional - don't fail if it doesn't work)
         match forest_map.save_to_file(&forest_map_file) {
-            Ok(_) => info!("Forest map created for future lazy loading."),
+            Ok(_) => info!("Forest map created for future lazy loading: {}.", forest_map_file),
             Err(e) => warn!("Failed to create forest map: {}. Index will work without it.", e),
         }
         

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
-use coitrees::{Interval, IntervalTree};
+use coitrees::{BasicCOITree, Interval, IntervalTree};
 use impg::faidx::FastaIndex;
-use impg::impg::{AdjustedInterval, CigarOp, Impg};
+use impg::forest_map::ForestMap;
+use impg::impg::{AdjustedInterval, CigarOp, Impg, SerializableInterval};
 use impg::paf::{PartialPafRecord, Strand};
 use impg::partition::partition_alignments;
 use impg::seqidx::SequenceIndex;
@@ -14,6 +15,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, BufReader, BufWriter};
+use std::sync::RwLock;
 
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1073,13 +1075,142 @@ fn load_multi_index(paf_files: &[String], custom_index: Option<&str>) -> io::Res
         });
     }
 
-    // Load with embedded forest map (single-file format)
-    let file = File::open(&index_file)?;
-    let reader = BufReader::new(file);
+    // Check if forest map exists for lazy loading
+    let forest_map_file = ForestMap::get_forest_map_filename(&index_file);
     
-    let impg = Impg::load_from_embedded_forest_map(reader, paf_files, index_file.clone())?;
-    info!("Loaded index with embedded forest map. Lazy loading enabled.");
-    Ok(impg)
+    if std::path::Path::new(&forest_map_file).exists() {
+        info!("Forest map found. Lazy loading enabled.");
+        
+        // Load sequence index only
+        let file = File::open(&index_file)?;
+        let mut reader = BufReader::new(file);
+        let seq_index: SequenceIndex =
+            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
+                |e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Failed to load sequence index: {:?}", e),
+                    )
+                },
+            )?;
+        
+        // Load forest map
+        let forest_map = ForestMap::load_from_file(&forest_map_file)?;
+        
+        Ok(Impg::with_forest_map(
+            paf_files,
+            seq_index,
+            forest_map,
+            index_file,
+        ))
+    } else {
+        info!("No forest map found. Loading full index.");
+        
+        // Load full index into memory
+        let file = File::open(&index_file)?;
+        let mut reader = BufReader::new(file);
+        
+        // Load sequence index
+        let seq_index: SequenceIndex =
+            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
+                |e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Failed to load sequence index: {:?}", e),
+                    )
+                },
+            )?;
+        
+        // Load tree count
+        let tree_count: u32 =
+            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
+                |e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Failed to load tree count: {:?}", e),
+                    )
+                },
+            )?;
+        
+        // Load all trees into memory
+        let mut trees = FxHashMap::default();
+        let mut forest_map = ForestMap::new();
+        let seq_index_size = bincode::serde::encode_to_vec(&seq_index, bincode::config::standard())
+            .map(|v| v.len() as u64)
+            .unwrap_or(0);
+        let tree_count_size = bincode::serde::encode_to_vec(&tree_count, bincode::config::standard())
+            .map(|v| v.len() as u64)
+            .unwrap_or(0);
+        let mut current_offset = seq_index_size + tree_count_size;
+        
+        for _ in 0..tree_count {
+            let tree_start_offset = current_offset;
+            let (target_id, intervals): (u32, Vec<SerializableInterval>) =
+                bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
+                    |e| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Failed to load tree data: {:?}", e),
+                        )
+                    },
+                )?;
+            
+            // Add to forest map for future use
+            forest_map.add_entry(target_id, tree_start_offset);
+            
+            // Reconstruct tree and load into memory
+            let tree = BasicCOITree::new(
+                intervals
+                    .iter()
+                    .map(|interval| Interval {
+                        first: interval.first,
+                        last: interval.last,
+                        metadata: interval.metadata.clone(),
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            );
+            trees.insert(target_id, tree);
+            
+            // Calculate size for next offset
+            let tree_size = bincode::serde::encode_to_vec(&(target_id, &intervals), bincode::config::standard())
+                .map(|v| v.len() as u64)
+                .unwrap_or(0);
+            current_offset += tree_size;
+        }
+        
+        // Try to save forest map for future use (optional - don't fail if it doesn't work)
+        match forest_map.save_to_file(&forest_map_file) {
+            Ok(_) => info!("Forest map created for future lazy loading: {}.", forest_map_file),
+            Err(e) => warn!("Failed to create forest map: {}. Index will work without it.", e),
+        }
+        
+        // Build paf_gzi_indices
+        let paf_gzi_indices: Vec<_> = paf_files
+            .par_iter()
+            .map(|paf_file| {
+                if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
+                    let paf_gzi_file = paf_file.to_owned() + ".gzi";
+                    Some(
+                        bgzf::gzi::fs::read(paf_gzi_file.clone())
+                            .unwrap_or_else(|_| panic!("Could not open {}", paf_gzi_file)),
+                    )
+                } else {
+                    None
+                }
+            })
+            .collect();
+        
+        // Return IMPG with all trees loaded (no forest map needed)
+        Ok(Impg {
+            trees: RwLock::new(trees),
+            seq_index,
+            paf_files: paf_files.to_vec(),
+            paf_gzi_indices,
+            forest_map: None, // No forest map - all trees are loaded
+            index_file_path: None,
+        })
+    }
 }
 
 
@@ -1177,12 +1308,16 @@ fn generate_multi_index(
         )
     })?;
 
-    // Serialize the index with embedded forest map
+    // Serialize the index with forest map creation
     let index_file_path = index_file.clone();
     let file = File::create(&index_file_path)?;
     let mut writer = BufWriter::new(file);
-    impg.serialize_with_embedded_forest_map(&mut writer)?;
-    info!("Index with embedded forest map saved to {}", index_file_path);
+    let forest_map = impg.serialize_with_forest_map(&mut writer)?;
+    
+    // Save the forest map to a separate file
+    let forest_map_file = ForestMap::get_forest_map_filename(&index_file_path);
+    info!("Saving forest map to {}", forest_map_file);
+    forest_map.save_to_file(&forest_map_file)?;
 
     Ok(impg)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
-use coitrees::{BasicCOITree, Interval, IntervalTree};
+use coitrees::{Interval, IntervalTree};
 use impg::faidx::FastaIndex;
-use impg::forest_map::ForestMap;
-use impg::impg::{AdjustedInterval, CigarOp, Impg, SerializableInterval};
+use impg::impg::{AdjustedInterval, CigarOp, Impg};
 use impg::paf::{PartialPafRecord, Strand};
 use impg::partition::partition_alignments;
 use impg::seqidx::SequenceIndex;
@@ -15,7 +14,6 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, BufReader, BufWriter};
-use std::sync::RwLock;
 
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1075,142 +1073,13 @@ fn load_multi_index(paf_files: &[String], custom_index: Option<&str>) -> io::Res
         });
     }
 
-    // Check if forest map exists for lazy loading
-    let forest_map_file = ForestMap::get_forest_map_filename(&index_file);
+    // Load with embedded forest map (single-file format)
+    let file = File::open(&index_file)?;
+    let reader = BufReader::new(file);
     
-    if std::path::Path::new(&forest_map_file).exists() {
-        info!("Forest map found. Lazy loading enabled.");
-        
-        // Load sequence index only
-        let file = File::open(&index_file)?;
-        let mut reader = BufReader::new(file);
-        let seq_index: SequenceIndex =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                |e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to load sequence index: {:?}", e),
-                    )
-                },
-            )?;
-        
-        // Load forest map
-        let forest_map = ForestMap::load_from_file(&forest_map_file)?;
-        
-        Ok(Impg::with_forest_map(
-            paf_files,
-            seq_index,
-            forest_map,
-            index_file,
-        ))
-    } else {
-        info!("No forest map found. Loading full index.");
-        
-        // Load full index into memory
-        let file = File::open(&index_file)?;
-        let mut reader = BufReader::new(file);
-        
-        // Load sequence index
-        let seq_index: SequenceIndex =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                |e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to load sequence index: {:?}", e),
-                    )
-                },
-            )?;
-        
-        // Load tree count
-        let tree_count: u32 =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                |e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to load tree count: {:?}", e),
-                    )
-                },
-            )?;
-        
-        // Load all trees into memory
-        let mut trees = FxHashMap::default();
-        let mut forest_map = ForestMap::new();
-        let seq_index_size = bincode::serde::encode_to_vec(&seq_index, bincode::config::standard())
-            .map(|v| v.len() as u64)
-            .unwrap_or(0);
-        let tree_count_size = bincode::serde::encode_to_vec(&tree_count, bincode::config::standard())
-            .map(|v| v.len() as u64)
-            .unwrap_or(0);
-        let mut current_offset = seq_index_size + tree_count_size;
-        
-        for _ in 0..tree_count {
-            let tree_start_offset = current_offset;
-            let (target_id, intervals): (u32, Vec<SerializableInterval>) =
-                bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                    |e| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("Failed to load tree data: {:?}", e),
-                        )
-                    },
-                )?;
-            
-            // Add to forest map for future use
-            forest_map.add_entry(target_id, tree_start_offset);
-            
-            // Reconstruct tree and load into memory
-            let tree = BasicCOITree::new(
-                intervals
-                    .iter()
-                    .map(|interval| Interval {
-                        first: interval.first,
-                        last: interval.last,
-                        metadata: interval.metadata.clone(),
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            );
-            trees.insert(target_id, tree);
-            
-            // Calculate size for next offset
-            let tree_size = bincode::serde::encode_to_vec(&(target_id, &intervals), bincode::config::standard())
-                .map(|v| v.len() as u64)
-                .unwrap_or(0);
-            current_offset += tree_size;
-        }
-        
-        // Try to save forest map for future use (optional - don't fail if it doesn't work)
-        match forest_map.save_to_file(&forest_map_file) {
-            Ok(_) => info!("Forest map created for future lazy loading: {}.", forest_map_file),
-            Err(e) => warn!("Failed to create forest map: {}. Index will work without it.", e),
-        }
-        
-        // Build paf_gzi_indices
-        let paf_gzi_indices: Vec<_> = paf_files
-            .par_iter()
-            .map(|paf_file| {
-                if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
-                    let paf_gzi_file = paf_file.to_owned() + ".gzi";
-                    Some(
-                        bgzf::gzi::fs::read(paf_gzi_file.clone())
-                            .unwrap_or_else(|_| panic!("Could not open {}", paf_gzi_file)),
-                    )
-                } else {
-                    None
-                }
-            })
-            .collect();
-        
-        // Return IMPG with all trees loaded (no forest map needed)
-        Ok(Impg {
-            trees: RwLock::new(trees),
-            seq_index,
-            paf_files: paf_files.to_vec(),
-            paf_gzi_indices,
-            forest_map: None, // No forest map - all trees are loaded
-            index_file_path: None,
-        })
-    }
+    let impg = Impg::load_from_embedded_forest_map(reader, paf_files, index_file.clone())?;
+    info!("Loaded index with embedded forest map. Lazy loading enabled.");
+    Ok(impg)
 }
 
 
@@ -1308,16 +1177,12 @@ fn generate_multi_index(
         )
     })?;
 
-    // Serialize the index with forest map creation
+    // Serialize the index with embedded forest map
     let index_file_path = index_file.clone();
     let file = File::create(&index_file_path)?;
     let mut writer = BufWriter::new(file);
-    let forest_map = impg.serialize_with_forest_map(&mut writer)?;
-    
-    // Save the forest map to a separate file
-    let forest_map_file = ForestMap::get_forest_map_filename(&index_file_path);
-    info!("Saving forest map to {}", forest_map_file);
-    forest_map.save_to_file(&forest_map_file)?;
+    impg.serialize_with_embedded_forest_map(&mut writer)?;
+    info!("Index with embedded forest map saved to {}", index_file_path);
 
     Ok(impg)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2077,7 +2077,7 @@ fn print_stats(impg: &Impg) {
         .sum();
 
     // Compute overlap stats - forest map is mandatory in IMPG index
-    let forest_map = impg.forest_map.as_ref().expect("Error loading forest map");
+    let forest_map = &impg.forest_map;
 
     info!(
         "Computing statistics for {} trees...",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
-use coitrees::{BasicCOITree, Interval, IntervalTree};
+use coitrees::{Interval, IntervalTree};
 use impg::faidx::FastaIndex;
-use impg::forest_map::ForestMap;
-use impg::impg::{AdjustedInterval, CigarOp, Impg, SerializableInterval};
+use impg::impg::{AdjustedInterval, CigarOp, Impg};
 use impg::paf::{PartialPafRecord, Strand};
 use impg::partition::partition_alignments;
 use impg::seqidx::SequenceIndex;
@@ -15,7 +14,6 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, BufReader, BufWriter};
-use std::sync::RwLock;
 
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1075,142 +1073,11 @@ fn load_multi_index(paf_files: &[String], custom_index: Option<&str>) -> io::Res
         });
     }
 
-    // Check if forest map exists for lazy loading
-    let forest_map_file = ForestMap::get_forest_map_filename(&index_file);
+    // Load from embedded format
+    let file = File::open(&index_file)?;
+    let reader = BufReader::new(file);
     
-    if std::path::Path::new(&forest_map_file).exists() {
-        info!("Forest map found. Lazy loading enabled.");
-        
-        // Load sequence index only
-        let file = File::open(&index_file)?;
-        let mut reader = BufReader::new(file);
-        let seq_index: SequenceIndex =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                |e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to load sequence index: {:?}", e),
-                    )
-                },
-            )?;
-        
-        // Load forest map
-        let forest_map = ForestMap::load_from_file(&forest_map_file)?;
-        
-        Ok(Impg::with_forest_map(
-            paf_files,
-            seq_index,
-            forest_map,
-            index_file,
-        ))
-    } else {
-        info!("No forest map found. Loading full index.");
-        
-        // Load full index into memory
-        let file = File::open(&index_file)?;
-        let mut reader = BufReader::new(file);
-        
-        // Load sequence index
-        let seq_index: SequenceIndex =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                |e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to load sequence index: {:?}", e),
-                    )
-                },
-            )?;
-        
-        // Load tree count
-        let tree_count: u32 =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                |e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to load tree count: {:?}", e),
-                    )
-                },
-            )?;
-        
-        // Load all trees into memory
-        let mut trees = FxHashMap::default();
-        let mut forest_map = ForestMap::new();
-        let seq_index_size = bincode::serde::encode_to_vec(&seq_index, bincode::config::standard())
-            .map(|v| v.len() as u64)
-            .unwrap_or(0);
-        let tree_count_size = bincode::serde::encode_to_vec(&tree_count, bincode::config::standard())
-            .map(|v| v.len() as u64)
-            .unwrap_or(0);
-        let mut current_offset = seq_index_size + tree_count_size;
-        
-        for _ in 0..tree_count {
-            let tree_start_offset = current_offset;
-            let (target_id, intervals): (u32, Vec<SerializableInterval>) =
-                bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard()).map_err(
-                    |e| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("Failed to load tree data: {:?}", e),
-                        )
-                    },
-                )?;
-            
-            // Add to forest map for future use
-            forest_map.add_entry(target_id, tree_start_offset);
-            
-            // Reconstruct tree and load into memory
-            let tree = BasicCOITree::new(
-                intervals
-                    .iter()
-                    .map(|interval| Interval {
-                        first: interval.first,
-                        last: interval.last,
-                        metadata: interval.metadata.clone(),
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            );
-            trees.insert(target_id, tree);
-            
-            // Calculate size for next offset
-            let tree_size = bincode::serde::encode_to_vec(&(target_id, &intervals), bincode::config::standard())
-                .map(|v| v.len() as u64)
-                .unwrap_or(0);
-            current_offset += tree_size;
-        }
-        
-        // Try to save forest map for future use (optional - don't fail if it doesn't work)
-        match forest_map.save_to_file(&forest_map_file) {
-            Ok(_) => info!("Forest map created for future lazy loading: {}.", forest_map_file),
-            Err(e) => warn!("Failed to create forest map: {}. Index will work without it.", e),
-        }
-        
-        // Build paf_gzi_indices
-        let paf_gzi_indices: Vec<_> = paf_files
-            .par_iter()
-            .map(|paf_file| {
-                if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
-                    let paf_gzi_file = paf_file.to_owned() + ".gzi";
-                    Some(
-                        bgzf::gzi::fs::read(paf_gzi_file.clone())
-                            .unwrap_or_else(|_| panic!("Could not open {}", paf_gzi_file)),
-                    )
-                } else {
-                    None
-                }
-            })
-            .collect();
-        
-        // Return IMPG with all trees loaded (no forest map needed)
-        Ok(Impg {
-            trees: RwLock::new(trees),
-            seq_index,
-            paf_files: paf_files.to_vec(),
-            paf_gzi_indices,
-            forest_map: None, // No forest map - all trees are loaded
-            index_file_path: None,
-        })
-    }
+    Impg::load_from_file(reader, paf_files, index_file)
 }
 
 
@@ -1308,16 +1175,11 @@ fn generate_multi_index(
         )
     })?;
 
-    // Serialize the index with forest map creation
+    // Serialize the index with embedded forest map
     let index_file_path = index_file.clone();
     let file = File::create(&index_file_path)?;
     let mut writer = BufWriter::new(file);
-    let forest_map = impg.serialize_with_forest_map(&mut writer)?;
-    
-    // Save the forest map to a separate file
-    let forest_map_file = ForestMap::get_forest_map_filename(&index_file_path);
-    info!("Saving forest map to {}", forest_map_file);
-    forest_map.save_to_file(&forest_map_file)?;
+    impg.serialize_with_forest_map(&mut writer)?;
 
     Ok(impg)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2145,7 +2145,7 @@ fn trim_cigar_prefix(cigar: &[CigarOp], query_len: i32, target_len: i32) -> Vec<
 
 fn compute_stats_memory_efficient(impg: &Impg) -> io::Result<(usize, FxHashMap<u32, usize>)> {
     if let Some(forest_map) = &impg.forest_map {
-        info!("Computing statistics for {} trees in parallel (memory-efficient mode)...", forest_map.entries.len());
+        info!("Computing statistics for {} trees...", forest_map.entries.len());
         
         // Collect target IDs to process
         let target_ids: Vec<u32> = forest_map.entries.keys().copied().collect();


### PR DESCRIPTION
With the previous implementation, we had to load the entire IMPG index into memory even to perform a very small operation that used a very small part of it.

This PR introduces a "forest map" that traces for each target the position of its interval tree in the IMPG index. This allows lazy loading of the tree, only if and when necessary. When a tree is loaded, it is kept in memory for faster future retrieval (useful for transitive queries, and for `impg partition` and `impg similarity` commands).

Knowing where all trees are also allows a parallelized, then much faster full IMPG index loading, if needed. Indeed, `impg stats` is way faster than before and can even compute statistics without keeping all trees in memory.

The lazy approach strongly reduces runtime and memory when we don't need to query the full pangenome. In the following example, >300X faster and ~76.32X less memory.

**Single query of the HPRCv2 implicit graph**
The input alignments are in a ~300GB bgzipped PAF file (maximum level of compression, `-l 9`).
The IMPG index file takes 17GB.
The forest map file takes just 388Kb.

```shell
# before (full IMPG index loading)
\time -v impg query -p hprc25272.aln.paf.gz -r GRCh38#0#chr17:43299000-43300000 -v 2 -t 44 > /dev/null
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:16.90
        Maximum resident set size (kbytes): 24626460

# now (lazy tree loading)
\time -v impg query -p hprc25272.aln.paf.gz -r GRCh38#0#chr17:43299000-43300000 -v 2 -t 44 > /dev/null
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20
        Maximum resident set size (kbytes): 322644
```