### PR TITLE
Fix rayon pool initialization and cover tests

### DIFF
--- a/.github/workflows/rust_build_test.yml
+++ b/.github/workflows/rust_build_test.yml
@@ -58,4 +58,4 @@ jobs:
       run: cargo build --verbose
     
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-targets --verbose


### PR DESCRIPTION
I asked codex to fix this bug, and it seems fixed: 

impg similarity -p hprc465vschm13.aln.paf.gz -r CHM13#0#chr1:158341439-158341639 --sequence-files HPRC_r2_assemblies_0.6.1.agc

thread 'main' panicked at src/main.rs:1216:10:
called `Result::unwrap()` on an `Err` value: ThreadPoolBuildError { kind: GlobalPoolAlreadyInitialized }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

