### PR TITLE
`impq query`: add `--original-sequence-coordinates` flag to get coordinates w.r.t. the original sequences

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ struct QueryOpts {
     #[clap(long, value_parser, default_value_t = 0)]
     min_distance_between_ranges: i32,
 
-    /// Update coordinates to original sequences when input sequences are subsequences
+    /// Update coordinates to original sequences when input sequences are subsequences (seq_name:start-end) for 'bed', 'bedpe', and 'paf'
     #[clap(long, action)]
     original_sequence_coordinates: bool,
 }


### PR DESCRIPTION
```shell
# Without `--original-sequence-coordinates`
impg query -p w1000000-m5-f10000-d1000000-l1000-chm13-total.partition5.fa.gz.c69640f.alignments.wfmash.paf.gz -r GRCh38#0#chr1:5477602-6474357:45781-45839 -x -m 0 | grep HG002 -w
    HG002#1#chr1:5116130-6116563    45803   45861   GRCh38#0#chr1:5477602-6474357:45781-45839       .       +

# With `--original-sequence-coordinates`
impg query -p w1000000-m5-f10000-d1000000-l1000-chm13-total.partition5.fa.gz.c69640f.alignments.wfmash.paf.gz -r GRCh38#0#chr1:5477602-6474357:45781-45839 -x -m 0 --original-sequence-coordinates | grep HG002 -w
    HG002#1#chr1    5161933 5161991 GRCh38#0#chr1:5477602-6474357:45781-45839       .       +
```