### PR TITLE
Add `fasta+paf` output format and `-O` output basename option to `impg query`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ impl GfaMafFastaOpts {
         Option<UnifiedSequenceIndex>,
         Option<(u8, u8, u8, u8, u8, u8)>,
     )> {
-        let needs_sequence_mandatory = matches!(output_format, "gfa" | "maf" | "fasta");
+        let needs_sequence_mandatory = matches!(output_format, "gfa" | "maf" | "fasta" | "fasta+paf");
         let needs_sequence_optional = output_format == "paf" && original_sequence_coordinates;
         let needs_poa = matches!(output_format, "gfa" | "maf");
 


### PR DESCRIPTION
This enables `impg query` to output its sub-alignment as a FASTA *and* an associated PAF, which should be sufficient to reconstruct the implied local graph without any re-alignment.

To write out both the FASTA and the PAF to separate streams, there is now a `-O` option which takes a file basename. The FASTA will go to that plus `.fa`, and the PAF to that plus `.paf`. The other output formats are also updated to support this.

You *can* leave it out for `fasta+paf`, but then you get both the FASTA and the PAF data to standard output and it's up to you to sort that out.

Also, all the output functions now consistently return a `Result`.

I haven't done anything to the FASTA header generation, so to actually reconstruct the alignment from the FASTA and the PAF, you need to parse the `:` ranges out of the FASTA headers when interpreting them.