### PR TITLE
Add depth command for computing coverage depth across all sequences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`impg` (implicit pangenome graph) is a Rust tool for rapid querying of pangenome alignments. It treats all-vs-all pairwise alignments as an implicit pangenome graph, enabling fast projection of target ranges through alignment networks to extract homologous sequences without building explicit graph structures.
+
+## Build and Test Commands
+
+```bash
+# Install (recommended for production use)
+cargo install --force --path .
+
+# Build for development
+cargo build                    # Debug build
+cargo build --release          # Release build (use for benchmarking)
+cargo build --release --no-default-features  # Without AGC support
+
+# Run without installing
+cargo run --release -- query -a alignments.paf -r chr1:1000-2000
+
+# Testing
+cargo test                     # All tests
+cargo test test_name           # Specific test
+cargo test -- --nocapture      # With output
+
+# Code quality
+cargo check                    # Check compilation
+cargo clippy                   # Linter
+cargo fmt                      # Format code
+```
+
+## Core Architecture
+
+### Alignment Index System
+- **coitrees** (Cache Oblivious Interval Trees): Fast range lookups over alignments
+- **Serialized indices**: Bincode-serialized indices cached on disk for fast startup
+- **Two input formats**:
+  - **PAF files**: Standard pairwise alignment format with CIGAR (from wfmash/minimap2 --eqx)
+  - **.1aln files**: Compressed format using tracepoints instead of full CIGAR strings
+
+### Key Modules
+
+- `src/main.rs`: CLI argument parsing, command dispatch, output format handling
+- `src/impg.rs`: Core interval projection logic, CIGAR delta encoding, transitive queries (BFS/DFS)
+- `src/alignment_record.rs`: Unified representation for PAF and .1aln alignments
+- `src/onealn.rs`: Parser for .1aln format with tracepoint-to-CIGAR reconstruction
+- `src/paf.rs`: PAF file parsing and CIGAR handling
+- `src/sequence_index.rs`: Unified sequence access for FASTA and AGC archives
+- `src/forest_map.rs`: Interval tree forest mapping sequences to their alignment trees
+- `src/commands/`: Subcommands (partition, refine, similarity, lace)
+
+### .1aln Format Details
+
+The .1aln format stores alignments compactly using tracepoints:
+- `trace_spacing`: Regular interval on query sequence (typically 100bp)
+- `tracepoints[]`: Array of consumed lengths on target sequence at each interval
+- `trace_diffs[]`: Number of differences at each tracepoint (for identity calculation)
+
+**Two execution modes for .1aln**:
+1. **Normal mode**: Reconstructs full CIGAR from tracepoints using WFA (Wavefront Alignment)
+2. **Approximate mode** (`--approximate`): Skips CIGAR reconstruction, uses refined tracepoint statistics for ~10-100x speedup
+
+See `notes/FAST_MODE_IMPLEMENTATION.md` for detailed implementation notes on tracepoint subsetting and approximate mode.
+
+### Transitive Queries
+
+The tool supports finding alignments connected through multiple hops:
+- **BFS mode** (default `-x`): Breadth-first exploration, finds more overlapping results
+- **DFS mode** (`--transitive-dfs`): Depth-first exploration, fewer overlaps but deeper paths
+- **Max depth** (`-m`): Control transitive search depth (0 = unlimited)
+
+## Commands
+
+- **query**: Query overlapping alignments for a region or BED file
+- **partition**: Partition alignments into windows across sequences
+- **refine**: Refine loci to maximize sample support
+- **similarity**: Compute pairwise similarity matrices with optional PCA
+- **lace**: Combine multiple GFA or VCF files
+- **stats**: Print alignment statistics
+- **index**: Create IMPG index from alignment files
+
+## Development Notes
+
+### Adding New Output Format
+1. Update `OutputFormat` enum in `src/main.rs`
+2. Implement format writer in `write_*_output()` function
+3. Update format validation in command handlers
+
+### Modifying Alignment Processing
+1. Core projection logic: `src/impg.rs::project_overlapping_interval()`
+2. For .1aln approximate mode: `project_overlapping_interval_fast()`
+3. CIGAR operations use `CigarOp` enum with delta encoding
+
+### Working with Sequences
+- `UnifiedSequenceIndex` handles both FASTA and AGC formats
+- AGC support is optional (controlled by `agc` feature flag)
+- Use `#[cfg(feature = "agc")]` for AGC-specific code
+
+## Important Implementation Notes
+
+### CIGAR Delta Encoding
+`impg` uses compact delta encoding for CIGAR operations rather than storing full strings. When working with CIGAR:
+- Operations are `Vec<CigarOp>` where each op is an enum variant (Match, Insertion, Deletion, etc.)
+- Convert to/from string representation as needed for output formats
+
+### Coordinate Systems
+- **PAF coordinates**: 0-based, half-open intervals [start, end)
+- **BED coordinates**: 0-based, half-open intervals [start, end)
+- **GFA coordinates**: 1-based, closed intervals [start, end]
+- Target reverse strand: coordinates are flipped within the contig
+- Query reverse strand: coordinates stored forward in metadata, swap after projection for output
+
+### Memory and Performance
+- Use `rayon` for parallelization (configured via `-t` threads parameter)
+- Interval trees are memory-intensive for large alignments
+- Index caching avoids re-parsing alignment files
+- For .1aln approximate mode: skip sequence fetching for bed/bedpe output
+
+### Approximate Mode Requirements
+When using `--approximate` with transitive queries (`-x` or partition/refine commands):
+- Must set `--min-transitive-len` > trace_spacing
+- Typical: `--min-transitive-len 101` for trace_spacing=100bp
+- Non-transitive queries don't need this restriction
+
+## Dependencies of Note
+
+- `rust-htslib`: Fixed at version 0.46.0 (see Cargo.toml comment about issue #434)
+- `lib_wfa2`, `lib_tracepoints`, `onecode`: For .1aln format support
+- `handlegraph`: For GFA graph operations in lace command
+
+## Testing
+
+Test data is in `tests/test_data/` with sample FASTA and AGC files. Key testing considerations:
+- Test with both PAF and .1aln alignment formats
+- Verify output formats: bed, bedpe, paf, gfa, maf, fasta, fasta-aln
+- Test transitive queries at various depths (-m 1, -m 2, -m 10)
+- Compare approximate mode results to normal mode for accuracy
+- Test edge cases: reverse strand alignments, overlapping intervals
+
+## Debugging
+
+- Verbosity: `-v 2` for debug logs, or `RUST_LOG=debug`
+- For .1aln issues: check trace_spacing cache and tracepoint reconstruction
+- Performance profiling: always use `--release` build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ cargo fmt                      # Format code
 - `src/paf.rs`: PAF file parsing and CIGAR handling
 - `src/sequence_index.rs`: Unified sequence access for FASTA and AGC archives
 - `src/forest_map.rs`: Interval tree forest mapping sequences to their alignment trees
-- `src/commands/`: Subcommands (partition, refine, similarity, lace)
+- `src/commands/`: Subcommands (depth, partition, refine, similarity, lace)
+- `src/commands/depth.rs`: Depth computation — two-phase global depth, region queries, sweep-line algorithm
+- `src/multi_impg.rs`: Multi-file index with lazy sub-index loading and tree caching
 
 ### .1aln Format Details
 
@@ -74,6 +76,7 @@ The tool supports finding alignments connected through multiple hops:
 ## Commands
 
 - **query**: Query overlapping alignments for a region or BED file
+- **depth**: Compute per-position coverage depth across samples (see `notes/DEPTH_COMMAND.md`)
 - **partition**: Partition alignments into windows across sequences
 - **refine**: Refine loci to maximize sample support
 - **similarity**: Compute pairwise similarity matrices with optional PCA
@@ -138,6 +141,16 @@ Test data is in `tests/test_data/` with sample FASTA and AGC files. Key testing 
 - Test transitive queries at various depths (-m 1, -m 2, -m 10)
 - Compare approximate mode results to normal mode for accuracy
 - Test edge cases: reverse strand alignments, overlapping intervals
+
+### Depth Command Architecture
+
+The depth command (`src/commands/depth.rs`) computes per-position coverage depth:
+
+- **Two-phase global depth**: Phase 1 processes hub sequences (high degree or `--ref` sample) as anchors; Phase 2 processes remaining unprocessed regions. `ConcurrentProcessedTracker` prevents double-counting.
+- **Transitive depth**: Default uses raw-interval BFS (`depth_transitive_bfs()`) with linear interpolation — faster, no CIGAR needed. `--use-BFS` flag enables CIGAR-precise BFS for base-level precision.
+- **Sweep-line depth counting**: `sweep_line_depth()` is a pure sweep-line that counts unique samples per position. Callers add a synthetic anchor alignment covering `[region_start, region_end]` so depth naturally includes the anchor sample. depth = total unique samples sharing each position.
+- **5MB chunk splitting** (`TRANSITIVE_CHUNK_SIZE`): Global transitive mode splits large sequences into 5MB chunks for BFS to limit memory.
+- **Pre-scan memory**: When using `--index-mode per-file` with many files, tree cache must be disabled during `compute_alignment_degrees()` pre-scan to prevent loading all sub-indices simultaneously (`set_tree_cache_enabled(false)` + `clear_sub_index_cache()`).
 
 ## Debugging
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,12 +46,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +178,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -239,16 +233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-pseudorand"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2097358495d244a0643746f4d13eedba4608137008cf9dec54e53a3b700115a6"
-dependencies = [
- "chiapos-chacha8",
- "nanorand 0.6.1",
 ]
 
 [[package]]
@@ -332,12 +316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cbindgen"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,15 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chiapos-chacha8"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f8be573a85f6c2bc1b8e43834c07e32f95e489b914bf856c0549c3c269cd0a"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,33 +372,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -564,42 +506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
-]
-
-[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,12 +560,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -896,7 +796,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand 0.7.0",
+ "nanorand",
  "spin",
 ]
 
@@ -1044,17 +944,6 @@ dependencies = [
  "log",
  "num_cpus",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -1304,6 +1193,7 @@ dependencies = [
  "spoa_rs",
  "sweepga",
  "tempfile",
+ "tikv-jemallocator",
  "tracepoints",
  "zstd",
 ]
@@ -1332,30 +1222,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1651,12 +1521,6 @@ dependencies = [
 
 [[package]]
 name = "nanorand"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
-
-[[package]]
-name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
@@ -1846,12 +1710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,34 +1764,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -2160,17 +1990,13 @@ dependencies = [
 
 [[package]]
 name = "rdst"
-version = "0.20.14"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7970b4e577b76a96d5e56b5f6662b66d1a4e1f5bb026ee118fc31b373c2752"
+checksum = "6cf18dd479f856ca75267591c062e22b50e2db791157495bc2d533558de7061d"
 dependencies = [
  "arbitrary-chunks",
- "block-pseudorand",
- "criterion",
  "partition",
  "rayon",
- "tikv-jemallocator",
- "voracious_radix_sort",
 ]
 
 [[package]]
@@ -2305,15 +2131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2647,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
  "libc",
@@ -2657,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -2673,16 +2490,6 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2822,25 +2629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
-name = "voracious_radix_sort"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446e7ffcb6c27a71d05af7e51ef2ee5b71c48424b122a832f2439651e1914899"
-dependencies = [
- "rayon",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,16 +2686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
  "noodles",
  "num_cpus",
  "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=38182c7acf7cccc53509176b1d11001ae6ff2642)",
+ "parking_lot",
  "ragc-core",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Memory allocator: jemalloc handles multi-threaded alloc/free patterns far better than glibc malloc.
+# Without it, 128 threads doing rapid large alloc/free cycles (tree deserialization in BFS)
+# cause glibc ptmalloc arena fragmentation where RSS grows continuously.
+tikv-jemallocator = "0.6"
+
 bincode = { version = "2.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2021"
 # cause glibc ptmalloc arena fragmentation where RSS grows continuously.
 tikv-jemallocator = "0.6"
 
+# Lightweight mutex implementation (1 byte vs std::sync::Mutex's 40+ bytes)
+# Used for ConcurrentProcessedTracker in depth command to reduce memory overhead
+parking_lot = "0.12"
+
 bincode = { version = "2.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.5", features = ["derive"] }

--- a/notes/DEPTH_COMMAND.md
+++ b/notes/DEPTH_COMMAND.md
@@ -1,0 +1,276 @@
+# impg depth
+
+## What it does
+
+`impg depth` computes pangenome coverage depth: for every locus in the pangenome, it counts how many distinct haplotypes (samples) cover that position. The output tells you which regions are shared across many genomes (high depth) versus unique to a single assembly (depth=1).
+
+This is useful for:
+
+- **Identifying conserved regions** shared by all or most assemblies
+- **Detecting sample-specific sequence** (depth=1 regions, e.g., novel insertions)
+- **Quality-checking pangenome alignments** (unexpected depth drops may indicate alignment gaps)
+- **Guiding downstream analyses** like variant calling or structural variant detection in regions with sufficient sample coverage
+
+## Core idea
+
+Traditional depth tools (like `samtools depth`) require reads mapped to a single reference. In a pangenome, there is no single reference -- you have N assemblies with pairwise alignments between them. `impg depth` solves this by treating pairwise alignments as an implicit graph and traversing it to find all haplotypes covering each locus, without building an explicit graph structure.
+
+The key insight: if sample A aligns to sample B, and sample B aligns to sample C, then A, B, and C all cover the same locus. `impg depth` discovers these transitive relationships through BFS traversal of the alignment graph.
+
+## Basic usage
+
+By default, `impg depth` computes depth across the entire pangenome. Every base is assigned to exactly one output row -- no double-counting. Hub sequences (those with the most alignments) are auto-detected via a degree pre-scan and processed first as anchors.
+
+```bash
+impg depth -a alignments.paf -O output_prefix -t 64
+```
+
+Output format (`output_prefix.depth.tsv`):
+
+```
+#id  length  depth  SampleA          SampleB           SampleC
+1    50000   3      chrA:0-50000     chrB:100-50100    chrC:200-50200
+2    30000   1      chrA:50000-80000 NA                NA
+```
+
+Each row is an interval. The `depth` column is the number of distinct samples covering it. Each sample column shows `seq:start-end` coordinates or `NA`.
+
+## Modes
+
+### 1. Ref-anchored mode (`--ref SAMPLE`)
+
+Prioritizes the specified sample's sequences as anchors. This guarantees that all regions covered by the ref sample are reported in the ref sample's coordinate system.
+
+```bash
+impg depth -a alignments.paf --ref CHM13 -O output_prefix
+```
+
+The ref sample's sequences are processed in Phase 1 (before all others), so they claim all their homologous regions first. Non-ref sequences only anchor regions the ref sample doesn't cover. All sequences from all samples still appear in the output.
+
+### 2. Ref-only mode (`--ref SAMPLE --ref-only`)
+
+Only outputs depth for regions anchored on the ref sample's sequences. Regions not covered by the ref sample are omitted from the output entirely.
+
+```bash
+impg depth -a alignments.paf --ref CHM13 --ref-only -O output_prefix
+```
+
+This is useful when you want a reference-centric view: "for each position on CHM13, how many other haplotypes align here?"
+
+### 3. Region query mode (`-r` or `-b`)
+
+Query depth for specific genomic regions rather than the whole pangenome.
+
+```bash
+# Single region
+impg depth -a alignments.paf -r chr1:1000000-2000000
+
+# Multiple regions from BED file
+impg depth -a alignments.paf -b regions.bed
+```
+
+Output format:
+
+```
+#ref_seq   ref_start  ref_end  depth  Sample1            Sample2
+chr1       1000000    1050000  3      sample2_seq:100-200  sample3_seq:50-150
+```
+
+### Add-on: Statistics output (`--stats`)
+
+The `--stats` flag can be combined with the global or ref-anchored modes to produce summary statistics and per-depth BED files instead of the default tabular output.
+
+```bash
+# Basic statistics
+impg depth -a alignments.paf --stats -O depth_stats
+
+# Statistics with per-interval sample tracking
+impg depth -a alignments.paf --stats --combined-output -O depth_stats
+
+# Statistics anchored on a reference
+impg depth -a alignments.paf --stats --ref CHM13 -O depth_stats
+```
+
+Outputs:
+- `depth_stats.summary.txt`: depth distribution (depth N covers X bp, Y%)
+- `depth_stats.depthN.bed`: BED file for each depth level
+- `depth_stats.combined.bed` (with `--combined-output`): single sorted BED with depth and sample columns
+
+## How the algorithm works
+
+### Step 1: Degree pre-scan
+
+Before computing depth, `impg depth` scans all sequences to compute their **alignment degree** -- the number of distinct other samples each sequence has direct alignments to.
+
+```
+Example (star topology: B,C,D,E all aligned to A):
+  A: degree=4  (aligned to B, C, D, E)
+  B: degree=1  (aligned to A)
+  C: degree=1  (aligned to A)
+  D: degree=1  (aligned to A)
+  E: degree=1  (aligned to A)
+```
+
+This pre-scan identifies **hub sequences** (high-degree nodes) that should be processed first. The pre-scan runs in parallel and is fast (seconds for thousands of sequences).
+
+When `--ref` is specified, the ref sample's sequences are used as Phase 1 directly, but the degree pre-scan still runs to sort the remaining sequences by connectivity.
+
+### Step 2: Sequence ordering
+
+Sequences are sorted for processing by:
+
+1. `--ref` sample sequences first (if specified)
+2. Alignment degree descending (hubs before leaves)
+3. Sequence length descending (longer sequences first, as tiebreaker)
+
+### Step 3: Two-phase parallel processing
+
+**Phase 1 -- Hub sequences**: High-connectivity sequences are processed first, guaranteeing they become the coordinate-system anchors for their homologous regions.
+
+- With `--ref`: the ref sample's sequences are Phase 1
+- Without `--ref`: sequences with degree >= max_degree/2 are auto-detected as hubs
+
+For transitive mode (`-x`), Phase 1 uses **chunk-level parallelism**: each hub sequence is split into 5MB chunks, giving ~1200 parallel tasks for a human-sized genome -- fully utilizing all threads. For non-transitive mode, Phase 1 uses sequence-level parallelism (each hub sequence is one task).
+
+**Phase 2 -- Remaining sequences**: Processes the rest. Most regions are already claimed by Phase 1 hubs, so Phase 2 only anchors regions the hubs didn't cover.
+
+### Step 4: Per-anchor depth computation
+
+For each anchor sequence (or unprocessed region within it):
+
+**Non-transitive (default):**
+Direct interval tree query. Finds all sequences with 1-hop alignments to the anchor region. Fast O(log n + k). The bidirectional index captures both alignment directions, so a single 1-hop query finds all directly aligned samples.
+
+**Transitive (`-x`):**
+BFS traversal through the alignment graph. Starting from the anchor region, follows alignment chains up to `--max-depth` hops (default: 2). This discovers samples connected indirectly.
+
+```
+Example with -x and max_depth=2:
+  Anchor: A (hub)
+  Hop 1: A -> B, A -> C, A -> D (direct alignments)
+  Hop 2: B -> E (E aligns to B but not to A)
+  Result: depth=5 (A + B + C + D + E)
+```
+
+All discovered regions on other sequences are projected back to the anchor's coordinate system via linear interpolation.
+
+### Step 5: Sweep-line depth computation
+
+Once all overlapping alignments are gathered for an anchor region, a sweep-line algorithm computes per-position depth:
+
+1. Create events: (position, START/END, sample_id) for each alignment
+2. Sort events by position
+3. Sweep left-to-right, maintaining a bitmap of active samples
+4. At each position change, emit an interval with the current depth and sample set
+
+The `SampleBitmap` structure tracks active samples in O(1) per depth query, handling multiple overlapping alignments from the same sample correctly (counted as depth=1, not double-counted).
+
+### Step 6: Processed region tracking
+
+A `ConcurrentProcessedTracker` ensures every base in the pangenome is counted exactly once:
+
+- When an anchor discovers alignments on other sequences, those regions are marked as "processed"
+- When a sequence comes up for processing, only its unprocessed regions are computed
+- Per-sequence mutexes provide lock-free parallelism (different sequences never contend)
+
+## Why hub-first ordering matters
+
+Consider a star topology where samples B, C, D, E are all aligned to sample A:
+
+```
+Without hub-first ordering:
+  B processed first -> finds A -> depth=2 (B+A)
+  A is now "processed" -> skipped
+  C processed -> finds A -> depth=2 (C+A)
+  D, E same -> depth=2 each
+  WRONG: true depth should be 5
+
+With hub-first ordering:
+  A processed first -> finds B,C,D,E -> depth=5 (A+B+C+D+E)
+  B,C,D,E marked as processed -> skipped
+  CORRECT: depth=5 reported in A's coordinate system
+```
+
+When `--ref` is not specified, the degree pre-scan automatically detects A as the hub (degree=4 >> others' degree=1) and processes it first. When `--ref A` is specified, the same result is guaranteed explicitly.
+
+## Key options
+
+### Transitive queries
+
+| Option | Description |
+|--------|-------------|
+| `-x` | Enable transitive BFS traversal (richer depth for sparse alignments) |
+| `-m, --max-depth N` | Maximum BFS hops (default: 2, 0 = unlimited) |
+| `--min-transitive-len N` | Minimum alignment length for transitive hops |
+
+Without `-x`, only direct (1-hop) alignments are considered. This is fast but may underestimate depth when the anchor is not the hub. With `-x`, BFS discovers indirect connections at the cost of more computation.
+
+### Reference selection
+
+| Option | Description |
+|--------|-------------|
+| `--ref SAMPLE` | Prioritize this sample's sequences as Phase 1 anchors |
+| `--ref-only` | Only output rows anchored on the ref sample (requires `--ref`) |
+
+`--ref` ensures the named sample's sequences are processed first, so they become coordinate-system anchors for all regions they cover. All sequences are still included in the output. Adding `--ref-only` filters the output to only include the ref sample's anchored rows.
+
+When `--ref` is not specified, hub sequences are auto-detected via the degree pre-scan.
+
+### Sequence filtering
+
+| Option | Description |
+|--------|-------------|
+| `--min-seq-length SIZE` | Exclude sequences shorter than SIZE (accepts k/m/g suffixes) |
+| `--fai-list FILE` | FAI index files; sequences not in alignments get depth=1 |
+| `--samples LIST` | Comma-separated sample names to include |
+| `--samples-file FILE` | File with sample names to include (one per line) |
+
+### Output control
+
+| Option | Description |
+|--------|-------------|
+| `-O, --output-prefix PREFIX` | Output file prefix (stdout if omitted) |
+| `--window-size N` | Split output into fixed-size windows (default: 50000 bp) |
+| `--merge-tolerance F` | Merge adjacent intervals with similar depth (default: 0.05 = 5%) |
+| `--separator CHAR` | PanSN format separator for sample name extraction (default: `#`) |
+
+### Performance
+
+| Option | Description |
+|--------|-------------|
+| `-t N` | Number of threads |
+| `--approximate` | Fast approximate mode for .1aln files |
+| `--index-mode per-file` | Per-file indexing for many alignment files |
+
+## Limitations
+
+- **Non-transitive mode with star topologies**: Without `-x`, leaf nodes only see the hub (depth=2 instead of N). Hub-first ordering mitigates this for the hub itself, but leaf-anchored regions still report incomplete depth. Use `-x` for full coverage.
+- **Transitive depth limit**: With `-x -m 2` (default), chains longer than 2 hops may miss distant samples. Increase `-m` for deeper traversal at the cost of more computation.
+- **Coordinate projection is approximate**: When projecting through transitive alignments, linear interpolation is used (not CIGAR-level mapping). Coordinates in non-anchor sample columns are approximate.
+- **Parallel non-determinism within Phase 2**: Within Phase 2, rayon's work-stealing means the exact assignment of anchors can vary slightly between runs. Phase 1 (hub) results are deterministic.
+
+## Examples
+
+```bash
+# Global depth with auto hub detection
+impg depth -a all_vs_all.paf -O pangenome -t 64
+
+# Transitive depth with reference anchoring
+impg depth -a all_vs_all.paf -x --ref CHM13 -O pangenome -t 128
+
+# Ref-only: depth from CHM13's perspective only
+impg depth -a all_vs_all.paf -x --ref CHM13 --ref-only -O pangenome -t 128
+
+# Large-scale with per-file indexing and length filter
+impg depth --alignment-list files.list --index-mode per-file \
+    --ref CHM13 -x --min-seq-length 1M -O result -t 128
+
+# Global depth with statistics output
+impg depth -a all_vs_all.paf --stats --combined-output -O stats
+
+# Query specific region
+impg depth -a all_vs_all.paf -x -r chr1:10000000-20000000
+
+# Filter to specific samples
+impg depth -a all_vs_all.paf --samples HG002,HG003,CHM13 -O filtered
+```

--- a/notes/DEPTH_COMMAND.md
+++ b/notes/DEPTH_COMMAND.md
@@ -33,7 +33,7 @@ Output format (`output_prefix.depth.tsv`):
 2    30000   1      chrA:50000-80000 NA                NA
 ```
 
-Each row is an interval. The `depth` column is the number of distinct samples covering it. Each sample column shows `seq:start-end` coordinates or `NA`.
+Each row is an interval. The `depth` column is the number of distinct samples covering it. Each sample column shows `seq:start-end` coordinates or `NA`. Gaps between alignment intervals are filled with depth=1 (the anchor sequence only).
 
 ## Modes
 
@@ -59,7 +59,7 @@ This is useful when you want a reference-centric view: "for each position on CHM
 
 ### 3. Region query mode (`-r` or `-b`)
 
-Query depth for specific genomic regions rather than the whole pangenome.
+Query depth for specific genomic regions rather than the whole pangenome. This mode queries both forward and reverse alignment directions (via `query_reverse_for_depth`) to ensure complete coverage.
 
 ```bash
 # Single region
@@ -76,9 +76,11 @@ Output format:
 chr1       1000000    1050000  3      sample2_seq:100-200  sample3_seq:50-150
 ```
 
+Note: `--samples` and `--samples-file` filtering only applies in region query mode. In global mode, these options are loaded but not passed to the depth computation pipeline.
+
 ### Add-on: Statistics output (`--stats`)
 
-The `--stats` flag can be combined with the global or ref-anchored modes to produce summary statistics and per-depth BED files instead of the default tabular output.
+The `--stats` flag can be combined with the global or ref-anchored modes to produce summary statistics and per-depth BED files instead of the default tabular output. Cannot be combined with region query mode (`-r`/`-b`).
 
 ```bash
 # Basic statistics
@@ -96,11 +98,21 @@ Outputs:
 - `depth_stats.depthN.bed`: BED file for each depth level
 - `depth_stats.combined.bed` (with `--combined-output`): single sorted BED with depth and sample columns
 
+Combined BED format:
+
+```
+#seq_name  length  depth  samples
+chrA       50000   3      sample1,sample2,sample3
+chrA       30000   1      sample1
+```
+
+Note: the `length` column is `end - start` (the interval width), not the full sequence length. When `--merge-tolerance` is set, adjacent intervals with similar depth are merged (depth = max of merged group, samples = union).
+
 ## How the algorithm works
 
 ### Step 1: Degree pre-scan
 
-Before computing depth, `impg depth` scans all sequences to compute their **alignment degree** -- the number of distinct other samples each sequence has direct alignments to.
+Before computing depth, `impg depth` scans all sequences in parallel to compute their **alignment degree** -- the number of distinct other samples each sequence has direct alignments to. Only sequences passing the `--min-seq-length` filter are considered.
 
 ```
 Example (star topology: B,C,D,E all aligned to A):
@@ -128,7 +140,7 @@ Sequences are sorted for processing by:
 **Phase 1 -- Hub sequences**: High-connectivity sequences are processed first, guaranteeing they become the coordinate-system anchors for their homologous regions.
 
 - With `--ref`: the ref sample's sequences are Phase 1
-- Without `--ref`: sequences with degree >= max_degree/2 are auto-detected as hubs
+- Without `--ref`: sequences with degree >= ceil(max_degree/2) are auto-detected as hubs (computed as `(max_degree + 1) / 2`). If max_degree <= 1, Phase 1 is skipped entirely.
 
 For transitive mode (`-x`), Phase 1 uses **chunk-level parallelism**: each hub sequence is split into 5MB chunks, giving ~1200 parallel tasks for a human-sized genome -- fully utilizing all threads. For non-transitive mode, Phase 1 uses sequence-level parallelism (each hub sequence is one task).
 
@@ -139,10 +151,13 @@ For transitive mode (`-x`), Phase 1 uses **chunk-level parallelism**: each hub s
 For each anchor sequence (or unprocessed region within it):
 
 **Non-transitive (default):**
-Direct interval tree query. Finds all sequences with 1-hop alignments to the anchor region. Fast O(log n + k). The bidirectional index captures both alignment directions, so a single 1-hop query finds all directly aligned samples.
+Uses a fast path with pre-scanned raw alignment intervals. All raw intervals for the anchor sequence are loaded via `query_raw_intervals()`, sorted by target start, and searched with binary search -- O(log n) to find the relevant range, then linear scan over overlapping intervals. The bidirectional index captures both alignment directions, so a single 1-hop query finds all directly aligned samples.
 
-**Transitive (`-x`):**
-BFS traversal through the alignment graph. Starting from the anchor region, follows alignment chains up to `--max-depth` hops (default: 2). This discovers samples connected indirectly.
+**Transitive (`-x`) — default raw-interval BFS:**
+Uses a depth-specific raw-interval BFS (`depth_transitive_bfs`) that operates on raw alignment extents via `query_raw_overlapping()` at each hop -- an O(n+k) coitrees range query that fetches only intervals overlapping the current region. Query coordinates are computed via linear interpolation (same as the non-transitive path). This avoids CIGAR walk overhead and chunk boundary gaps from CIGAR-precise projection, making it faster and more robust for depth computation where base-level precision is not needed. Starting from the anchor region, follows alignment chains up to `--max-depth` hops (default: 2). Large regions are split into 5MB chunks to prevent BFS from exploring the entire pangenome. Visited ranges are lazily allocated per sequence (not pre-allocated for all sequences), keeping memory footprint minimal.
+
+**Transitive with `--use-BFS` — CIGAR-precise BFS:**
+Uses the same CIGAR-based BFS as the `query` command (`query_transitive_bfs`/`query_transitive_dfs`), providing base-level precision at the cost of CIGAR walk overhead. Use this when exact coordinate projection is needed rather than region-level depth.
 
 ```
 Example with -x and max_depth=2:
@@ -152,26 +167,42 @@ Example with -x and max_depth=2:
   Result: depth=5 (A + B + C + D + E)
 ```
 
-All discovered regions on other sequences are projected back to the anchor's coordinate system via linear interpolation.
+All discovered regions on other sequences are projected back to the anchor's coordinate system via chained linear interpolation.
+
+**Self-alignment filtering**: Alignments where the query sample matches the anchor sample but the query sequence ID differs (intra-genome duplications) are filtered out. Same-sample, same-sequence alignments (the anchor covering itself) are explicitly added as depth=1.
+
+**BFS visited tracking**: A region is considered "visited" if >80% of it is already covered by previously visited ranges on the same sequence. This prevents infinite loops and redundant work.
 
 ### Step 5: Sweep-line depth computation
 
 Once all overlapping alignments are gathered for an anchor region, a sweep-line algorithm computes per-position depth:
 
 1. Create events: (position, START/END, sample_id) for each alignment
-2. Sort events by position
-3. Sweep left-to-right, maintaining a bitmap of active samples
-4. At each position change, emit an interval with the current depth and sample set
+2. Sort events by position, with starts before ends at the same position
+3. Sweep left-to-right, maintaining a `SampleBitmap` of active samples
+4. At each position change, emit a `SparseDepthInterval` with the current depth and sample set
+5. Fill gaps between intervals with depth=1 (anchor sample only)
 
-The `SampleBitmap` structure tracks active samples in O(1) per depth query, handling multiple overlapping alignments from the same sample correctly (counted as depth=1, not double-counted).
+The `SampleBitmap` structure tracks active samples using 1 bit per sample plus a u32 overlap count per sample. Multiple overlapping alignments from the same sample are correctly tracked (counted as depth=1 for that sample, not double-counted). When multiple alignments from the same sample overlap, the one with the largest overlap with the current interval is chosen for coordinate reporting.
 
-### Step 6: Processed region tracking
+**Sparse storage**: `SparseDepthInterval` only stores samples that are present (as `Vec<(sample_id, query_seq_id, query_start, query_end)>`), sorted by sample_id for O(log n) binary search lookup. This is far more memory-efficient than storing all samples per interval.
+
+### Step 6: Output formatting
+
+After sweep-line produces intervals:
+
+1. **Window splitting** (only when `--window-size` is explicitly provided): Intervals crossing window boundaries are cut into pieces, with sample query coordinates proportionally adjusted.
+2. **Merge tolerance** (when `--merge-tolerance > 0`): Adjacent intervals with similar depth are merged. An interval can merge with the current group if `(max_depth - min_depth) / max_depth <= tolerance`. When merged: depth = max of group, samples = union.
+3. **Output**: In normal mode, each interval becomes a TSV row with `#id length depth Sample1 Sample2 ...`. In stats mode, intervals are accumulated into depth distribution histograms and per-depth BED files.
+
+### Step 7: Processed region tracking
 
 A `ConcurrentProcessedTracker` ensures every base in the pangenome is counted exactly once:
 
 - When an anchor discovers alignments on other sequences, those regions are marked as "processed"
 - When a sequence comes up for processing, only its unprocessed regions are computed
-- Per-sequence mutexes provide lock-free parallelism (different sequences never contend)
+- Per-sequence mutexes provide zero-contention parallelism (different sequences never share a lock)
+- After Phase 1, all hub sequences are explicitly marked as fully processed
 
 ## Why hub-first ordering matters
 
@@ -200,8 +231,10 @@ When `--ref` is not specified, the degree pre-scan automatically detects A as th
 | Option | Description |
 |--------|-------------|
 | `-x` | Enable transitive BFS traversal (richer depth for sparse alignments) |
-| `-m, --max-depth N` | Maximum BFS hops (default: 2, 0 = unlimited) |
-| `--min-transitive-len N` | Minimum alignment length for transitive hops |
+| `--transitive-dfs` | Use DFS instead of BFS (conflicts with `-x`; slower, fewer overlapping results) |
+| `-m, --max-depth N` | Maximum BFS/DFS hops (default: 2, 0 = unlimited) |
+| `--min-transitive-len N` | Minimum alignment length for transitive hops (default: 100) |
+| `--min-distance-between-ranges N` | Minimum distance between ranges on same sequence (default: 10) |
 
 Without `-x`, only direct (1-hop) alignments are considered. This is fast but may underestimate depth when the anchor is not the hub. With `-x`, BFS discovers indirect connections at the cost of more computation.
 
@@ -222,32 +255,67 @@ When `--ref` is not specified, hub sequences are auto-detected via the degree pr
 |--------|-------------|
 | `--min-seq-length SIZE` | Exclude sequences shorter than SIZE (accepts k/m/g suffixes) |
 | `--fai-list FILE` | FAI index files; sequences not in alignments get depth=1 |
+
+### Sample filtering (region query mode only)
+
+| Option | Description |
+|--------|-------------|
 | `--samples LIST` | Comma-separated sample names to include |
 | `--samples-file FILE` | File with sample names to include (one per line) |
+
+Note: these options only take effect in region query mode (`-r`/`-b`). In global mode, the filter is loaded but not passed to the depth computation.
 
 ### Output control
 
 | Option | Description |
 |--------|-------------|
 | `-O, --output-prefix PREFIX` | Output file prefix (stdout if omitted) |
-| `--window-size N` | Split output into fixed-size windows (default: 50000 bp) |
-| `--merge-tolerance F` | Merge adjacent intervals with similar depth (default: 0.05 = 5%) |
+| `--window-size N` | Split output into fixed-size windows. Only applied when explicitly set; no windowing by default. |
+| `--merge-tolerance F` | Merge adjacent intervals with similar depth (default: 0.05 = 5%). Formula: `(max - min) / max <= tolerance`. When merged: depth = max, samples = union. |
+| `--merge-adjacent` | Merge adjacent results with identical depth (region query mode) |
 | `--separator CHAR` | PanSN format separator for sample name extraction (default: `#`) |
+
+### Statistics add-on
+
+| Option | Description |
+|--------|-------------|
+| `--stats` | Produce summary statistics and per-depth BED files (conflicts with `-r`/`-b`) |
+| `--combined-output` | Single BED file with depth and sample columns (requires `--stats`) |
 
 ### Performance
 
 | Option | Description |
 |--------|-------------|
 | `-t N` | Number of threads |
-| `--approximate` | Fast approximate mode for .1aln files |
+| `--use-BFS` | Use CIGAR-precise BFS for transitive depth (slower but base-level precision). Default uses raw-interval BFS with linear interpolation, which is faster and sufficient for region-level depth. |
 | `--index-mode per-file` | Per-file indexing for many alignment files |
+
+### Memory management
+
+In transitive mode, interval tree caching is enabled (`set_tree_cache_enabled(true)`) to reuse trees across BFS nodes within the same sequence. The sub-index cache is cleared after each sequence (`clear_sub_index_cache()`) to bound memory usage. With jemalloc, this avoids RSS fragmentation.
+
+## Data structures
+
+Key data structures used for memory-efficient depth computation:
+
+| Structure | Purpose | Memory |
+|-----------|---------|--------|
+| `SampleIndex` | Maps sample names to compact u16 IDs (max 65535 samples) | O(num_samples) |
+| `CompactSequenceLengths` | Sequence lengths, sample-to-seq and seq-to-sample mappings using numeric IDs | O(num_sequences) |
+| `CompactAlignmentInfo` | Alignment record using numeric IDs instead of strings | ~60% less than string-based |
+| `SampleBitmap` | Tracks active samples in sweep-line: 1 bit per sample + u32 overlap count | O(num_samples) per instance |
+| `SparseDepthInterval` | Depth interval storing only present samples | 24 bytes base + 16 bytes per sample |
+| `IntervalSet` | Sorted non-overlapping intervals with binary search operations | O(num_intervals) |
+| `ConcurrentProcessedTracker` | Per-sequence mutexes wrapping IntervalSets | O(num_sequences) |
 
 ## Limitations
 
 - **Non-transitive mode with star topologies**: Without `-x`, leaf nodes only see the hub (depth=2 instead of N). Hub-first ordering mitigates this for the hub itself, but leaf-anchored regions still report incomplete depth. Use `-x` for full coverage.
 - **Transitive depth limit**: With `-x -m 2` (default), chains longer than 2 hops may miss distant samples. Increase `-m` for deeper traversal at the cost of more computation.
-- **Coordinate projection is approximate**: When projecting through transitive alignments, linear interpolation is used (not CIGAR-level mapping). Coordinates in non-anchor sample columns are approximate.
+- **Coordinate projection is approximate by default**: Default raw-interval BFS uses linear interpolation (not CIGAR-level mapping). Coordinates in non-anchor sample columns are approximate. Use `--use-BFS` for CIGAR-precise mapping, though this may produce more discontinuities at chunk boundaries due to revealing actual alignment structure differences.
 - **Parallel non-determinism within Phase 2**: Within Phase 2, rayon's work-stealing means the exact assignment of anchors can vary slightly between runs. Phase 1 (hub) results are deterministic.
+- **Sample filtering scope**: `--samples` and `--samples-file` only work in region query mode. Global mode does not support sample-level filtering.
+- **BFS visited heuristic**: The 80% coverage threshold for "visited" is a heuristic. In rare cases with highly fragmented overlaps, a region may be revisited or skipped prematurely.
 
 ## Examples
 
@@ -271,6 +339,15 @@ impg depth -a all_vs_all.paf --stats --combined-output -O stats
 # Query specific region
 impg depth -a all_vs_all.paf -x -r chr1:10000000-20000000
 
-# Filter to specific samples
-impg depth -a all_vs_all.paf --samples HG002,HG003,CHM13 -O filtered
+# Filter to specific samples (region query mode only)
+impg depth -a all_vs_all.paf --samples HG002,HG003,CHM13 -r chr1:10000000-20000000
+
+# DFS traversal instead of BFS
+impg depth -a all_vs_all.paf --transitive-dfs --ref CHM13 -O pangenome -t 128
+
+# With explicit window splitting
+impg depth -a all_vs_all.paf --ref CHM13 --window-size 100000 -O pangenome -t 64
+
+# CIGAR-precise BFS mode (slower, base-level precision)
+impg depth -a all_vs_all.paf -x --use-BFS --ref CHM13 -O pangenome -t 128
 ```

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -220,6 +220,7 @@ fn query_overlaps_for_ref(
                 None,
                 sequence_index,
                 config.approximate_mode,
+                None, // subset_filter
             )
         } else {
             impg.query_transitive_bfs(
@@ -235,6 +236,7 @@ fn query_overlaps_for_ref(
                 None,
                 sequence_index,
                 config.approximate_mode,
+                None, // subset_filter
             )
         }
     } else {

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -1,9 +1,12 @@
-use crate::impg::{AdjustedInterval, Impg};
+use crate::impg::{AdjustedInterval, CigarOp, Impg};
 use crate::sequence_index::UnifiedSequenceIndex;
+use bitvec::prelude::*;
+use coitrees::IntervalTree;
 use log::{debug, info};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::io::{self, BufWriter, Write};
+use std::io::{self, BufRead, BufWriter, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Configuration for the depth command
 pub struct DepthConfig {
@@ -14,6 +17,1215 @@ pub struct DepthConfig {
     pub min_distance_between_ranges: i32,
     pub merge_adjacent: bool,
     pub approximate_mode: bool,
+}
+
+// ============================================================================
+// Sample filtering for depth computation
+// ============================================================================
+
+/// Filter for samples to include in depth calculation
+#[derive(Debug, Clone)]
+pub struct SampleFilter {
+    /// Set of sample names to include (empty = include all)
+    samples: FxHashSet<String>,
+}
+
+impl SampleFilter {
+    /// Create a new filter with no restrictions (all samples included)
+    pub fn new() -> Self {
+        Self {
+            samples: FxHashSet::default(),
+        }
+    }
+
+    /// Create from a list of sample names
+    pub fn from_samples(samples: Vec<String>) -> Self {
+        Self {
+            samples: samples.into_iter().collect(),
+        }
+    }
+
+    /// Load from a file (one sample name per line)
+    pub fn from_file(path: &str) -> io::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let samples: FxHashSet<String> = content
+            .lines()
+            .map(|line| line.trim())
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(|s| s.to_string())
+            .collect();
+        Ok(Self { samples })
+    }
+
+    /// Check if a sample should be included
+    pub fn includes(&self, sample: &str) -> bool {
+        self.samples.is_empty() || self.samples.contains(sample)
+    }
+
+    /// Check if the filter is active (has restrictions)
+    pub fn is_active(&self) -> bool {
+        !self.samples.is_empty()
+    }
+
+    /// Get the number of samples in the filter
+    pub fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Check if the filter is empty (no restrictions)
+    pub fn is_empty(&self) -> bool {
+        self.samples.is_empty()
+    }
+
+    /// Get the set of sample names
+    pub fn get_samples(&self) -> &FxHashSet<String> {
+        &self.samples
+    }
+}
+
+impl Default for SampleFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Depth statistics for stats mode
+// ============================================================================
+
+/// Statistics for depth distribution across all sequences
+#[derive(Debug, Clone, Default)]
+pub struct DepthStats {
+    /// Total bases analyzed
+    pub total_bases: i64,
+    /// Distribution: depth -> total bases at that depth
+    pub depth_distribution: FxHashMap<usize, i64>,
+    /// Per-depth intervals for output files: depth -> Vec<(seq_name, start, end)>
+    pub depth_intervals: FxHashMap<usize, Vec<(String, i64, i64)>>,
+}
+
+impl DepthStats {
+    /// Create a new empty stats container
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an interval with a specific depth
+    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize) {
+        let length = end - start;
+        if length <= 0 {
+            return;
+        }
+        self.total_bases += length;
+        *self.depth_distribution.entry(depth).or_insert(0) += length;
+        self.depth_intervals
+            .entry(depth)
+            .or_default()
+            .push((seq_name.to_string(), start, end));
+    }
+
+    /// Merge another DepthStats into this one
+    pub fn merge(&mut self, other: &DepthStats) {
+        self.total_bases += other.total_bases;
+        for (&depth, &bases) in &other.depth_distribution {
+            *self.depth_distribution.entry(depth).or_insert(0) += bases;
+        }
+        for (depth, intervals) in &other.depth_intervals {
+            self.depth_intervals
+                .entry(*depth)
+                .or_default()
+                .extend(intervals.iter().cloned());
+        }
+    }
+
+    /// Get sorted list of depths with their base counts
+    pub fn get_sorted_distribution(&self) -> Vec<(usize, i64)> {
+        let mut dist: Vec<_> = self
+            .depth_distribution
+            .iter()
+            .map(|(&d, &c)| (d, c))
+            .collect();
+        dist.sort_by_key(|&(d, _)| d);
+        dist
+    }
+
+    /// Get maximum depth
+    pub fn max_depth(&self) -> usize {
+        self.depth_distribution.keys().copied().max().unwrap_or(0)
+    }
+
+    /// Write summary to a writer
+    pub fn write_summary<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writeln!(writer, "Total bases: {}", self.total_bases)?;
+        writeln!(writer, "Depth distribution:")?;
+        for (depth, bases) in self.get_sorted_distribution() {
+            let pct = if self.total_bases > 0 {
+                100.0 * bases as f64 / self.total_bases as f64
+            } else {
+                0.0
+            };
+            writeln!(writer, "  depth={}: {} bp ({:.2}%)", depth, bases, pct)?;
+        }
+        Ok(())
+    }
+
+    /// Write per-depth BED files
+    pub fn write_depth_bed_files(&self, prefix: &str) -> io::Result<()> {
+        for (&depth, intervals) in &self.depth_intervals {
+            let path = format!("{}.depth{}.bed", prefix, depth);
+            let file = std::fs::File::create(&path)?;
+            let mut writer = BufWriter::new(file);
+            for (seq_name, start, end) in intervals {
+                writeln!(writer, "{}\t{}\t{}", seq_name, start, end)?;
+            }
+            writer.flush()?;
+            info!("Wrote {} intervals to {}", intervals.len(), path);
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Combined depth output with sample lists
+// ============================================================================
+
+/// Interval with depth and list of covering samples
+#[derive(Debug, Clone)]
+pub struct DepthIntervalWithSamples {
+    /// Sequence name
+    pub seq_name: String,
+    /// Start position (0-based)
+    pub start: i64,
+    /// End position (exclusive)
+    pub end: i64,
+    /// Depth (number of unique samples)
+    pub depth: usize,
+    /// Sorted list of sample names covering this interval
+    pub samples: Vec<String>,
+}
+
+impl DepthIntervalWithSamples {
+    pub fn new(seq_name: String, start: i64, end: i64, depth: usize, samples: Vec<String>) -> Self {
+        Self {
+            seq_name,
+            start,
+            end,
+            depth,
+            samples,
+        }
+    }
+}
+
+/// Statistics with sample tracking for combined output
+#[derive(Debug, Clone, Default)]
+pub struct DepthStatsWithSamples {
+    /// Total bases analyzed
+    pub total_bases: i64,
+    /// Distribution: depth -> total bases at that depth
+    pub depth_distribution: FxHashMap<usize, i64>,
+    /// All intervals with samples (unsorted, to be sorted at output time)
+    pub intervals: Vec<DepthIntervalWithSamples>,
+}
+
+impl DepthStatsWithSamples {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an interval with depth and sample list
+    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize, samples: Vec<String>) {
+        let length = end - start;
+        if length <= 0 {
+            return;
+        }
+        self.total_bases += length;
+        *self.depth_distribution.entry(depth).or_insert(0) += length;
+        self.intervals.push(DepthIntervalWithSamples::new(
+            seq_name.to_string(),
+            start,
+            end,
+            depth,
+            samples,
+        ));
+    }
+
+    /// Merge another DepthStatsWithSamples into this one
+    pub fn merge(&mut self, other: DepthStatsWithSamples) {
+        self.total_bases += other.total_bases;
+        for (&depth, &bases) in &other.depth_distribution {
+            *self.depth_distribution.entry(depth).or_insert(0) += bases;
+        }
+        self.intervals.extend(other.intervals);
+    }
+
+    /// Get sorted list of depths with their base counts
+    pub fn get_sorted_distribution(&self) -> Vec<(usize, i64)> {
+        let mut dist: Vec<_> = self
+            .depth_distribution
+            .iter()
+            .map(|(&d, &c)| (d, c))
+            .collect();
+        dist.sort_by_key(|&(d, _)| d);
+        dist
+    }
+
+    /// Get maximum depth
+    pub fn max_depth(&self) -> usize {
+        self.depth_distribution.keys().copied().max().unwrap_or(0)
+    }
+
+    /// Write summary to a writer
+    pub fn write_summary<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writeln!(writer, "Total bases: {}", self.total_bases)?;
+        writeln!(writer, "Depth distribution:")?;
+        for (depth, bases) in self.get_sorted_distribution() {
+            let pct = if self.total_bases > 0 {
+                100.0 * bases as f64 / self.total_bases as f64
+            } else {
+                0.0
+            };
+            writeln!(writer, "  depth={}: {} bp ({:.2}%)", depth, bases, pct)?;
+        }
+        Ok(())
+    }
+
+    /// Write combined output file sorted by chromosome and position
+    /// If merge_tolerance > 0, adjacent intervals with depth difference within tolerance are merged
+    /// tolerance is a fraction (e.g., 0.05 = 5%)
+    pub fn write_combined_output(&mut self, prefix: &str, merge_tolerance: f64) -> io::Result<()> {
+        let path = format!("{}.combined.bed", prefix);
+        let file = std::fs::File::create(&path)?;
+        let mut writer = BufWriter::new(file);
+
+        // Sort intervals by sequence name, then by start position
+        self.intervals.sort_by(|a, b| {
+            a.seq_name.cmp(&b.seq_name)
+                .then_with(|| a.start.cmp(&b.start))
+                .then_with(|| a.end.cmp(&b.end))
+        });
+
+        // Write header
+        writeln!(writer, "#seq_name\tstart\tend\tdepth\tsamples")?;
+
+        if merge_tolerance > 0.0 && !self.intervals.is_empty() {
+            // Merge adjacent intervals within tolerance
+            let merged = self.merge_intervals_with_tolerance(merge_tolerance);
+            info!(
+                "Merged {} intervals into {} intervals (tolerance: {:.1}%)",
+                self.intervals.len(),
+                merged.len(),
+                merge_tolerance * 100.0
+            );
+
+            for interval in &merged {
+                let samples_str = interval.samples.join(",");
+                writeln!(
+                    writer,
+                    "{}\t{}\t{}\t{}\t{}",
+                    interval.seq_name, interval.start, interval.end, interval.depth, samples_str
+                )?;
+            }
+
+            writer.flush()?;
+            info!(
+                "Wrote {} intervals to {} (combined output with samples)",
+                merged.len(),
+                path
+            );
+        } else {
+            // No merging, write as-is
+            for interval in &self.intervals {
+                let samples_str = interval.samples.join(",");
+                writeln!(
+                    writer,
+                    "{}\t{}\t{}\t{}\t{}",
+                    interval.seq_name, interval.start, interval.end, interval.depth, samples_str
+                )?;
+            }
+
+            writer.flush()?;
+            info!(
+                "Wrote {} intervals to {} (combined output with samples)",
+                self.intervals.len(),
+                path
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Merge adjacent intervals where depth difference is within tolerance
+    /// tolerance: fraction (e.g., 0.05 means 5%)
+    /// When merging: depth = max, samples = union
+    /// Tracks full min-max range of merged group: (max - min) / max <= tolerance
+    fn merge_intervals_with_tolerance(&self, tolerance: f64) -> Vec<DepthIntervalWithSamples> {
+        if self.intervals.is_empty() {
+            return Vec::new();
+        }
+
+        let mut merged: Vec<DepthIntervalWithSamples> = Vec::new();
+
+        // Track current merge group with min and max depth
+        let mut current_seq = self.intervals[0].seq_name.clone();
+        let mut current_start = self.intervals[0].start;
+        let mut current_end = self.intervals[0].end;
+        let mut current_min_depth = self.intervals[0].depth;
+        let mut current_max_depth = self.intervals[0].depth;
+        let mut current_samples: FxHashSet<String> = self.intervals[0].samples.iter().cloned().collect();
+
+        for interval in self.intervals.iter().skip(1) {
+            // Check if this interval can be merged with current group
+            // The new range after merging would be [min(current_min, new), max(current_max, new)]
+            // Check if this range is within tolerance
+            let can_merge = interval.seq_name == current_seq
+                && interval.start == current_end  // Adjacent
+                && Self::within_tolerance_range(current_min_depth, current_max_depth, interval.depth, tolerance);
+
+            if can_merge {
+                // Extend current group
+                current_end = interval.end;
+                current_min_depth = current_min_depth.min(interval.depth);
+                current_max_depth = current_max_depth.max(interval.depth);
+                current_samples.extend(interval.samples.iter().cloned());
+            } else {
+                // Emit current group and start new one
+                let mut samples_vec: Vec<String> = current_samples.into_iter().collect();
+                samples_vec.sort();
+                merged.push(DepthIntervalWithSamples::new(
+                    current_seq,
+                    current_start,
+                    current_end,
+                    current_max_depth,  // Use max depth for output
+                    samples_vec,
+                ));
+
+                // Start new group
+                current_seq = interval.seq_name.clone();
+                current_start = interval.start;
+                current_end = interval.end;
+                current_min_depth = interval.depth;
+                current_max_depth = interval.depth;
+                current_samples = interval.samples.iter().cloned().collect();
+            }
+        }
+
+        // Emit final group
+        let mut samples_vec: Vec<String> = current_samples.into_iter().collect();
+        samples_vec.sort();
+        merged.push(DepthIntervalWithSamples::new(
+            current_seq,
+            current_start,
+            current_end,
+            current_max_depth,
+            samples_vec,
+        ));
+
+        merged
+    }
+
+    /// Check if adding a new depth to an existing range would keep it within tolerance
+    /// Returns true if (new_max - new_min) / new_max <= tolerance
+    /// where new_min = min(current_min, new_depth) and new_max = max(current_max, new_depth)
+    fn within_tolerance_range(current_min: usize, current_max: usize, new_depth: usize, tolerance: f64) -> bool {
+        let new_min = current_min.min(new_depth);
+        let new_max = current_max.max(new_depth);
+
+        if new_max == 0 {
+            return true;  // All zeros, can merge
+        }
+
+        let diff = (new_max - new_min) as f64 / new_max as f64;
+        diff <= tolerance
+    }
+}
+
+/// Compute depth using sweep-line algorithm, tracking which samples cover each window
+fn compute_sweep_line_depth_with_samples(
+    _anchor_seq: &str,
+    seq_len: i64,
+    sample_intervals: &[(i64, i64, String)],
+) -> Vec<(i64, i64, usize, Vec<String>)> {
+    if sample_intervals.is_empty() {
+        return vec![(0, seq_len, 0, Vec::new())];
+    }
+
+    // Create events: (position, is_start, sample_name)
+    let mut events: Vec<(i64, bool, &str)> = Vec::with_capacity(sample_intervals.len() * 2);
+    for (start, end, sample) in sample_intervals {
+        events.push((*start, true, sample.as_str()));
+        events.push((*end, false, sample.as_str()));
+    }
+
+    // Sort by position, with end events before start events at same position
+    events.sort_by(|a, b| {
+        a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1))
+    });
+
+    let mut results: Vec<(i64, i64, usize, Vec<String>)> = Vec::new();
+    let mut active_samples: FxHashMap<&str, usize> = FxHashMap::default();
+    let mut prev_pos: Option<i64> = None;
+    let mut prev_sample_set: Vec<String> = Vec::new();
+
+    for (pos, is_start, sample) in events {
+        if let Some(prev) = prev_pos {
+            if pos > prev {
+                // Emit window from prev to pos with current depth and samples
+                let depth = active_samples.len();
+                if depth > 0 {
+                    results.push((prev, pos, depth, prev_sample_set.clone()));
+                }
+            }
+        }
+
+        // Update active samples
+        if is_start {
+            *active_samples.entry(sample).or_insert(0) += 1;
+        } else if let Some(count) = active_samples.get_mut(sample) {
+            *count -= 1;
+            if *count == 0 {
+                active_samples.remove(sample);
+            }
+        }
+
+        // Update sample set for next window
+        prev_sample_set = active_samples.keys().map(|s| s.to_string()).collect();
+        prev_sample_set.sort();  // Keep sorted for consistent output
+        prev_pos = Some(pos);
+    }
+
+    // Merge adjacent windows with same depth AND same sample set
+    if results.len() <= 1 {
+        return results;
+    }
+
+    let mut merged: Vec<(i64, i64, usize, Vec<String>)> = Vec::with_capacity(results.len());
+    let mut current = results[0].clone();
+
+    for (start, end, depth, samples) in results.into_iter().skip(1) {
+        if current.1 == start && current.2 == depth && current.3 == samples {
+            // Extend current window
+            current.1 = end;
+        } else {
+            merged.push(current);
+            current = (start, end, depth, samples);
+        }
+    }
+    merged.push(current);
+
+    merged
+}
+
+// ============================================================================
+// Region query result for region query mode
+// ============================================================================
+
+/// Result of a region query with per-sample position tracking
+#[derive(Debug, Clone)]
+pub struct RegionDepthResult {
+    /// Reference sequence name
+    pub ref_seq: String,
+    /// Reference start position
+    pub ref_start: i64,
+    /// Reference end position
+    pub ref_end: i64,
+    /// Depth (number of samples covering this region)
+    pub depth: usize,
+    /// Per-sample positions: sample -> Vec<(seq_name, start, end)>
+    /// Multiple alignments per sample are possible
+    pub sample_positions: FxHashMap<String, Vec<(String, i64, i64)>>,
+}
+
+impl RegionDepthResult {
+    /// Create a new result
+    pub fn new(ref_seq: String, ref_start: i64, ref_end: i64) -> Self {
+        Self {
+            ref_seq,
+            ref_start,
+            ref_end,
+            depth: 0,
+            sample_positions: FxHashMap::default(),
+        }
+    }
+
+    /// Add a sample position
+    pub fn add_sample_position(&mut self, sample: &str, seq_name: &str, start: i64, end: i64) {
+        self.sample_positions
+            .entry(sample.to_string())
+            .or_default()
+            .push((seq_name.to_string(), start, end));
+    }
+
+    /// Update depth based on sample_positions
+    pub fn update_depth(&mut self) {
+        self.depth = self.sample_positions.len();
+    }
+
+    /// Format sample positions as semicolon-separated strings
+    pub fn format_sample_positions(&self, sample: &str) -> String {
+        match self.sample_positions.get(sample) {
+            Some(positions) if !positions.is_empty() => positions
+                .iter()
+                .map(|(seq, start, end)| format!("{}:{}-{}", seq, start, end))
+                .collect::<Vec<_>>()
+                .join(";"),
+            _ => "NA".to_string(),
+        }
+    }
+}
+
+/// Write region depth results in tabular format
+pub fn write_region_depth_output<W: Write>(
+    writer: &mut W,
+    results: &[RegionDepthResult],
+    sample_order: &[String],
+) -> io::Result<()> {
+    // Write header
+    write!(writer, "#ref_seq\tref_start\tref_end\tdepth")?;
+    for sample in sample_order {
+        write!(writer, "\t{}", sample)?;
+    }
+    writeln!(writer)?;
+
+    // Write data rows
+    for result in results {
+        write!(
+            writer,
+            "{}\t{}\t{}\t{}",
+            result.ref_seq, result.ref_start, result.ref_end, result.depth
+        )?;
+        for sample in sample_order {
+            write!(writer, "\t{}", result.format_sample_positions(sample))?;
+        }
+        writeln!(writer)?;
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// New data structures for sample-based depth computation
+// ============================================================================
+
+/// Stores sequence lengths and sample-to-sequence mappings
+#[derive(Debug, Clone)]
+pub struct SequenceLengths {
+    /// seq_name -> length
+    pub lengths: FxHashMap<String, i64>,
+    /// sample_name -> list of seq_names belonging to this sample
+    pub sample_to_seqs: FxHashMap<String, Vec<String>>,
+    /// seq_name -> sample_name (reverse lookup)
+    pub seq_to_sample: FxHashMap<String, String>,
+}
+
+impl SequenceLengths {
+    /// Build from impg sequence index
+    pub fn from_impg(impg: &Impg, separator: &str) -> Self {
+        let mut lengths = FxHashMap::default();
+        let mut sample_to_seqs: FxHashMap<String, Vec<String>> = FxHashMap::default();
+        let mut seq_to_sample = FxHashMap::default();
+
+        for id in 0..impg.seq_index.len() as u32 {
+            if let (Some(name), Some(len)) = (
+                impg.seq_index.get_name(id),
+                impg.seq_index.get_len_from_id(id),
+            ) {
+                let sample = extract_sample(name, separator);
+                lengths.insert(name.to_string(), len as i64);
+                sample_to_seqs
+                    .entry(sample.clone())
+                    .or_default()
+                    .push(name.to_string());
+                seq_to_sample.insert(name.to_string(), sample);
+            }
+        }
+
+        // Sort sequences within each sample for deterministic ordering
+        for seqs in sample_to_seqs.values_mut() {
+            seqs.sort();
+        }
+
+        SequenceLengths {
+            lengths,
+            sample_to_seqs,
+            seq_to_sample,
+        }
+    }
+
+    /// Build from FAI file list
+    pub fn from_fai_list(fai_list_path: &str, separator: &str) -> io::Result<Self> {
+        let mut lengths = FxHashMap::default();
+        let mut sample_to_seqs: FxHashMap<String, Vec<String>> = FxHashMap::default();
+        let mut seq_to_sample = FxHashMap::default();
+
+        let content = std::fs::read_to_string(fai_list_path).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Failed to read FAI list file '{}': {}", fai_list_path, e),
+            )
+        })?;
+
+        for line in content.lines() {
+            let fai_path = line.trim();
+            if fai_path.is_empty() || fai_path.starts_with('#') {
+                continue;
+            }
+
+            let fai_content = std::fs::read_to_string(fai_path).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Failed to read FAI file '{}': {}", fai_path, e),
+                )
+            })?;
+
+            for fai_line in fai_content.lines() {
+                let parts: Vec<&str> = fai_line.split('\t').collect();
+                if parts.len() >= 2 {
+                    let seq_name = parts[0].to_string();
+                    let seq_len: i64 = parts[1].parse().unwrap_or(0);
+
+                    let sample = extract_sample(&seq_name, separator);
+                    lengths.insert(seq_name.clone(), seq_len);
+                    sample_to_seqs
+                        .entry(sample.clone())
+                        .or_default()
+                        .push(seq_name.clone());
+                    seq_to_sample.insert(seq_name, sample);
+                }
+            }
+        }
+
+        // Sort sequences within each sample for deterministic ordering
+        for seqs in sample_to_seqs.values_mut() {
+            seqs.sort();
+        }
+
+        Ok(SequenceLengths {
+            lengths,
+            sample_to_seqs,
+            seq_to_sample,
+        })
+    }
+
+    /// Get all samples
+    pub fn get_samples(&self) -> Vec<String> {
+        let mut samples: Vec<_> = self.sample_to_seqs.keys().cloned().collect();
+        samples.sort();
+        samples
+    }
+
+    /// Get sequences for a sample
+    pub fn get_seqs_of_sample(&self, sample: &str) -> &[String] {
+        self.sample_to_seqs
+            .get(sample)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Get length of a sequence
+    pub fn get_length(&self, seq_name: &str) -> Option<i64> {
+        self.lengths.get(seq_name).copied()
+    }
+}
+
+/// High-performance interval set with efficient intersection and subtraction
+#[derive(Debug, Clone, Default)]
+pub struct IntervalSet {
+    /// Sorted, non-overlapping intervals [(start, end), ...]
+    intervals: Vec<(i64, i64)>,
+    /// Total covered length (for quick empty check)
+    total_length: i64,
+}
+
+impl IntervalSet {
+    /// Create a new empty interval set
+    pub fn new() -> Self {
+        Self {
+            intervals: Vec::new(),
+            total_length: 0,
+        }
+    }
+
+    /// Create interval set with a single interval
+    pub fn new_single(start: i64, end: i64) -> Self {
+        if start >= end {
+            return Self::new();
+        }
+        Self {
+            intervals: vec![(start, end)],
+            total_length: end - start,
+        }
+    }
+
+    /// Add an interval to this set (merging with existing if overlapping)
+    pub fn add(&mut self, start: i64, end: i64) {
+        if start >= end {
+            return;
+        }
+
+        if self.intervals.is_empty() {
+            self.intervals.push((start, end));
+            self.total_length = end - start;
+            return;
+        }
+
+        // Find insertion point and merge overlapping intervals
+        let mut new_start = start;
+        let mut new_end = end;
+        let mut to_remove = Vec::new();
+
+        for (i, &(iv_start, iv_end)) in self.intervals.iter().enumerate() {
+            // Check if intervals overlap or are adjacent
+            if iv_end >= new_start && iv_start <= new_end {
+                // Merge
+                new_start = new_start.min(iv_start);
+                new_end = new_end.max(iv_end);
+                to_remove.push(i);
+            }
+        }
+
+        // Calculate new total length
+        let added_length = new_end - new_start;
+        let removed_length: i64 = to_remove
+            .iter()
+            .map(|&i| self.intervals[i].1 - self.intervals[i].0)
+            .sum();
+
+        // Remove merged intervals (in reverse order to preserve indices)
+        for &i in to_remove.iter().rev() {
+            self.intervals.remove(i);
+        }
+
+        // Insert new merged interval
+        let insert_pos = self
+            .intervals
+            .iter()
+            .position(|&(s, _)| s > new_start)
+            .unwrap_or(self.intervals.len());
+        self.intervals.insert(insert_pos, (new_start, new_end));
+
+        self.total_length = self.total_length - removed_length + added_length;
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.total_length == 0
+    }
+
+    /// Get total covered length
+    pub fn total_length(&self) -> i64 {
+        self.total_length
+    }
+
+    /// Get number of intervals
+    pub fn interval_count(&self) -> usize {
+        self.intervals.len()
+    }
+
+    /// Get all intervals
+    pub fn intervals(&self) -> &[(i64, i64)] {
+        &self.intervals
+    }
+
+    /// Intersect with a query interval, return intersecting portions
+    pub fn intersect(&self, query_start: i64, query_end: i64) -> Vec<(i64, i64)> {
+        if query_start >= query_end || self.intervals.is_empty() {
+            return Vec::new();
+        }
+
+        let mut result = Vec::new();
+
+        // Binary search for the first interval that might overlap
+        let start_idx = self
+            .intervals
+            .partition_point(|&(_, end)| end <= query_start);
+
+        for &(iv_start, iv_end) in &self.intervals[start_idx..] {
+            if iv_start >= query_end {
+                break;
+            }
+
+            let intersect_start = iv_start.max(query_start);
+            let intersect_end = iv_end.min(query_end);
+
+            if intersect_start < intersect_end {
+                result.push((intersect_start, intersect_end));
+            }
+        }
+
+        result
+    }
+
+    /// Subtract a single interval from this set
+    pub fn subtract(&mut self, sub_start: i64, sub_end: i64) {
+        if sub_start >= sub_end || self.intervals.is_empty() {
+            return;
+        }
+
+        let mut new_intervals = Vec::new();
+        let mut removed_length: i64 = 0;
+
+        for &(iv_start, iv_end) in &self.intervals {
+            if iv_end <= sub_start || iv_start >= sub_end {
+                // No overlap, keep as is
+                new_intervals.push((iv_start, iv_end));
+            } else {
+                // There's overlap
+                if iv_start < sub_start {
+                    // Keep left portion
+                    new_intervals.push((iv_start, sub_start));
+                }
+                if iv_end > sub_end {
+                    // Keep right portion
+                    new_intervals.push((sub_end, iv_end));
+                }
+                // Calculate removed length
+                let overlap_start = iv_start.max(sub_start);
+                let overlap_end = iv_end.min(sub_end);
+                removed_length += overlap_end - overlap_start;
+            }
+        }
+
+        self.intervals = new_intervals;
+        self.total_length -= removed_length;
+    }
+
+    /// Batch subtract multiple intervals (more efficient than individual subtracts)
+    pub fn subtract_batch(&mut self, to_remove: &[(i64, i64)]) {
+        if to_remove.is_empty() || self.intervals.is_empty() {
+            return;
+        }
+
+        // Merge overlapping intervals to remove
+        let merged_remove = merge_intervals(to_remove);
+
+        let mut new_intervals = Vec::new();
+        let mut remove_idx = 0;
+        let mut removed_length: i64 = 0;
+
+        for &(iv_start, iv_end) in &self.intervals {
+            let mut current_start = iv_start;
+
+            while remove_idx < merged_remove.len() && current_start < iv_end {
+                let (rm_start, rm_end) = merged_remove[remove_idx];
+
+                if rm_end <= current_start {
+                    // Remove interval is before current position
+                    remove_idx += 1;
+                    continue;
+                }
+
+                if rm_start >= iv_end {
+                    // Remove interval is after current interval
+                    break;
+                }
+
+                // There's overlap
+                if rm_start > current_start {
+                    // Keep [current_start, rm_start)
+                    new_intervals.push((current_start, rm_start));
+                }
+
+                // Calculate removed portion
+                let overlap_start = current_start.max(rm_start);
+                let overlap_end = iv_end.min(rm_end);
+                if overlap_end > overlap_start {
+                    removed_length += overlap_end - overlap_start;
+                }
+
+                current_start = rm_end;
+
+                if rm_end <= iv_end {
+                    remove_idx += 1;
+                }
+            }
+
+            if current_start < iv_end {
+                new_intervals.push((current_start, iv_end));
+            }
+        }
+
+        self.intervals = new_intervals;
+        self.total_length -= removed_length;
+    }
+}
+
+/// Merge overlapping/adjacent intervals
+fn merge_intervals(intervals: &[(i64, i64)]) -> Vec<(i64, i64)> {
+    if intervals.is_empty() {
+        return Vec::new();
+    }
+
+    let mut sorted: Vec<_> = intervals.to_vec();
+    sorted.sort_by_key(|&(s, _)| s);
+
+    let mut merged = Vec::new();
+    let mut current = sorted[0];
+
+    for &(start, end) in &sorted[1..] {
+        if start <= current.1 {
+            // Overlapping or adjacent
+            current.1 = current.1.max(end);
+        } else {
+            merged.push(current);
+            current = (start, end);
+        }
+    }
+    merged.push(current);
+
+    merged
+}
+
+/// Pool: tracks unprocessed regions for all samples
+#[derive(Debug)]
+pub struct Pool {
+    /// sample_name -> seq_name -> interval set of unprocessed regions
+    regions: FxHashMap<String, FxHashMap<String, IntervalSet>>,
+}
+
+impl Pool {
+    /// Initialize pool with full-length intervals for all sequences
+    pub fn new(seq_lengths: &SequenceLengths) -> Self {
+        let mut regions = FxHashMap::default();
+
+        for (sample, seqs) in &seq_lengths.sample_to_seqs {
+            let mut sample_regions = FxHashMap::default();
+            for seq in seqs {
+                if let Some(&len) = seq_lengths.lengths.get(seq) {
+                    sample_regions.insert(seq.clone(), IntervalSet::new_single(0, len));
+                }
+            }
+            regions.insert(sample.clone(), sample_regions);
+        }
+
+        Pool { regions }
+    }
+
+    /// Get remaining intervals for a specific sequence
+    pub fn get_intervals(&self, sample: &str, seq: &str) -> Vec<(i64, i64)> {
+        self.regions
+            .get(sample)
+            .and_then(|s| s.get(seq))
+            .map(|is| is.intervals().to_vec())
+            .unwrap_or_default()
+    }
+
+    /// Get all remaining intervals for a sample: Vec<(seq_name, start, end)>
+    pub fn get_sample_intervals(&self, sample: &str) -> Vec<(String, i64, i64)> {
+        let mut result = Vec::new();
+        if let Some(seqs) = self.regions.get(sample) {
+            for (seq, interval_set) in seqs {
+                for &(start, end) in interval_set.intervals() {
+                    result.push((seq.clone(), start, end));
+                }
+            }
+        }
+        result
+    }
+
+    /// Count total intervals for a sample
+    pub fn count_intervals(&self, sample: &str) -> usize {
+        self.regions
+            .get(sample)
+            .map(|seqs| seqs.values().map(|is| is.interval_count()).sum())
+            .unwrap_or(0)
+    }
+
+    /// Check if a sample has no remaining intervals
+    pub fn is_sample_empty(&self, sample: &str) -> bool {
+        self.regions
+            .get(sample)
+            .map(|seqs| seqs.values().all(|is| is.is_empty()))
+            .unwrap_or(true)
+    }
+
+    /// Check if entire pool is empty
+    pub fn is_empty(&self) -> bool {
+        self.regions
+            .values()
+            .all(|seqs| seqs.values().all(|is| is.is_empty()))
+    }
+
+    /// Subtract a single region
+    pub fn subtract(&mut self, sample: &str, seq: &str, start: i64, end: i64) {
+        if let Some(seqs) = self.regions.get_mut(sample) {
+            if let Some(interval_set) = seqs.get_mut(seq) {
+                interval_set.subtract(start, end);
+            }
+        }
+    }
+
+    /// Check if a region has any overlap with the pool for a sample/seq
+    /// Returns the intersection intervals if any
+    pub fn get_overlap(&self, sample: &str, seq: &str, start: i64, end: i64) -> Vec<(i64, i64)> {
+        if let Some(seqs) = self.regions.get(sample) {
+            if let Some(interval_set) = seqs.get(seq) {
+                return interval_set.intersect(start, end);
+            }
+        }
+        Vec::new()
+    }
+
+    /// Check if a region has any overlap with the pool
+    pub fn has_overlap(&self, sample: &str, seq: &str, start: i64, end: i64) -> bool {
+        !self.get_overlap(sample, seq, start, end).is_empty()
+    }
+
+    /// Batch subtract multiple regions: Vec<(sample, seq, start, end)>
+    pub fn subtract_batch(&mut self, regions_to_remove: &[(String, String, i64, i64)]) {
+        // Group by (sample, seq) for efficiency
+        let mut grouped: FxHashMap<(&str, &str), Vec<(i64, i64)>> = FxHashMap::default();
+
+        for (sample, seq, start, end) in regions_to_remove {
+            grouped
+                .entry((sample.as_str(), seq.as_str()))
+                .or_default()
+                .push((*start, *end));
+        }
+
+        // Batch update each (sample, seq)
+        for ((sample, seq), intervals) in grouped {
+            if let Some(seqs) = self.regions.get_mut(sample) {
+                if let Some(interval_set) = seqs.get_mut(seq) {
+                    interval_set.subtract_batch(&intervals);
+                }
+            }
+        }
+    }
+
+    /// Get total remaining length across all samples
+    pub fn total_remaining_length(&self) -> i64 {
+        self.regions
+            .values()
+            .flat_map(|seqs| seqs.values())
+            .map(|is| is.total_length())
+            .sum()
+    }
+}
+
+/// Reverse index: maps query sequences to their alignments
+/// This enables efficient lookup of alignments where a sequence is the query
+#[derive(Debug, Default)]
+pub struct ReverseAlignmentIndex {
+    /// seq_name -> Vec<(target_seq_name, target_start, target_end, query_start, query_end, is_reverse)>
+    by_query_seq: FxHashMap<String, Vec<ReverseAlignmentEntry>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReverseAlignmentEntry {
+    pub target_seq: String,
+    pub target_start: i64,
+    pub target_end: i64,
+    pub query_start: i64,
+    pub query_end: i64,
+    pub is_reverse: bool,
+}
+
+impl ReverseAlignmentIndex {
+    /// Build reverse index from impg
+    pub fn build(impg: &Impg) -> Self {
+        let mut by_query_seq: FxHashMap<String, Vec<ReverseAlignmentEntry>> = FxHashMap::default();
+
+        // Iterate through all target sequences' interval trees
+        let target_ids: Vec<u32> = impg.forest_map.entries.keys().copied().collect();
+
+        for target_id in target_ids {
+            let target_name = match impg.seq_index.get_name(target_id) {
+                Some(name) => name.to_string(),
+                None => continue,
+            };
+
+            // Get the actual tree
+            let tree = match impg.get_or_load_tree(target_id) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            // Query all intervals in this tree
+            let target_len = impg.seq_index.get_len_from_id(target_id).unwrap_or(0);
+            tree.query(0, target_len as i32, |interval| {
+                let query_id = interval.metadata.query_id();
+                if let Some(query_name) = impg.seq_index.get_name(query_id) {
+                    let q_start = interval.metadata.query_start();
+                    let q_end = interval.metadata.query_end();
+                    let is_reverse = q_start > q_end;
+                    let query_start = q_start.min(q_end) as i64;
+                    let query_end = q_start.max(q_end) as i64;
+
+                    by_query_seq
+                        .entry(query_name.to_string())
+                        .or_default()
+                        .push(ReverseAlignmentEntry {
+                            target_seq: target_name.clone(),
+                            target_start: interval.first as i64,
+                            target_end: interval.last as i64,
+                            query_start,
+                            query_end,
+                            is_reverse,
+                        });
+                }
+            });
+        }
+
+        ReverseAlignmentIndex { by_query_seq }
+    }
+
+    /// Query alignments where the given sequence is a query, filtering by range
+    pub fn query_range(
+        &self,
+        query_seq: &str,
+        range_start: i64,
+        range_end: i64,
+    ) -> Vec<&ReverseAlignmentEntry> {
+        self.by_query_seq
+            .get(query_seq)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|e| {
+                        // Check if alignment overlaps with query range
+                        e.query_start < range_end && e.query_end > range_start
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get all alignments where the given sequence is a query
+    pub fn get_all(&self, query_seq: &str) -> Option<&Vec<ReverseAlignmentEntry>> {
+        self.by_query_seq.get(query_seq)
+    }
+
+    /// Count total alignments indexed
+    pub fn total_alignments(&self) -> usize {
+        self.by_query_seq.values().map(|v| v.len()).sum()
+    }
+}
+
+/// Strategy for querying alignments
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryStrategy {
+    /// First round: collect all alignments for the sample from index
+    FromIndex,
+    /// Subsequent rounds: query from remaining pool intervals
+    FromPool,
+}
+
+/// Result from processing a single sequence's alignments
+#[derive(Debug)]
+pub struct SeqProcessResult {
+    /// Generated depth windows
+    pub windows: Vec<DepthWindow>,
+    /// Regions to remove from pool: (sample, seq, start, end)
+    pub regions_to_remove: Vec<(String, String, i64, i64)>,
+}
+
+/// Result from processing a sample
+#[derive(Debug)]
+pub struct SampleProcessResult {
+    /// All windows from this sample
+    pub windows: Vec<DepthWindow>,
+    /// All regions to remove from pool
+    pub regions_to_remove: Vec<(String, String, i64, i64)>,
 }
 
 /// Tracks processed regions for each haplotype to avoid duplicate output
@@ -108,6 +1320,96 @@ impl ProcessedRegions {
     }
 }
 
+/// Tracks processed regions in query space for each (sample, query_seq) pair
+#[derive(Default)]
+pub struct QueryProcessedRegions {
+    /// (sample, query_seq_name) -> sorted list of (start, end) intervals
+    regions: FxHashMap<(String, String), Vec<(i64, i64)>>,
+}
+
+impl QueryProcessedRegions {
+    pub fn new() -> Self {
+        Self {
+            regions: FxHashMap::default(),
+        }
+    }
+
+    /// Get ALL unprocessed portions of a query region
+    /// Returns a vector of (start, end) intervals that haven't been processed yet
+    pub fn get_all_unprocessed(
+        &self,
+        sample: &str,
+        query_seq: &str,
+        start: i64,
+        end: i64,
+    ) -> Vec<(i64, i64)> {
+        let key = (sample.to_string(), query_seq.to_string());
+        if let Some(intervals) = self.regions.get(&key) {
+            let mut result = Vec::new();
+            let mut current_start = start;
+
+            for &(proc_start, proc_end) in intervals {
+                if proc_end <= current_start {
+                    continue;
+                }
+                if proc_start >= end {
+                    break;
+                }
+
+                if proc_start > current_start {
+                    // There's an unprocessed gap before this processed region
+                    result.push((current_start, proc_start.min(end)));
+                }
+                // Move past this processed region
+                current_start = proc_end;
+                if current_start >= end {
+                    return result;
+                }
+            }
+
+            // Don't forget the tail portion after all processed regions
+            if current_start < end {
+                result.push((current_start, end));
+            }
+            result
+        } else {
+            vec![(start, end)]
+        }
+    }
+
+    /// Mark a query region as processed
+    pub fn mark_processed(&mut self, sample: &str, query_seq: &str, start: i64, end: i64) {
+        let key = (sample.to_string(), query_seq.to_string());
+        let intervals = self.regions.entry(key).or_default();
+
+        let mut new_start = start;
+        let mut new_end = end;
+        let mut merged_indices = Vec::new();
+
+        for (i, &(s, e)) in intervals.iter().enumerate() {
+            if e < new_start {
+                continue;
+            }
+            if s > new_end {
+                break;
+            }
+            new_start = new_start.min(s);
+            new_end = new_end.max(e);
+            merged_indices.push(i);
+        }
+
+        for i in merged_indices.into_iter().rev() {
+            intervals.remove(i);
+        }
+
+        let pos = intervals
+            .iter()
+            .position(|&(s, _)| s > new_start)
+            .unwrap_or(intervals.len());
+        intervals.insert(pos, (new_start, new_end));
+    }
+}
+
 /// Represents a depth window - a region with a specific coverage depth
 #[derive(Debug, Clone)]
 pub struct DepthWindow {
@@ -116,8 +1418,66 @@ pub struct DepthWindow {
     pub ref_name: String,
     pub ref_start: i64,
     pub ref_end: i64,
-    /// haplotype_name -> (start, end) position on the reference
-    pub haplotype_positions: FxHashMap<String, (i64, i64)>,
+    /// sample_name -> (query_seq_name, query_start, query_end) position on the query sequence
+    pub haplotype_positions: FxHashMap<String, (String, i64, i64)>,
+}
+
+/// Information about a sample's alignment (for tracking query coordinates)
+#[derive(Debug, Clone)]
+struct SampleAlignmentInfo {
+    sample: String,
+    query_name: String,
+    query_start: i64,
+    query_end: i64,
+    target_start: i64,
+    target_end: i64,
+    /// True if the alignment is on the reverse strand (query.first > query.last)
+    is_reverse: bool,
+    /// CIGAR operations for precise coordinate mapping
+    cigar: Vec<CigarOp>,
+}
+
+/// Map a target coordinate range to query coordinates using linear interpolation.
+/// This provides smooth coordinate transitions between adjacent windows.
+///
+/// Note: CIGAR-precise mapping was considered but produces more discontinuities
+/// because it reveals actual alignment structure differences. Linear interpolation
+/// smooths these over at the cost of some coordinate accuracy.
+#[allow(unused_variables)]
+fn map_target_to_query_linear(
+    cigar: &[CigarOp],
+    aln_target_start: i64,
+    aln_target_end: i64,
+    aln_query_start: i64,
+    aln_query_end: i64,
+    window_target_start: i64,
+    window_target_end: i64,
+    is_reverse: bool,
+) -> (i64, i64) {
+    let target_len = aln_target_end - aln_target_start;
+    let query_len = aln_query_end - aln_query_start;
+
+    if target_len == 0 {
+        return (aln_query_start, aln_query_end);
+    }
+
+    let window_target_start_clamped = window_target_start.max(aln_target_start);
+    let window_target_end_clamped = window_target_end.min(aln_target_end);
+
+    let start_offset = window_target_start_clamped - aln_target_start;
+    let end_offset = window_target_end_clamped - aln_target_start;
+
+    let ratio = query_len as f64 / target_len as f64;
+
+    if is_reverse {
+        let q_end = aln_query_end - (start_offset as f64 * ratio) as i64;
+        let q_start = aln_query_end - (end_offset as f64 * ratio) as i64;
+        (q_start.min(q_end), q_start.max(q_end))
+    } else {
+        let q_start = aln_query_start + (start_offset as f64 * ratio) as i64;
+        let q_end = aln_query_start + (end_offset as f64 * ratio) as i64;
+        (q_start.min(q_end), q_start.max(q_end))
+    }
 }
 
 /// Event for sweep-line algorithm to compute depth
@@ -126,6 +1486,8 @@ struct DepthEvent {
     position: i64,
     is_start: bool,
     haplotype: String,
+    /// Index into the alignment info array (for looking up query coordinates)
+    alignment_idx: usize,
 }
 
 impl Ord for DepthEvent {
@@ -177,9 +1539,13 @@ fn merge_adjacent_windows(mut windows: Vec<DepthWindow>) -> Vec<DepthWindow> {
             // Merge windows
             current.ref_end = window.ref_end;
             // Update haplotype positions to span both windows
-            for (hap, (_, new_end)) in window.haplotype_positions {
+            // Format: (query_name, query_start, query_end)
+            for (hap, (query_name, _, new_end)) in window.haplotype_positions {
                 if let Some(pos) = current.haplotype_positions.get_mut(&hap) {
-                    pos.1 = new_end;
+                    // Only extend if same query sequence
+                    if pos.0 == query_name {
+                        pos.2 = new_end;
+                    }
                 }
             }
         } else {
@@ -216,7 +1582,7 @@ fn query_overlaps_for_ref(
                 config.min_transitive_len,
                 config.min_distance_between_ranges,
                 None,
-                false,
+                true, // Store CIGAR for precise coordinate mapping
                 None,
                 sequence_index,
                 config.approximate_mode,
@@ -232,7 +1598,7 @@ fn query_overlaps_for_ref(
                 config.min_transitive_len,
                 config.min_distance_between_ranges,
                 None,
-                false,
+                true, // Store CIGAR for precise coordinate mapping
                 None,
                 sequence_index,
                 config.approximate_mode,
@@ -244,7 +1610,7 @@ fn query_overlaps_for_ref(
             ref_id,
             0,
             ref_length as i32,
-            false,
+            true, // Store CIGAR for precise coordinate mapping
             None,
             sequence_index,
             config.approximate_mode,
@@ -252,28 +1618,23 @@ fn query_overlaps_for_ref(
     }
 }
 
-/// Process overlaps into depth windows (used in sequential phase with deduplication)
+/// Process overlaps into depth windows (used in sequential phase)
+/// Note: Deduplication is handled in output_depth_tsv using QueryProcessedRegions
+/// reverse_alignments: Vec of (ref_start, ref_end, target_id) for alignments where ref is query
 fn process_overlaps_to_windows(
     impg: &Impg,
     _ref_id: u32,
     ref_name: &str,
     ref_length: i64,
     overlaps: &[AdjustedInterval],
+    reverse_alignments: &[(i32, i32, u32)],
     config: &DepthConfig,
-    processed_regions: &mut ProcessedRegions,
     separator: &str,
 ) -> Vec<DepthWindow> {
     let ref_sample = extract_sample(ref_name, separator);
 
-    // Check if this reference region is already processed
-    if processed_regions.is_fully_processed(&ref_sample, 0, ref_length) {
-        debug!("Reference {} is fully processed, skipping", ref_name);
-        return Vec::new();
-    }
-
-    if overlaps.is_empty() {
+    if overlaps.is_empty() && reverse_alignments.is_empty() {
         debug!("No overlaps found for reference {}", ref_name);
-        processed_regions.mark_processed(&ref_sample, 0, ref_length);
         return vec![DepthWindow {
             window_id: 0,
             depth: 1,
@@ -282,155 +1643,189 @@ fn process_overlaps_to_windows(
             ref_end: ref_length,
             haplotype_positions: {
                 let mut map = FxHashMap::default();
-                map.insert(ref_sample.clone(), (0, ref_length));
+                map.insert(ref_sample.clone(), (ref_name.to_string(), 0, ref_length));
                 map
             },
         }];
     }
 
-    // Group overlaps by sample, collecting ALL intervals (union approach)
-    let mut sample_intervals: FxHashMap<String, Vec<(i64, i64)>> = FxHashMap::default();
+    // Collect all alignment info (including query coordinates and CIGAR)
+    let mut all_alignments: Vec<SampleAlignmentInfo> = Vec::new();
 
+    // Forward direction: ref is target, other samples are queries
     for overlap in overlaps {
         let query_interval = &overlap.0;
+        let cigar = &overlap.1;
         let target_interval = &overlap.2;
 
         let query_name = impg.seq_index.get_name(query_interval.metadata).unwrap();
         let sample = extract_sample(query_name, separator);
 
+        // Check if reverse strand (query.first > query.last)
+        let is_reverse = query_interval.first > query_interval.last;
+        let query_start = query_interval.first.min(query_interval.last) as i64;
+        let query_end = query_interval.first.max(query_interval.last) as i64;
         let target_start = target_interval.first.min(target_interval.last) as i64;
         let target_end = target_interval.first.max(target_interval.last) as i64;
 
-        sample_intervals
-            .entry(sample)
-            .or_default()
-            .push((target_start, target_end));
+        all_alignments.push(SampleAlignmentInfo {
+            sample,
+            query_name: query_name.to_string(),
+            query_start,
+            query_end,
+            target_start,
+            target_end,
+            is_reverse,
+            cigar: cigar.clone(),
+        });
     }
 
-    // Add self (reference) as a sample
-    sample_intervals
-        .entry(ref_sample.clone())
-        .or_default()
-        .push((0, ref_length));
+    // Reverse direction: ref is query, other samples are targets
+    // In these alignments, our ref was aligned TO other sequences
+    // So the "covering sample" is the original target sequence
+    for &(ref_start, ref_end, target_id) in reverse_alignments {
+        // target_id is the sequence that our ref aligned to
+        // That sequence's sample is the "covering sample"
+        if let Some(target_name) = impg.seq_index.get_name(target_id) {
+            let sample = extract_sample(target_name, separator);
 
-    // Merge overlapping intervals for each sample and filter out processed regions
-    let mut filtered_intervals: FxHashMap<String, Vec<(i64, i64)>> = FxHashMap::default();
-    for (sample, mut intervals) in sample_intervals {
-        // Sort and merge overlapping intervals
-        intervals.sort_by_key(|(s, _)| *s);
-        let mut merged: Vec<(i64, i64)> = Vec::new();
-        for (start, end) in intervals {
-            if let Some(last) = merged.last_mut() {
-                if start <= last.1 {
-                    // Overlapping or adjacent, extend
-                    last.1 = last.1.max(end);
-                } else {
-                    merged.push((start, end));
-                }
-            } else {
-                merged.push((start, end));
+            // Skip if same sample (shouldn't contribute to depth)
+            if sample == ref_sample {
+                continue;
             }
-        }
 
-        // Filter out already processed regions
-        let mut unprocessed: Vec<(i64, i64)> = Vec::new();
-        for (start, end) in merged {
-            // Get all unprocessed portions of this interval
-            let mut current = start;
-            while current < end {
-                if let Some((unproc_start, unproc_end)) =
-                    processed_regions.get_unprocessed(&sample, current, end)
-                {
-                    unprocessed.push((unproc_start, unproc_end));
-                    current = unproc_end;
-                } else {
-                    break;
-                }
-            }
-        }
-
-        if !unprocessed.is_empty() {
-            filtered_intervals.insert(sample, unprocessed);
+            // For reverse alignments:
+            // - target_start/target_end on ref = ref_start/ref_end (the query coords)
+            // - query_start/query_end = position on the covering sample's sequence (we use ref coords for simplicity)
+            // Since we're computing depth on ref, the "target" coords are the ref coords
+            all_alignments.push(SampleAlignmentInfo {
+                sample,
+                query_name: target_name.to_string(),
+                query_start: ref_start as i64, // Approximation: use ref coords
+                query_end: ref_end as i64,
+                target_start: ref_start as i64,
+                target_end: ref_end as i64,
+                is_reverse: false,
+                cigar: Vec::new(), // No CIGAR for reverse (linear mapping)
+            });
         }
     }
 
-    if filtered_intervals.is_empty() {
-        debug!("All intervals for {} are already processed", ref_name);
-        return Vec::new();
-    }
+    // Add self (reference) as a sample with empty CIGAR (identity mapping)
+    all_alignments.push(SampleAlignmentInfo {
+        sample: ref_sample.clone(),
+        query_name: ref_name.to_string(),
+        query_start: 0,
+        query_end: ref_length,
+        target_start: 0,
+        target_end: ref_length,
+        is_reverse: false,
+        cigar: Vec::new(), // Empty CIGAR for self-alignment (identity)
+    });
 
-    // Create events for sweep-line algorithm (one pair per interval)
+    // Create events for sweep-line algorithm
+    // We need to track alignment indices to look up query info later
     let mut events: Vec<DepthEvent> = Vec::new();
-    for (sample, intervals) in &filtered_intervals {
-        for (start, end) in intervals {
-            events.push(DepthEvent {
-                position: *start,
-                is_start: true,
-                haplotype: sample.clone(),
-            });
-            events.push(DepthEvent {
-                position: *end,
-                is_start: false,
-                haplotype: sample.clone(),
-            });
-        }
+    for (idx, aln) in all_alignments.iter().enumerate() {
+        events.push(DepthEvent {
+            position: aln.target_start,
+            is_start: true,
+            haplotype: aln.sample.clone(),
+            alignment_idx: idx,
+        });
+        events.push(DepthEvent {
+            position: aln.target_end,
+            is_start: false,
+            haplotype: aln.sample.clone(),
+            alignment_idx: idx,
+        });
     }
     events.sort();
 
     // Sweep-line to compute depth windows
-    // Use counter to track multiple overlapping intervals from same sample
+    // Track active alignments for each sample (to get query info)
     let mut windows: Vec<DepthWindow> = Vec::new();
-    let mut active_sample_counts: FxHashMap<String, usize> = FxHashMap::default();
+    let mut active_alignments: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     let mut prev_pos: Option<i64> = None;
     let mut window_id = 0;
 
     for event in events {
         if let Some(prev) = prev_pos {
             if event.position > prev {
-                // Collect samples that are currently active
-                let active_samples: Vec<&String> = active_sample_counts
+                // Collect samples that are currently active (have at least one alignment)
+                let active_samples: Vec<&String> = active_alignments
                     .iter()
-                    .filter(|(_, &count)| count > 0)
+                    .filter(|(_, alns)| !alns.is_empty())
                     .map(|(s, _)| s)
                     .collect();
 
                 if !active_samples.is_empty() {
-                    let mut sample_positions: FxHashMap<String, (i64, i64)> = FxHashMap::default();
+                    let mut sample_positions: FxHashMap<String, (String, i64, i64)> =
+                        FxHashMap::default();
                     for sample in &active_samples {
-                        // For this window, use the window boundaries as positions
-                        sample_positions.insert((*sample).clone(), (prev, event.position));
+                        // Get the best alignment for this sample (pick the one with largest overlap)
+                        if let Some(aln_indices) = active_alignments.get(*sample) {
+                            if let Some(&best_idx) = aln_indices.iter().max_by_key(|&&idx| {
+                                let aln = &all_alignments[idx];
+                                // Calculate overlap with current window
+                                let overlap_start = prev.max(aln.target_start);
+                                let overlap_end = event.position.min(aln.target_end);
+                                overlap_end - overlap_start
+                            }) {
+                                let aln = &all_alignments[best_idx];
+
+                                // Calculate query coordinates corresponding to this window
+                                // Window on target: [prev, event.position]
+                                let window_target_start = prev.max(aln.target_start);
+                                let window_target_end = event.position.min(aln.target_end);
+
+                                // Use linear interpolation for coordinate mapping
+                                let (window_query_start, window_query_end) =
+                                    map_target_to_query_linear(
+                                        &aln.cigar,
+                                        aln.target_start,
+                                        aln.target_end,
+                                        aln.query_start,
+                                        aln.query_end,
+                                        window_target_start,
+                                        window_target_end,
+                                        aln.is_reverse,
+                                    );
+
+                                sample_positions.insert(
+                                    (*sample).clone(),
+                                    (aln.query_name.clone(), window_query_start, window_query_end),
+                                );
+                            }
+                        }
                     }
 
-                    windows.push(DepthWindow {
-                        window_id,
-                        depth: sample_positions.len(),
-                        ref_name: ref_name.to_string(),
-                        ref_start: prev,
-                        ref_end: event.position,
-                        haplotype_positions: sample_positions,
-                    });
-                    window_id += 1;
+                    if !sample_positions.is_empty() {
+                        windows.push(DepthWindow {
+                            window_id,
+                            depth: sample_positions.len(),
+                            ref_name: ref_name.to_string(),
+                            ref_start: prev,
+                            ref_end: event.position,
+                            haplotype_positions: sample_positions,
+                        });
+                        window_id += 1;
+                    }
                 }
             }
         }
 
-        // Update active counts
+        // Update active alignments
         if event.is_start {
-            *active_sample_counts.entry(event.haplotype).or_insert(0) += 1;
-        } else {
-            if let Some(count) = active_sample_counts.get_mut(&event.haplotype) {
-                *count = count.saturating_sub(1);
-            }
+            active_alignments
+                .entry(event.haplotype.clone())
+                .or_default()
+                .push(event.alignment_idx);
+        } else if let Some(alns) = active_alignments.get_mut(&event.haplotype) {
+            alns.retain(|&idx| idx != event.alignment_idx);
         }
 
         prev_pos = Some(event.position);
-    }
-
-    // Mark all processed regions
-    for (sample, intervals) in &filtered_intervals {
-        for (start, end) in intervals {
-            processed_regions.mark_processed(sample, *start, *end);
-        }
     }
 
     // Optionally merge adjacent windows
@@ -442,6 +1837,10 @@ fn process_overlaps_to_windows(
 }
 
 /// Main function to compute depth across all sequences
+/// Uses streaming architecture to minimize memory usage:
+/// - Process one reference at a time
+/// - Query overlaps → Process windows → Deduplicate → Output immediately
+/// - Release memory before processing next reference
 pub fn compute_depth(
     impg: &Impg,
     config: &DepthConfig,
@@ -450,7 +1849,7 @@ pub fn compute_depth(
     separator: &str,
     output_prefix: Option<&str>,
 ) -> io::Result<()> {
-    info!("Computing depth coverage");
+    info!("Computing depth coverage (streaming mode)");
 
     // Determine processing order
     let mut seq_order: Vec<(u32, String, i64)> = Vec::new();
@@ -494,56 +1893,39 @@ pub fn compute_depth(
     let mut sample_list: Vec<String> = all_samples.into_iter().collect();
     sample_list.sort();
 
-    // Phase 1: Parallel query all overlaps
-    info!("Phase 1: Querying overlaps in parallel...");
-    let all_overlaps: Vec<Vec<AdjustedInterval>> = seq_order
-        .par_iter()
-        .map(|(ref_id, _ref_name, ref_len)| {
-            query_overlaps_for_ref(impg, *ref_id, *ref_len, config, sequence_index)
-        })
+    // Build seq_lengths map for uncovered regions
+    let seq_lengths: FxHashMap<String, i64> = seq_order
+        .iter()
+        .map(|(_, name, len)| (name.clone(), *len))
         .collect();
 
-    // Phase 2: Sequential processing with deduplication
-    info!("Phase 2: Processing depth windows with deduplication...");
-    let mut processed_regions = ProcessedRegions::new();
-    let mut all_windows: Vec<DepthWindow> = Vec::new();
-    let mut global_window_id = 0;
+    // Build string interning maps
+    let sample_to_idx: FxHashMap<&str, u16> = sample_list
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.as_str(), i as u16))
+        .collect();
 
-    for (i, (ref_id, ref_name, ref_len)) in seq_order.iter().enumerate() {
-        let mut windows = process_overlaps_to_windows(
-            impg,
-            *ref_id,
-            ref_name,
-            *ref_len,
-            &all_overlaps[i],
-            config,
-            &mut processed_regions,
-            separator,
-        );
+    let seq_names: Vec<&String> = seq_lengths.keys().collect();
+    let seq_to_idx: FxHashMap<&str, u32> = seq_names
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.as_str(), i as u32))
+        .collect();
 
-        // Update global window IDs
-        for w in &mut windows {
-            w.window_id = global_window_id;
-            global_window_id += 1;
-        }
+    let idx_to_seq: Vec<&str> = {
+        let mut v: Vec<(&str, u32)> = seq_to_idx.iter().map(|(&s, &i)| (s, i)).collect();
+        v.sort_by_key(|(_, i)| *i);
+        v.into_iter().map(|(s, _)| s).collect()
+    };
 
-        all_windows.extend(windows);
-    }
+    info!(
+        "String interning: {} samples, {} sequences",
+        sample_to_idx.len(),
+        seq_to_idx.len()
+    );
 
-    info!("Generated {} depth windows", all_windows.len());
-
-    // Output results
-    output_depth_tsv(&all_windows, &sample_list, output_prefix)?;
-
-    Ok(())
-}
-
-/// Output depth windows as TSV
-fn output_depth_tsv(
-    windows: &[DepthWindow],
-    sample_list: &[String],
-    output_prefix: Option<&str>,
-) -> io::Result<()> {
+    // Open output file
     let writer: Box<dyn Write> = if let Some(prefix) = output_prefix {
         let path = format!("{}.depth.tsv", prefix);
         Box::new(BufWriter::new(std::fs::File::create(&path)?))
@@ -554,27 +1936,299 @@ fn output_depth_tsv(
 
     // Write header
     write!(writer, "window_id\tdepth")?;
-    for sample in sample_list {
+    for sample in &sample_list {
         write!(writer, "\t{}", sample)?;
     }
     writeln!(writer)?;
 
-    // Write data rows
-    for window in windows {
-        write!(writer, "{}\t{}", window.window_id, window.depth)?;
+    // Coverage trackers for each (sample_idx, seq_idx) pair
+    // This tracks what we've already output to avoid duplicates
+    let mut coverage_trackers: FxHashMap<(u16, u32), CoverageTracker> = FxHashMap::default();
 
-        for sample in sample_list {
-            if let Some((start, end)) = window.haplotype_positions.get(sample) {
-                write!(writer, "\t{}:{}-{}", window.ref_name, start, end)?;
-            } else {
-                write!(writer, "\tNA")?;
+    // Process in batches for parallelism while limiting memory
+    // Batch size: process N references at a time
+    const BATCH_SIZE: usize = 8;
+    let mut global_window_id: usize = 0;
+    let total_refs = seq_order.len();
+
+    info!("Processing {} references in batches of {}", total_refs, BATCH_SIZE);
+
+    for (batch_idx, batch) in seq_order.chunks(BATCH_SIZE).enumerate() {
+        let batch_start = batch_idx * BATCH_SIZE;
+        debug!(
+            "Processing batch {}: refs {}-{} of {}",
+            batch_idx,
+            batch_start,
+            batch_start + batch.len() - 1,
+            total_refs
+        );
+
+        // Phase 1: Query overlaps for this batch in parallel
+        let batch_overlaps: Vec<Vec<AdjustedInterval>> = batch
+            .par_iter()
+            .map(|(ref_id, _ref_name, ref_len)| {
+                query_overlaps_for_ref(impg, *ref_id, *ref_len, config, sequence_index)
+            })
+            .collect();
+
+        // Phase 2: Query reverse alignments in parallel (where ref is query in PAF)
+        let batch_reverse_alignments: Vec<Vec<(i32, i32, u32)>> = batch
+            .par_iter()
+            .map(|(ref_id, _ref_name, _ref_len)| {
+                impg.query_reverse_for_depth(*ref_id)
+            })
+            .collect();
+
+        // Phase 3: Process overlaps into depth windows in parallel
+        let batch_windows: Vec<Vec<DepthWindow>> = batch
+            .par_iter()
+            .zip(batch_overlaps.par_iter())
+            .zip(batch_reverse_alignments.par_iter())
+            .map(|(((ref_id, ref_name, ref_len), overlaps), reverse_alignments)| {
+                process_overlaps_to_windows(
+                    impg,
+                    *ref_id,
+                    ref_name,
+                    *ref_len,
+                    overlaps,
+                    reverse_alignments,
+                    config,
+                    separator,
+                )
+            })
+            .collect();
+
+        // Phase 4: Deduplicate and output (sequential to maintain order)
+        for mut windows in batch_windows {
+            // Assign global window IDs
+            for w in &mut windows {
+                w.window_id = global_window_id;
+                global_window_id += 1;
+            }
+
+            // Process each window and output deduplicated intervals
+            for window in &windows {
+                for (sample, (seq_name, start, end)) in &window.haplotype_positions {
+                    if let (Some(&sample_idx), Some(&seq_idx)) = (
+                        sample_to_idx.get(sample.as_str()),
+                        seq_to_idx.get(seq_name.as_str()),
+                    ) {
+                        let key = (sample_idx, seq_idx);
+                        let tracker = coverage_trackers.entry(key).or_default();
+
+                        // Get uncovered portions
+                        let uncovered = tracker.add_interval(*start, *end);
+
+                        // Output each uncovered portion
+                        for (unc_start, unc_end) in uncovered {
+                            write!(writer, "{}\t{}", window.window_id, window.depth)?;
+                            for (i, _) in sample_list.iter().enumerate() {
+                                if i as u16 == sample_idx {
+                                    write!(
+                                        writer,
+                                        "\t{}:{}-{}",
+                                        idx_to_seq[seq_idx as usize], unc_start, unc_end
+                                    )?;
+                                } else {
+                                    write!(writer, "\tNA")?;
+                                }
+                            }
+                            writeln!(writer)?;
+                        }
+                    }
+                }
+            }
+            // Windows for this reference are dropped here, releasing memory
+        }
+        // batch_overlaps and batch_windows are dropped here
+
+        if (batch_idx + 1) % 10 == 0 || batch_idx == seq_order.chunks(BATCH_SIZE).count() - 1 {
+            info!(
+                "Progress: {}/{} references processed",
+                (batch_idx + 1) * BATCH_SIZE.min(total_refs - batch_idx * BATCH_SIZE),
+                total_refs
+            );
+        }
+    }
+
+    info!("Generated {} depth windows", global_window_id);
+
+    // Phase 4: Find and output uncovered regions
+    info!("Finding uncovered regions...");
+    let mut uncovered_count = 0;
+
+    for (seq_name, &seq_len) in &seq_lengths {
+        let sample = extract_sample(seq_name, separator);
+        if let (Some(&sample_idx), Some(&seq_idx)) = (
+            sample_to_idx.get(sample.as_str()),
+            seq_to_idx.get(seq_name.as_str()),
+        ) {
+            let key = (sample_idx, seq_idx);
+            let mut current_pos: i64 = 0;
+
+            if let Some(tracker) = coverage_trackers.get(&key) {
+                for &(iv_start, iv_end) in tracker.get_intervals() {
+                    if iv_start > current_pos {
+                        // Output uncovered region
+                        write!(writer, "uncovered\t1")?;
+                        for (i, _) in sample_list.iter().enumerate() {
+                            if i as u16 == sample_idx {
+                                write!(
+                                    writer,
+                                    "\t{}:{}-{}",
+                                    idx_to_seq[seq_idx as usize], current_pos, iv_start
+                                )?;
+                            } else {
+                                write!(writer, "\tNA")?;
+                            }
+                        }
+                        writeln!(writer)?;
+                        uncovered_count += 1;
+                    }
+                    current_pos = current_pos.max(iv_end);
+                }
+            }
+
+            // Check for uncovered region at the end
+            if current_pos < seq_len {
+                write!(writer, "uncovered\t1")?;
+                for (i, _) in sample_list.iter().enumerate() {
+                    if i as u16 == sample_idx {
+                        write!(
+                            writer,
+                            "\t{}:{}-{}",
+                            idx_to_seq[seq_idx as usize], current_pos, seq_len
+                        )?;
+                    } else {
+                        write!(writer, "\tNA")?;
+                    }
+                }
+                writeln!(writer)?;
+                uncovered_count += 1;
             }
         }
-        writeln!(writer)?;
+    }
+
+    if uncovered_count > 0 {
+        info!("Found {} uncovered regions", uncovered_count);
     }
 
     writer.flush()?;
+    info!("Output complete");
+
     Ok(())
+}
+
+/// Coverage tracker for a single (sample, seq) pair
+/// Maintains a sorted list of non-overlapping covered intervals
+#[derive(Debug, Default)]
+struct CoverageTracker {
+    /// Sorted, non-overlapping intervals: Vec<(start, end)>
+    intervals: Vec<(i64, i64)>,
+}
+
+impl CoverageTracker {
+    /// Add a new interval and return the uncovered portions
+    /// Returns: Vec<(start, end)> of newly covered regions
+    ///
+    /// This implementation uses a simple linear scan to be robust against edge cases.
+    /// It guarantees that returned intervals are non-overlapping with existing coverage.
+    fn add_interval(&mut self, start: i64, end: i64) -> Vec<(i64, i64)> {
+        if start >= end {
+            return Vec::new();
+        }
+
+        let mut uncovered = Vec::new();
+        let mut current = start;
+
+        // Simple linear scan through all intervals
+        for &(iv_start, iv_end) in &self.intervals {
+            // Skip intervals that end before our current position
+            if iv_end <= current {
+                continue;
+            }
+            // Stop if interval starts at or after our end
+            if iv_start >= end {
+                break;
+            }
+
+            // There's some overlap or gap
+            if current < iv_start {
+                // Gap before this interval - this portion is uncovered
+                let gap_end = iv_start.min(end);
+                uncovered.push((current, gap_end));
+            }
+
+            // Move current position past this interval
+            current = current.max(iv_end);
+
+            // Early exit if we've passed our end
+            if current >= end {
+                break;
+            }
+        }
+
+        // Final gap after all intervals
+        if current < end {
+            uncovered.push((current, end));
+        }
+
+        // Merge the new interval into our list if there are uncovered portions
+        if !uncovered.is_empty() {
+            self.merge_interval(start, end);
+        }
+
+        uncovered
+    }
+
+    /// Merge a new interval into the sorted list
+    /// Maintains the invariant that intervals are sorted and non-overlapping
+    fn merge_interval(&mut self, start: i64, end: i64) {
+        if self.intervals.is_empty() {
+            self.intervals.push((start, end));
+            return;
+        }
+
+        // Find all intervals that overlap or are adjacent to [start, end]
+        let mut merge_start = start;
+        let mut merge_end = end;
+        let mut first_overlap: Option<usize> = None;
+        let mut last_overlap: Option<usize> = None;
+
+        for (i, &(iv_start, iv_end)) in self.intervals.iter().enumerate() {
+            // Check if overlaps or adjacent (iv_end >= start && iv_start <= end)
+            if iv_end >= start && iv_start <= end {
+                if first_overlap.is_none() {
+                    first_overlap = Some(i);
+                }
+                last_overlap = Some(i);
+                merge_start = merge_start.min(iv_start);
+                merge_end = merge_end.max(iv_end);
+            }
+        }
+
+        match (first_overlap, last_overlap) {
+            (Some(first), Some(last)) => {
+                // Remove overlapping intervals and insert merged one
+                self.intervals.drain(first..=last);
+                self.intervals.insert(first, (merge_start, merge_end));
+            }
+            _ => {
+                // No overlap, insert at correct position
+                let pos = self
+                    .intervals
+                    .iter()
+                    .position(|&(s, _)| s > start)
+                    .unwrap_or(self.intervals.len());
+                self.intervals.insert(pos, (start, end));
+            }
+        }
+    }
+
+    /// Get all intervals (for final output)
+    fn get_intervals(&self) -> &[(i64, i64)] {
+        &self.intervals
+    }
 }
 
 /// Load reference order from file
@@ -585,4 +2239,3805 @@ pub fn load_ref_order_file(path: &str) -> io::Result<Vec<String>> {
         .filter(|line| !line.trim().is_empty() && !line.trim().starts_with('#'))
         .map(|line| line.trim().to_string())
         .collect())
+}
+
+// ============================================================================
+// New sample-based depth computation with hybrid strategy
+// ============================================================================
+
+/// Determine the optimal sample processing order
+/// Samples with more alignments are processed first to maximize pool coverage early
+#[allow(dead_code)]
+fn determine_sample_order(
+    seq_lengths: &SequenceLengths,
+    impg: &Impg,
+    separator: &str,
+) -> Vec<String> {
+    let mut sample_alignment_counts: FxHashMap<String, usize> = FxHashMap::default();
+
+    // Count alignments per sample (as target)
+    let target_ids: Vec<u32> = impg.forest_map.entries.keys().copied().collect();
+
+    for target_id in target_ids {
+        if let Some(target_name) = impg.seq_index.get_name(target_id) {
+            let sample = extract_sample(target_name, separator);
+
+            // Get the actual tree and count alignments
+            if let Some(tree) = impg.get_or_load_tree(target_id) {
+                let target_len = impg.seq_index.get_len_from_id(target_id).unwrap_or(0);
+                let mut count = 0;
+                tree.query(0, target_len as i32, |_| count += 1);
+                *sample_alignment_counts.entry(sample).or_default() += count;
+            }
+        }
+    }
+
+    // Sort samples by alignment count (descending) for better early coverage
+    let mut samples: Vec<_> = seq_lengths.get_samples();
+    samples.sort_by(|a, b| {
+        let count_a = sample_alignment_counts.get(a).copied().unwrap_or(0);
+        let count_b = sample_alignment_counts.get(b).copied().unwrap_or(0);
+        count_b.cmp(&count_a).then_with(|| a.cmp(b))
+    });
+
+    samples
+}
+
+/// Choose query strategy based on pool state and alignment density
+fn choose_strategy(
+    _sample: &str,
+    _pool: &Pool,
+    _impg: &Impg,
+    _seq_lengths: &SequenceLengths,
+    _is_first_round: bool,
+) -> QueryStrategy {
+    // Always use FromIndex to ensure ALL alignments are collected
+    // This is necessary because FromPool would miss alignments for regions
+    // that were removed from the pool when earlier samples were processed,
+    // resulting in incomplete windows (missing samples)
+    // The pool filtering in window generation prevents duplicate output
+    QueryStrategy::FromIndex
+}
+
+/// Collect alignments for a sequence using FromIndex strategy
+fn collect_alignments_from_index(
+    impg: &Impg,
+    anchor_seq: &str,
+    anchor_sample: &str,
+    reverse_index: &ReverseAlignmentIndex,
+    config: &DepthConfig,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+    separator: &str,
+) -> Vec<SampleAlignmentInfo> {
+    let mut alignments = Vec::new();
+
+    let seq_id = match impg.seq_index.get_id(anchor_seq) {
+        Some(id) => id,
+        None => return alignments,
+    };
+    let seq_len = impg.seq_index.get_len_from_id(seq_id).unwrap_or(0) as i64;
+
+    // 1. Query where anchor_seq is TARGET (other samples aligned to this)
+    let overlaps = if config.transitive {
+        if config.transitive_dfs {
+            impg.query_transitive_dfs(
+                seq_id,
+                0,
+                seq_len as i32,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false, // Don't need CIGAR for now
+                None,
+                sequence_index,
+                config.approximate_mode,
+                None,
+            )
+        } else {
+            impg.query_transitive_bfs(
+                seq_id,
+                0,
+                seq_len as i32,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                config.approximate_mode,
+                None,
+            )
+        }
+    } else {
+        impg.query(seq_id, 0, seq_len as i32, false, None, sequence_index, config.approximate_mode)
+    };
+
+    for overlap in overlaps {
+        let query_interval = &overlap.0;
+        let target_interval = &overlap.2;
+
+        let query_name = match impg.seq_index.get_name(query_interval.metadata) {
+            Some(name) => name,
+            None => continue,
+        };
+        let sample = extract_sample(query_name, separator);
+
+        let is_reverse = query_interval.first > query_interval.last;
+        let query_start = query_interval.first.min(query_interval.last) as i64;
+        let query_end = query_interval.first.max(query_interval.last) as i64;
+        let target_start = target_interval.first.min(target_interval.last) as i64;
+        let target_end = target_interval.first.max(target_interval.last) as i64;
+
+        alignments.push(SampleAlignmentInfo {
+            sample,
+            query_name: query_name.to_string(),
+            query_start,
+            query_end,
+            target_start,
+            target_end,
+            is_reverse,
+            cigar: Vec::new(),
+        });
+    }
+
+    // 2. Query where anchor_seq is QUERY (this sample aligned to others)
+    if let Some(reverse_entries) = reverse_index.get_all(anchor_seq) {
+        for entry in reverse_entries {
+            let target_sample = extract_sample(&entry.target_seq, separator);
+
+            // Skip self-alignments
+            if target_sample == anchor_sample {
+                continue;
+            }
+
+            alignments.push(SampleAlignmentInfo {
+                sample: target_sample,
+                query_name: entry.target_seq.clone(),
+                query_start: entry.target_start,
+                query_end: entry.target_end,
+                target_start: entry.query_start,
+                target_end: entry.query_end,
+                is_reverse: entry.is_reverse,
+                cigar: Vec::new(),
+            });
+        }
+    }
+
+    alignments
+}
+
+/// Collect alignments for pool intervals using FromPool strategy
+fn collect_alignments_from_pool(
+    impg: &Impg,
+    anchor_seq: &str,
+    anchor_sample: &str,
+    pool_intervals: &[(i64, i64)],
+    reverse_index: &ReverseAlignmentIndex,
+    config: &DepthConfig,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+    separator: &str,
+) -> Vec<SampleAlignmentInfo> {
+    let mut alignments = Vec::new();
+    let mut seen_alignments: FxHashSet<(String, i64, i64, i64, i64)> = FxHashSet::default();
+
+    let seq_id = match impg.seq_index.get_id(anchor_seq) {
+        Some(id) => id,
+        None => return alignments,
+    };
+
+    // Merge nearby pool intervals to reduce query count
+    let merged_intervals = merge_nearby_intervals(pool_intervals, 1000);
+
+    for (start, end) in merged_intervals {
+        // 1. Query where anchor_seq is TARGET
+        let overlaps = if config.transitive {
+            if config.transitive_dfs {
+                impg.query_transitive_dfs(
+                    seq_id,
+                    start as i32,
+                    end as i32,
+                    None,
+                    config.max_depth,
+                    config.min_transitive_len,
+                    config.min_distance_between_ranges,
+                    None,
+                    false,
+                    None,
+                    sequence_index,
+                    config.approximate_mode,
+                    None,
+                )
+            } else {
+                impg.query_transitive_bfs(
+                    seq_id,
+                    start as i32,
+                    end as i32,
+                    None,
+                    config.max_depth,
+                    config.min_transitive_len,
+                    config.min_distance_between_ranges,
+                    None,
+                    false,
+                    None,
+                    sequence_index,
+                    config.approximate_mode,
+                    None,
+                )
+            }
+        } else {
+            impg.query(seq_id, start as i32, end as i32, false, None, sequence_index, config.approximate_mode)
+        };
+
+        for overlap in overlaps {
+            let query_interval = &overlap.0;
+            let target_interval = &overlap.2;
+
+            let query_name = match impg.seq_index.get_name(query_interval.metadata) {
+                Some(name) => name,
+                None => continue,
+            };
+            let sample = extract_sample(query_name, separator);
+
+            let is_reverse = query_interval.first > query_interval.last;
+            let query_start = query_interval.first.min(query_interval.last) as i64;
+            let query_end = query_interval.first.max(query_interval.last) as i64;
+            let target_start = target_interval.first.min(target_interval.last) as i64;
+            let target_end = target_interval.first.max(target_interval.last) as i64;
+
+            // Deduplicate
+            let key = (query_name.to_string(), query_start, query_end, target_start, target_end);
+            if seen_alignments.insert(key) {
+                alignments.push(SampleAlignmentInfo {
+                    sample,
+                    query_name: query_name.to_string(),
+                    query_start,
+                    query_end,
+                    target_start,
+                    target_end,
+                    is_reverse,
+                    cigar: Vec::new(),
+                });
+            }
+        }
+
+        // 2. Query reverse alignments for this range
+        let reverse_entries = reverse_index.query_range(anchor_seq, start, end);
+        for entry in reverse_entries {
+            let target_sample = extract_sample(&entry.target_seq, separator);
+
+            if target_sample == anchor_sample {
+                continue;
+            }
+
+            let key = (
+                entry.target_seq.clone(),
+                entry.target_start,
+                entry.target_end,
+                entry.query_start,
+                entry.query_end,
+            );
+            if seen_alignments.insert(key) {
+                alignments.push(SampleAlignmentInfo {
+                    sample: target_sample,
+                    query_name: entry.target_seq.clone(),
+                    query_start: entry.target_start,
+                    query_end: entry.target_end,
+                    target_start: entry.query_start,
+                    target_end: entry.query_end,
+                    is_reverse: entry.is_reverse,
+                    cigar: Vec::new(),
+                });
+            }
+        }
+    }
+
+    alignments
+}
+
+/// Merge nearby intervals (gap <= max_gap)
+fn merge_nearby_intervals(intervals: &[(i64, i64)], max_gap: i64) -> Vec<(i64, i64)> {
+    if intervals.is_empty() {
+        return Vec::new();
+    }
+
+    let mut sorted: Vec<_> = intervals.to_vec();
+    sorted.sort_by_key(|&(s, _)| s);
+
+    let mut merged = Vec::new();
+    let mut current = sorted[0];
+
+    for &(start, end) in &sorted[1..] {
+        if start <= current.1 + max_gap {
+            current.1 = current.1.max(end);
+        } else {
+            merged.push(current);
+            current = (start, end);
+        }
+    }
+    merged.push(current);
+
+    merged
+}
+
+/// Process alignments for a single anchor sequence, generating depth windows
+fn process_seq_to_windows(
+    anchor_sample: &str,
+    anchor_seq: &str,
+    anchor_len: i64,
+    alignments: &[SampleAlignmentInfo],
+    pool_intervals: &[(i64, i64)],
+    config: &DepthConfig,
+    _separator: &str,
+) -> SeqProcessResult {
+    let mut windows = Vec::new();
+    let mut regions_to_remove = Vec::new();
+
+    if alignments.is_empty() && pool_intervals.is_empty() {
+        return SeqProcessResult {
+            windows,
+            regions_to_remove,
+        };
+    }
+
+    // Build events for sweep-line
+    let mut events: Vec<DepthEvent> = Vec::new();
+    let mut all_alignments: Vec<SampleAlignmentInfo> = Vec::new();
+
+    // Add anchor sample itself
+    all_alignments.push(SampleAlignmentInfo {
+        sample: anchor_sample.to_string(),
+        query_name: anchor_seq.to_string(),
+        query_start: 0,
+        query_end: anchor_len,
+        target_start: 0,
+        target_end: anchor_len,
+        is_reverse: false,
+        cigar: Vec::new(),
+    });
+
+    // Add other alignments
+    all_alignments.extend(alignments.iter().cloned());
+
+    // Create events
+    for (idx, aln) in all_alignments.iter().enumerate() {
+        events.push(DepthEvent {
+            position: aln.target_start,
+            is_start: true,
+            haplotype: aln.sample.clone(),
+            alignment_idx: idx,
+        });
+        events.push(DepthEvent {
+            position: aln.target_end,
+            is_start: false,
+            haplotype: aln.sample.clone(),
+            alignment_idx: idx,
+        });
+    }
+    events.sort();
+
+    // Sweep-line to compute raw windows
+    let mut raw_windows: Vec<DepthWindow> = Vec::new();
+    let mut active_alignments: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut prev_pos: Option<i64> = None;
+    let mut window_id = 0;
+
+    for event in events {
+        if let Some(prev) = prev_pos {
+            if event.position > prev {
+                let active_samples: Vec<&String> = active_alignments
+                    .iter()
+                    .filter(|(_, alns)| !alns.is_empty())
+                    .map(|(s, _)| s)
+                    .collect();
+
+                if !active_samples.is_empty() {
+                    let mut sample_positions: FxHashMap<String, (String, i64, i64)> =
+                        FxHashMap::default();
+
+                    for sample in &active_samples {
+                        if let Some(aln_indices) = active_alignments.get(*sample) {
+                            if let Some(&best_idx) = aln_indices.iter().max_by_key(|&&idx| {
+                                let aln = &all_alignments[idx];
+                                let overlap_start = prev.max(aln.target_start);
+                                let overlap_end = event.position.min(aln.target_end);
+                                overlap_end - overlap_start
+                            }) {
+                                let aln = &all_alignments[best_idx];
+                                let (window_query_start, window_query_end) =
+                                    map_target_to_query_linear(
+                                        &aln.cigar,
+                                        aln.target_start,
+                                        aln.target_end,
+                                        aln.query_start,
+                                        aln.query_end,
+                                        prev,
+                                        event.position,
+                                        aln.is_reverse,
+                                    );
+
+                                sample_positions.insert(
+                                    (*sample).clone(),
+                                    (aln.query_name.clone(), window_query_start, window_query_end),
+                                );
+                            }
+                        }
+                    }
+
+                    if !sample_positions.is_empty() {
+                        raw_windows.push(DepthWindow {
+                            window_id,
+                            depth: sample_positions.len(),
+                            ref_name: anchor_seq.to_string(),
+                            ref_start: prev,
+                            ref_end: event.position,
+                            haplotype_positions: sample_positions,
+                        });
+                        window_id += 1;
+                    }
+                }
+            }
+        }
+
+        if event.is_start {
+            active_alignments
+                .entry(event.haplotype.clone())
+                .or_default()
+                .push(event.alignment_idx);
+        } else if let Some(alns) = active_alignments.get_mut(&event.haplotype) {
+            alns.retain(|&idx| idx != event.alignment_idx);
+        }
+
+        prev_pos = Some(event.position);
+    }
+
+    // Optionally merge adjacent windows
+    if config.merge_adjacent {
+        raw_windows = merge_adjacent_windows(raw_windows);
+    }
+
+    // Filter windows by pool intervals and collect regions to remove
+    let pool_interval_set = {
+        let mut is = IntervalSet::new();
+        for &(start, end) in pool_intervals {
+            // Simple merge for filtering
+            is.intervals.push((start, end));
+        }
+        is.intervals.sort_by_key(|&(s, _)| s);
+        is
+    };
+
+    for window in raw_windows {
+        // Check if window overlaps with any pool interval
+        let intersections = pool_interval_set.intersect(window.ref_start, window.ref_end);
+
+        for (int_start, int_end) in intersections {
+            // Create clipped window
+            let mut clipped_window = window.clone();
+            clipped_window.ref_start = int_start;
+            clipped_window.ref_end = int_end;
+
+            // Update sample positions proportionally
+            let window_len = window.ref_end - window.ref_start;
+            if window_len > 0 {
+                let ratio_start =
+                    (int_start - window.ref_start) as f64 / window_len as f64;
+                let ratio_end = (int_end - window.ref_start) as f64 / window_len as f64;
+
+                for (sample, (seq, orig_start, orig_end)) in &window.haplotype_positions {
+                    let orig_len = orig_end - orig_start;
+                    let new_start = orig_start + (orig_len as f64 * ratio_start) as i64;
+                    let new_end = orig_start + (orig_len as f64 * ratio_end) as i64;
+
+                    clipped_window
+                        .haplotype_positions
+                        .insert(sample.clone(), (seq.clone(), new_start, new_end));
+                }
+            }
+
+            // Record regions to remove from pool (for all samples in window)
+            for (sample, (seq, start, end)) in &clipped_window.haplotype_positions {
+                regions_to_remove.push((sample.clone(), seq.clone(), *start, *end));
+            }
+
+            windows.push(clipped_window);
+        }
+    }
+
+    SeqProcessResult {
+        windows,
+        regions_to_remove,
+    }
+}
+
+/// Main function: compute depth using sample-based iteration with hybrid strategy
+///
+/// When `ref_sample` is specified (targeted mode), only computes depth for the specified
+/// sample's sequences as reference. When `ref_sample` is None (global mode), computes
+/// depth for all sequences.
+pub fn compute_depth_by_sample(
+    impg: &Impg,
+    config: &DepthConfig,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+    separator: &str,
+    output_prefix: Option<&str>,
+    fai_list: Option<&str>,
+    ref_sample: Option<&str>,
+) -> io::Result<()> {
+    if let Some(ref_name) = ref_sample {
+        info!("Computing depth coverage (targeted mode for sample: {})", ref_name);
+    } else {
+        info!("Computing depth coverage (global mode)");
+    }
+
+    // Phase 0: Preprocessing
+    info!("Phase 0: Building indices...");
+
+    // 0.1 Build sequence lengths from impg (for alignment processing)
+    let seq_lengths = SequenceLengths::from_impg(impg, separator);
+    info!(
+        "  Found {} samples, {} sequences in alignments",
+        seq_lengths.sample_to_seqs.len(),
+        seq_lengths.lengths.len()
+    );
+
+    // 0.2 Build reverse alignment index
+    info!("  Building reverse alignment index...");
+    let reverse_index = ReverseAlignmentIndex::build(impg);
+    info!(
+        "  Reverse index contains {} alignments",
+        reverse_index.total_alignments()
+    );
+
+    // Clear tree cache after building reverse index - the index now contains all needed data
+    impg.clear_tree_cache();
+    info!("  Tree cache cleared after building reverse index");
+
+    // 0.3 Initialize pool - use FAI files if provided for full coverage
+    let (pool_seq_lengths, mut pool) = if let Some(fai_path) = fai_list {
+        info!("  Loading sequence lengths from FAI files...");
+        let fai_seq_lengths = SequenceLengths::from_fai_list(fai_path, separator)?;
+        info!(
+            "  FAI: {} samples, {} sequences",
+            fai_seq_lengths.sample_to_seqs.len(),
+            fai_seq_lengths.lengths.len()
+        );
+        let p = Pool::new(&fai_seq_lengths);
+        (fai_seq_lengths, p)
+    } else {
+        let p = Pool::new(&seq_lengths);
+        (seq_lengths.clone(), p)
+    };
+    let initial_pool_length = pool.total_remaining_length();
+    info!("  Pool initialized with {} bp total", initial_pool_length);
+
+    // 0.4 Determine sample processing order (from FAI if provided, otherwise from impg)
+    let sample_order = pool_seq_lengths.get_samples();
+    info!("  Sample processing order: {:?}", sample_order);
+
+    // 0.4.1 Validate ref_sample if specified (targeted mode)
+    if let Some(ref_name) = ref_sample {
+        if !sample_order.contains(&ref_name.to_string()) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Reference sample '{}' not found. Available samples: {:?}",
+                    ref_name, sample_order
+                ),
+            ));
+        }
+        info!("  Targeted mode: only processing sequences from sample '{}'", ref_name);
+    }
+
+    // 0.5 Prepare output
+    let writer: Box<dyn Write> = if let Some(prefix) = output_prefix {
+        let path = format!("{}.depth.tsv", prefix);
+        Box::new(BufWriter::new(std::fs::File::create(&path)?))
+    } else {
+        Box::new(BufWriter::new(std::io::stdout()))
+    };
+    let mut writer = BufWriter::new(writer);
+
+    // Write header
+    write!(writer, "window_id\tdepth")?;
+    for sample in &sample_order {
+        write!(writer, "\t{}", sample)?;
+    }
+    writeln!(writer)?;
+
+    let mut global_window_id: usize = 0;
+    let total_samples = sample_order.len();
+
+    // Phase 1: Process samples
+    info!("Phase 1: Processing {} samples...", total_samples);
+
+    for (sample_idx, anchor_sample) in sample_order.iter().enumerate() {
+        // In targeted mode, only process the specified reference sample
+        if let Some(ref_name) = ref_sample {
+            if anchor_sample != ref_name {
+                continue;
+            }
+        }
+
+        // Check if sample has remaining intervals
+        if pool.is_sample_empty(anchor_sample) {
+            debug!("Sample {} has no remaining intervals, skipping", anchor_sample);
+            continue;
+        }
+
+        let is_first_round = sample_idx == 0;
+        let strategy = choose_strategy(anchor_sample, &pool, impg, &seq_lengths, is_first_round);
+
+        debug!(
+            "Processing sample {}/{}: {} (strategy: {:?})",
+            sample_idx + 1,
+            total_samples,
+            anchor_sample,
+            strategy
+        );
+
+        // Get sequences for this sample
+        let seqs = seq_lengths.get_seqs_of_sample(anchor_sample);
+
+        // Process sequences in parallel
+        let seq_results: Vec<SeqProcessResult> = seqs
+            .par_iter()
+            .filter_map(|seq_name| {
+                let pool_intervals = pool.get_intervals(anchor_sample, seq_name);
+                if pool_intervals.is_empty() {
+                    return None;
+                }
+
+                let seq_len = seq_lengths.get_length(seq_name).unwrap_or(0);
+
+                // Collect alignments based on strategy
+                let alignments = match strategy {
+                    QueryStrategy::FromIndex => collect_alignments_from_index(
+                        impg,
+                        seq_name,
+                        anchor_sample,
+                        &reverse_index,
+                        config,
+                        sequence_index,
+                        separator,
+                    ),
+                    QueryStrategy::FromPool => collect_alignments_from_pool(
+                        impg,
+                        seq_name,
+                        anchor_sample,
+                        &pool_intervals,
+                        &reverse_index,
+                        config,
+                        sequence_index,
+                        separator,
+                    ),
+                };
+
+                // Process to windows
+                let result = process_seq_to_windows(
+                    anchor_sample,
+                    seq_name,
+                    seq_len,
+                    &alignments,
+                    &pool_intervals,
+                    config,
+                    separator,
+                );
+
+                Some(result)
+            })
+            .collect();
+
+        // Collect all windows from parallel processing
+        let mut all_windows: Vec<DepthWindow> = Vec::new();
+        for result in seq_results {
+            all_windows.extend(result.windows);
+        }
+
+        // Track regions output in this batch to prevent intra-batch overlaps
+        // Key: (sample, seq) -> IntervalSet of output regions
+        let mut batch_output: FxHashMap<(String, String), IntervalSet> = FxHashMap::default();
+        let mut regions_to_remove: Vec<(String, String, i64, i64)> = Vec::new();
+
+        for mut window in all_windows {
+            // Check each sample's region against:
+            // 1. The global pool (for inter-sample filtering)
+            // 2. The batch_output (for intra-batch overlap prevention)
+            let mut valid_positions: FxHashMap<String, (String, i64, i64)> =
+                FxHashMap::default();
+
+            for (sample, (seq, start, end)) in &window.haplotype_positions {
+                // First check global pool
+                let pool_overlaps = pool.get_overlap(sample, seq, *start, *end);
+                if pool_overlaps.is_empty() {
+                    continue;
+                }
+
+                // Get the largest overlap with pool
+                let (pool_start, pool_end) = pool_overlaps
+                    .iter()
+                    .max_by_key(|(s, e)| e - s)
+                    .copied()
+                    .unwrap();
+
+                // Then check if this region overlaps with already-output regions in this batch
+                let key = (sample.clone(), seq.clone());
+                let batch_overlaps = batch_output
+                    .get(&key)
+                    .map(|is| is.intersect(pool_start, pool_end))
+                    .unwrap_or_default();
+
+                if batch_overlaps.is_empty() {
+                    // No overlap with batch output, this region is valid
+                    valid_positions.insert(sample.clone(), (seq.clone(), pool_start, pool_end));
+                } else {
+                    // There's overlap - try to find a non-overlapping portion
+                    // Subtract batch_overlaps from [pool_start, pool_end]
+                    let mut remaining = vec![(pool_start, pool_end)];
+                    for (ov_start, ov_end) in batch_overlaps {
+                        let mut new_remaining = Vec::new();
+                        for (r_start, r_end) in remaining {
+                            if r_end <= ov_start || r_start >= ov_end {
+                                // No overlap
+                                new_remaining.push((r_start, r_end));
+                            } else {
+                                // Split around overlap
+                                if r_start < ov_start {
+                                    new_remaining.push((r_start, ov_start));
+                                }
+                                if r_end > ov_end {
+                                    new_remaining.push((ov_end, r_end));
+                                }
+                            }
+                        }
+                        remaining = new_remaining;
+                    }
+
+                    // Use the largest remaining interval if any
+                    if let Some(&(best_start, best_end)) =
+                        remaining.iter().max_by_key(|(s, e)| e - s)
+                    {
+                        if best_end > best_start {
+                            valid_positions
+                                .insert(sample.clone(), (seq.clone(), best_start, best_end));
+                        }
+                    }
+                }
+            }
+
+            // Skip window if no valid samples remain
+            if valid_positions.is_empty() {
+                continue;
+            }
+
+            // Update window with only valid positions
+            window.haplotype_positions = valid_positions;
+            window.depth = window.haplotype_positions.len();
+            window.window_id = global_window_id;
+            global_window_id += 1;
+
+            // Write window
+            write!(writer, "{}\t{}", window.window_id, window.depth)?;
+            for sample in &sample_order {
+                if let Some((seq, start, end)) = window.haplotype_positions.get(sample) {
+                    write!(writer, "\t{}:{}-{}", seq, start, end)?;
+                } else {
+                    write!(writer, "\tNA")?;
+                }
+            }
+            writeln!(writer)?;
+
+            // Record output regions for both batch tracking and pool update
+            for (sample, (seq, start, end)) in &window.haplotype_positions {
+                let key = (sample.clone(), seq.clone());
+                batch_output
+                    .entry(key)
+                    .or_default()
+                    .add(*start, *end);
+                regions_to_remove.push((sample.clone(), seq.clone(), *start, *end));
+            }
+        }
+
+        // Batch update pool at end
+        pool.subtract_batch(&regions_to_remove);
+
+        // Progress reporting
+        if (sample_idx + 1) % 10 == 0 || sample_idx + 1 == total_samples {
+            let remaining = pool.total_remaining_length();
+            let processed_pct =
+                100.0 * (1.0 - remaining as f64 / initial_pool_length as f64);
+            info!(
+                "  Progress: {}/{} samples, {:.1}% of genome covered",
+                sample_idx + 1,
+                total_samples,
+                processed_pct
+            );
+        }
+
+        // Early termination if pool is empty
+        if pool.is_empty() {
+            info!(
+                "  All regions covered after {} samples, stopping early",
+                sample_idx + 1
+            );
+            break;
+        }
+    }
+
+    // Phase 2: Fill remaining pool intervals with depth=1 (uncovered regions)
+    let remaining_length = pool.total_remaining_length();
+    if remaining_length > 0 {
+        let uncovered_pct = 100.0 * remaining_length as f64 / initial_pool_length as f64;
+        info!(
+            "Phase 2: Filling uncovered regions ({} bp, {:.2}%) with depth=1...",
+            remaining_length, uncovered_pct
+        );
+
+        let mut gap_windows = 0u64;
+        let mut gap_bp = 0i64;
+
+        // Output remaining pool intervals as depth=1
+        for sample in &sample_order {
+            let seqs = pool_seq_lengths.get_seqs_of_sample(sample);
+            for seq_name in seqs {
+                let remaining_intervals = pool.get_intervals(sample, seq_name);
+
+                for (gap_start, gap_end) in remaining_intervals {
+                    if gap_end <= gap_start {
+                        continue;
+                    }
+
+                    // Create depth=1 window with only this sample
+                    write!(writer, "{}\t1", global_window_id)?;
+                    for s in &sample_order {
+                        if s == sample {
+                            write!(writer, "\t{}:{}-{}", seq_name, gap_start, gap_end)?;
+                        } else {
+                            write!(writer, "\tNA")?;
+                        }
+                    }
+                    writeln!(writer)?;
+
+                    global_window_id += 1;
+                    gap_windows += 1;
+                    gap_bp += gap_end - gap_start;
+                }
+            }
+        }
+
+        info!(
+            "  Generated {} gap windows covering {} bp",
+            gap_windows, gap_bp
+        );
+    }
+
+    writer.flush()?;
+    info!("Output complete: {} windows generated", global_window_id);
+
+    Ok(())
+}
+
+// ============================================================================
+// Memory-efficient implementation using compressed bitmap coverage tracking
+// ============================================================================
+
+/// Resolution for bitmap coverage tracking (bp per bit)
+/// Lower value = more accurate but more memory
+/// 1bp: 3TB genome = 375GB (too much)
+/// 10bp: 3TB genome = 37.5GB (acceptable for most systems)
+/// For TB-scale data, recommend 10-100bp resolution
+const COVERAGE_RESOLUTION: i64 = 1;
+
+/// Compressed coverage tracker using BitVec
+/// Memory usage: ~375MB for 3TB genome @ 100bp resolution
+#[derive(Debug)]
+pub struct CompressedCoverageTracker {
+    /// (sample_idx, seq_idx) -> BitVec where each bit = COVERAGE_RESOLUTION bp
+    coverage: FxHashMap<(u16, u32), BitVec>,
+    /// Sequence lengths for bounds checking
+    seq_lengths: Vec<i64>,
+    /// Sample index mapping
+    sample_to_idx: FxHashMap<String, u16>,
+    /// Sequence index mapping
+    seq_to_idx: FxHashMap<String, u32>,
+    /// Reverse mappings for output (reserved for future use)
+    #[allow(dead_code)]
+    idx_to_sample: Vec<String>,
+    #[allow(dead_code)]
+    idx_to_seq: Vec<String>,
+}
+
+impl CompressedCoverageTracker {
+    /// Create a new coverage tracker from sequence lengths
+    pub fn new(seq_lengths_map: &SequenceLengths) -> Self {
+        let mut sample_to_idx = FxHashMap::default();
+        let mut seq_to_idx = FxHashMap::default();
+        let mut idx_to_sample = Vec::new();
+        let mut idx_to_seq = Vec::new();
+        let mut seq_lengths = Vec::new();
+
+        // Build sample index
+        let mut samples: Vec<_> = seq_lengths_map.sample_to_seqs.keys().collect();
+        samples.sort();
+        for (i, sample) in samples.iter().enumerate() {
+            sample_to_idx.insert((*sample).clone(), i as u16);
+            idx_to_sample.push((*sample).clone());
+        }
+
+        // Build sequence index
+        let mut seqs: Vec<_> = seq_lengths_map.lengths.keys().collect();
+        seqs.sort();
+        for (i, seq) in seqs.iter().enumerate() {
+            seq_to_idx.insert((*seq).clone(), i as u32);
+            idx_to_seq.push((*seq).clone());
+            seq_lengths.push(*seq_lengths_map.lengths.get(*seq).unwrap_or(&0));
+        }
+
+        // Initialize coverage bitmaps (all zeros = uncovered)
+        let mut coverage = FxHashMap::default();
+        for (seq_name, &length) in &seq_lengths_map.lengths {
+            let sample = seq_lengths_map.seq_to_sample.get(seq_name).unwrap();
+            if let (Some(&sample_idx), Some(&seq_idx)) = (
+                sample_to_idx.get(sample),
+                seq_to_idx.get(seq_name.as_str()),
+            ) {
+                let num_bits = ((length + COVERAGE_RESOLUTION - 1) / COVERAGE_RESOLUTION) as usize;
+                coverage.insert((sample_idx, seq_idx), bitvec![0; num_bits]);
+            }
+        }
+
+        CompressedCoverageTracker {
+            coverage,
+            seq_lengths,
+            sample_to_idx,
+            seq_to_idx,
+            idx_to_sample,
+            idx_to_seq,
+        }
+    }
+
+    /// Convert position to bit index
+    #[inline]
+    fn pos_to_bit(pos: i64) -> usize {
+        (pos / COVERAGE_RESOLUTION) as usize
+    }
+
+    /// Convert bit index to position range
+    #[inline]
+    fn bit_to_pos_range(bit_idx: usize) -> (i64, i64) {
+        let start = bit_idx as i64 * COVERAGE_RESOLUTION;
+        (start, start + COVERAGE_RESOLUTION)
+    }
+
+    /// Check if any portion of [start, end) is uncovered
+    pub fn has_uncovered(&self, sample: &str, seq: &str, start: i64, end: i64) -> bool {
+        let sample_idx = match self.sample_to_idx.get(sample) {
+            Some(&idx) => idx,
+            None => return false,
+        };
+        let seq_idx = match self.seq_to_idx.get(seq) {
+            Some(&idx) => idx,
+            None => return false,
+        };
+
+        if let Some(bits) = self.coverage.get(&(sample_idx, seq_idx)) {
+            let start_bit = Self::pos_to_bit(start);
+            let end_bit = Self::pos_to_bit(end.saturating_sub(1)).min(bits.len().saturating_sub(1));
+
+            for bit_idx in start_bit..=end_bit {
+                if bit_idx < bits.len() && !bits[bit_idx] {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Get uncovered intervals within [start, end)
+    /// Returns merged intervals of uncovered regions
+    pub fn get_uncovered_intervals(
+        &self,
+        sample: &str,
+        seq: &str,
+        start: i64,
+        end: i64,
+    ) -> Vec<(i64, i64)> {
+        let sample_idx = match self.sample_to_idx.get(sample) {
+            Some(&idx) => idx,
+            None => return vec![(start, end)],
+        };
+        let seq_idx = match self.seq_to_idx.get(seq) {
+            Some(&idx) => idx,
+            None => return vec![(start, end)],
+        };
+
+        let bits = match self.coverage.get(&(sample_idx, seq_idx)) {
+            Some(b) => b,
+            None => return vec![(start, end)],
+        };
+
+        let seq_len = self.seq_lengths.get(seq_idx as usize).copied().unwrap_or(end);
+        let clamped_end = end.min(seq_len);
+
+        let start_bit = Self::pos_to_bit(start);
+        let end_bit = Self::pos_to_bit(clamped_end.saturating_sub(1));
+
+        let mut result = Vec::new();
+        let mut current_start: Option<i64> = None;
+
+        for bit_idx in start_bit..=end_bit {
+            if bit_idx >= bits.len() {
+                break;
+            }
+
+            let (bit_start, bit_end) = Self::bit_to_pos_range(bit_idx);
+            let interval_start = bit_start.max(start);
+            let _interval_end = bit_end.min(clamped_end);
+
+            if !bits[bit_idx] {
+                // Uncovered
+                if current_start.is_none() {
+                    current_start = Some(interval_start);
+                }
+            } else {
+                // Covered - close current interval if open
+                if let Some(s) = current_start {
+                    result.push((s, interval_start));
+                    current_start = None;
+                }
+            }
+        }
+
+        // Close final interval
+        if let Some(s) = current_start {
+            result.push((s, clamped_end));
+        }
+
+        result
+    }
+
+    /// Mark region [start, end) as covered
+    pub fn mark_covered(&mut self, sample: &str, seq: &str, start: i64, end: i64) {
+        let sample_idx = match self.sample_to_idx.get(sample) {
+            Some(&idx) => idx,
+            None => return,
+        };
+        let seq_idx = match self.seq_to_idx.get(seq) {
+            Some(&idx) => idx,
+            None => return,
+        };
+
+        if let Some(bits) = self.coverage.get_mut(&(sample_idx, seq_idx)) {
+            let start_bit = Self::pos_to_bit(start);
+            let end_bit = Self::pos_to_bit(end.saturating_sub(1));
+
+            for bit_idx in start_bit..=end_bit {
+                if bit_idx < bits.len() {
+                    bits.set(bit_idx, true);
+                }
+            }
+        }
+    }
+
+    /// Get all uncovered intervals for a (sample, seq) pair
+    pub fn get_all_uncovered(&self, sample: &str, seq: &str) -> Vec<(i64, i64)> {
+        let sample_idx = match self.sample_to_idx.get(sample) {
+            Some(&idx) => idx,
+            None => return Vec::new(),
+        };
+        let seq_idx = match self.seq_to_idx.get(seq) {
+            Some(&idx) => idx,
+            None => return Vec::new(),
+        };
+
+        let bits = match self.coverage.get(&(sample_idx, seq_idx)) {
+            Some(b) => b,
+            None => return Vec::new(),
+        };
+
+        let seq_len = self.seq_lengths.get(seq_idx as usize).copied().unwrap_or(0);
+
+        let mut result = Vec::new();
+        let mut current_start: Option<i64> = None;
+
+        for (bit_idx, bit) in bits.iter().enumerate() {
+            let (bit_start, bit_end) = Self::bit_to_pos_range(bit_idx);
+            let _interval_end = bit_end.min(seq_len);
+
+            if !*bit {
+                if current_start.is_none() {
+                    current_start = Some(bit_start);
+                }
+            } else if let Some(s) = current_start {
+                result.push((s, bit_start));
+                current_start = None;
+            }
+        }
+
+        if let Some(s) = current_start {
+            result.push((s, seq_len));
+        }
+
+        result
+    }
+
+    /// Get total uncovered length
+    pub fn total_uncovered_length(&self) -> i64 {
+        let mut total = 0i64;
+
+        for ((_sample_idx, seq_idx), bits) in &self.coverage {
+            let seq_len = self.seq_lengths.get(*seq_idx as usize).copied().unwrap_or(0);
+
+            for (bit_idx, bit) in bits.iter().enumerate() {
+                if !*bit {
+                    let (bit_start, bit_end) = Self::bit_to_pos_range(bit_idx);
+                    let interval_len = bit_end.min(seq_len) - bit_start;
+                    if interval_len > 0 {
+                        total += interval_len;
+                    }
+                }
+            }
+        }
+
+        total
+    }
+
+    /// Get memory usage estimate in bytes
+    pub fn memory_usage(&self) -> usize {
+        let mut total = 0;
+        for (_, bits) in &self.coverage {
+            total += bits.len() / 8 + 1;
+        }
+        total
+    }
+}
+
+/// Memory-efficient depth computation using compressed bitmap
+///
+/// Key improvements over compute_depth_by_sample:
+/// 1. Uses BitVec instead of IntervalSet (memory: ~50GB -> ~500MB)
+/// 2. No pre-built reverse index (memory: ~30GB -> 0)
+/// 3. Streaming output (no batch accumulation)
+///
+/// When `ref_sample` is specified (targeted mode), only computes depth for the specified
+/// sample's sequences as reference. When `ref_sample` is None (global mode), computes
+/// depth for all sequences.
+pub fn compute_depth_by_sample_v2(
+    impg: &Impg,
+    config: &DepthConfig,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+    separator: &str,
+    output_prefix: Option<&str>,
+    fai_list: Option<&str>,
+    ref_sample: Option<&str>,
+) -> io::Result<()> {
+    if let Some(ref_name) = ref_sample {
+        info!("Computing depth coverage (memory-efficient mode v2, targeted for sample: {})", ref_name);
+    } else {
+        info!("Computing depth coverage (memory-efficient mode v2, global mode)");
+    }
+
+    // Phase 0: Build sequence lengths
+    info!("Phase 0: Building indices...");
+
+    let seq_lengths = SequenceLengths::from_impg(impg, separator);
+    info!(
+        "  Found {} samples, {} sequences in alignments",
+        seq_lengths.sample_to_seqs.len(),
+        seq_lengths.lengths.len()
+    );
+
+    // Use FAI files for pool if provided
+    let pool_seq_lengths = if let Some(fai_path) = fai_list {
+        info!("  Loading sequence lengths from FAI files...");
+        let fai_seq_lengths = SequenceLengths::from_fai_list(fai_path, separator)?;
+        info!(
+            "  FAI: {} samples, {} sequences",
+            fai_seq_lengths.sample_to_seqs.len(),
+            fai_seq_lengths.lengths.len()
+        );
+        fai_seq_lengths
+    } else {
+        seq_lengths.clone()
+    };
+
+    // Initialize compressed coverage tracker
+    let mut coverage = CompressedCoverageTracker::new(&pool_seq_lengths);
+    info!(
+        "  Coverage tracker initialized: {} bytes",
+        coverage.memory_usage()
+    );
+
+    let initial_uncovered = coverage.total_uncovered_length();
+    info!("  Total genome size: {} bp", initial_uncovered);
+
+    // Sample processing order
+    let sample_order = pool_seq_lengths.get_samples();
+    info!("  Sample order: {:?}", sample_order);
+
+    // Validate ref_sample if specified (targeted mode)
+    if let Some(ref_name) = ref_sample {
+        if !sample_order.contains(&ref_name.to_string()) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Reference sample '{}' not found. Available samples: {:?}",
+                    ref_name, sample_order
+                ),
+            ));
+        }
+        info!("  Targeted mode: only processing sequences from sample '{}'", ref_name);
+    }
+
+    // Build lightweight reverse index only for global mode
+    // For --ref mode, skip this expensive step to save memory
+    let query_to_targets = if ref_sample.is_none() {
+        info!("  Building lightweight reverse index (global mode)...");
+        let map = impg.build_query_to_targets_map();
+        info!(
+            "  Reverse index built: {} query sequences mapped",
+            map.len()
+        );
+        Some(map)
+    } else {
+        info!("  Skipping reverse index (targeted mode - using forward queries only)");
+        None
+    };
+
+    // Prepare output
+    let writer: Box<dyn Write> = if let Some(prefix) = output_prefix {
+        let path = format!("{}.depth.tsv", prefix);
+        Box::new(BufWriter::new(std::fs::File::create(&path)?))
+    } else {
+        Box::new(BufWriter::new(std::io::stdout()))
+    };
+    let mut writer = BufWriter::new(writer);
+
+    // Write header
+    write!(writer, "window_id\tdepth")?;
+    for sample in &sample_order {
+        write!(writer, "\t{}", sample)?;
+    }
+    writeln!(writer)?;
+
+    let mut global_window_id: usize = 0;
+    let total_samples = sample_order.len();
+
+    // Phase 1: Process each sample as anchor
+    info!("Phase 1: Processing {} samples...", total_samples);
+
+    for (sample_idx, anchor_sample) in sample_order.iter().enumerate() {
+        // In targeted mode, only process the specified reference sample
+        if let Some(ref_name) = ref_sample {
+            if anchor_sample != ref_name {
+                continue;
+            }
+        }
+
+        let seqs = seq_lengths.get_seqs_of_sample(anchor_sample);
+
+        debug!(
+            "Processing sample {}/{}: {} ({} sequences)",
+            sample_idx + 1,
+            total_samples,
+            anchor_sample,
+            seqs.len()
+        );
+
+        // Process each sequence of this sample
+        for anchor_seq in seqs {
+            let seq_id = match impg.seq_index.get_id(anchor_seq) {
+                Some(id) => id,
+                None => continue,
+            };
+            let seq_len = impg.seq_index.get_len_from_id(seq_id).unwrap_or(0) as i64;
+
+            // Check if there are any uncovered regions for this sequence
+            let uncovered = coverage.get_all_uncovered(anchor_sample, anchor_seq);
+            if uncovered.is_empty() {
+                continue;
+            }
+
+            // Collect forward alignments (anchor_seq as target)
+            let overlaps = if config.transitive {
+                if config.transitive_dfs {
+                    impg.query_transitive_dfs(
+                        seq_id, 0, seq_len as i32, None,
+                        config.max_depth, config.min_transitive_len,
+                        config.min_distance_between_ranges, None, false, None,
+                        sequence_index, config.approximate_mode, None,
+                    )
+                } else {
+                    impg.query_transitive_bfs(
+                        seq_id, 0, seq_len as i32, None,
+                        config.max_depth, config.min_transitive_len,
+                        config.min_distance_between_ranges, None, false, None,
+                        sequence_index, config.approximate_mode, None,
+                    )
+                }
+            } else {
+                impg.query(seq_id, 0, seq_len as i32, false, None, sequence_index, config.approximate_mode)
+            };
+
+            // Collect reverse alignments (anchor_seq as query) using pre-built index
+            // Skip in targeted mode (--ref) to save memory - forward queries capture most coverage
+            let reverse_alignments = if let Some(ref map) = query_to_targets {
+                impg.query_reverse_for_depth_with_map(seq_id, map)
+            } else {
+                Vec::new() // Skip reverse queries in targeted mode
+            };
+
+            // Build alignment info list
+            let mut all_alignments: Vec<SampleAlignmentInfo> = Vec::new();
+
+            // Add self
+            all_alignments.push(SampleAlignmentInfo {
+                sample: anchor_sample.clone(),
+                query_name: anchor_seq.clone(),
+                query_start: 0,
+                query_end: seq_len,
+                target_start: 0,
+                target_end: seq_len,
+                is_reverse: false,
+                cigar: Vec::new(),
+            });
+
+            // Forward alignments
+            for overlap in &overlaps {
+                let query_interval = &overlap.0;
+                let target_interval = &overlap.2;
+
+                let query_name = match impg.seq_index.get_name(query_interval.metadata) {
+                    Some(name) => name,
+                    None => continue,
+                };
+                let sample = extract_sample(query_name, separator);
+
+                let is_reverse = query_interval.first > query_interval.last;
+                let query_start = query_interval.first.min(query_interval.last) as i64;
+                let query_end = query_interval.first.max(query_interval.last) as i64;
+                let target_start = target_interval.first.min(target_interval.last) as i64;
+                let target_end = target_interval.first.max(target_interval.last) as i64;
+
+                all_alignments.push(SampleAlignmentInfo {
+                    sample,
+                    query_name: query_name.to_string(),
+                    query_start,
+                    query_end,
+                    target_start,
+                    target_end,
+                    is_reverse,
+                    cigar: Vec::new(),
+                });
+            }
+
+            // Reverse alignments
+            for &(ref_start, ref_end, target_id) in &reverse_alignments {
+                if let Some(target_name) = impg.seq_index.get_name(target_id) {
+                    let sample = extract_sample(target_name, separator);
+                    if sample == *anchor_sample {
+                        continue;
+                    }
+
+                    all_alignments.push(SampleAlignmentInfo {
+                        sample,
+                        query_name: target_name.to_string(),
+                        query_start: ref_start as i64,
+                        query_end: ref_end as i64,
+                        target_start: ref_start as i64,
+                        target_end: ref_end as i64,
+                        is_reverse: false,
+                        cigar: Vec::new(),
+                    });
+                }
+            }
+
+            // Build sweep-line events
+            let mut events: Vec<DepthEvent> = Vec::new();
+            for (idx, aln) in all_alignments.iter().enumerate() {
+                events.push(DepthEvent {
+                    position: aln.target_start,
+                    is_start: true,
+                    haplotype: aln.sample.clone(),
+                    alignment_idx: idx,
+                });
+                events.push(DepthEvent {
+                    position: aln.target_end,
+                    is_start: false,
+                    haplotype: aln.sample.clone(),
+                    alignment_idx: idx,
+                });
+            }
+            events.sort();
+
+            // Sweep-line to generate windows and output immediately
+            let mut active_alignments: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+            let mut prev_pos: Option<i64> = None;
+
+            for event in events {
+                if let Some(prev) = prev_pos {
+                    if event.position > prev {
+                        // Check if this window overlaps any uncovered region
+                        let window_start = prev;
+                        let window_end = event.position;
+
+                        // Get active samples
+                        let active_samples: Vec<&String> = active_alignments
+                            .iter()
+                            .filter(|(_, alns)| !alns.is_empty())
+                            .map(|(s, _)| s)
+                            .collect();
+
+                        if !active_samples.is_empty() {
+                            // Build sample positions for this window
+                            let mut sample_positions: FxHashMap<String, (String, i64, i64)> =
+                                FxHashMap::default();
+
+                            for sample in &active_samples {
+                                if let Some(aln_indices) = active_alignments.get(*sample) {
+                                    if let Some(&best_idx) = aln_indices.iter().max_by_key(|&&idx| {
+                                        let aln = &all_alignments[idx];
+                                        let overlap_start = prev.max(aln.target_start);
+                                        let overlap_end = event.position.min(aln.target_end);
+                                        overlap_end - overlap_start
+                                    }) {
+                                        let aln = &all_alignments[best_idx];
+                                        let (q_start, q_end) = map_target_to_query_linear(
+                                            &aln.cigar,
+                                            aln.target_start, aln.target_end,
+                                            aln.query_start, aln.query_end,
+                                            window_start, window_end,
+                                            aln.is_reverse,
+                                        );
+                                        sample_positions.insert(
+                                            (*sample).clone(),
+                                            (aln.query_name.clone(), q_start, q_end),
+                                        );
+                                    }
+                                }
+                            }
+
+                            // Filter: only output samples with uncovered regions
+                            let mut valid_positions: FxHashMap<String, (String, i64, i64)> =
+                                FxHashMap::default();
+
+                            for (sample, (seq, start, end)) in &sample_positions {
+                                // Check if this sample has uncovered region
+                                let uncovered_parts =
+                                    coverage.get_uncovered_intervals(sample, seq, *start, *end);
+
+                                if !uncovered_parts.is_empty() {
+                                    // Use the largest uncovered portion
+                                    if let Some(&(unc_start, unc_end)) = uncovered_parts
+                                        .iter()
+                                        .max_by_key(|(s, e)| e - s)
+                                    {
+                                        valid_positions.insert(
+                                            sample.clone(),
+                                            (seq.clone(), unc_start, unc_end),
+                                        );
+                                    }
+                                }
+                            }
+
+                            // Output if any valid samples
+                            if !valid_positions.is_empty() {
+                                let depth = valid_positions.len();
+
+                                write!(writer, "{}\t{}", global_window_id, depth)?;
+                                for sample in &sample_order {
+                                    if let Some((seq, start, end)) = valid_positions.get(sample) {
+                                        write!(writer, "\t{}:{}-{}", seq, start, end)?;
+                                    } else {
+                                        write!(writer, "\tNA")?;
+                                    }
+                                }
+                                writeln!(writer)?;
+                                global_window_id += 1;
+
+                                // Mark as covered
+                                for (sample, (seq, start, end)) in &valid_positions {
+                                    coverage.mark_covered(sample, seq, *start, *end);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Update active alignments
+                if event.is_start {
+                    active_alignments
+                        .entry(event.haplotype.clone())
+                        .or_default()
+                        .push(event.alignment_idx);
+                } else if let Some(alns) = active_alignments.get_mut(&event.haplotype) {
+                    alns.retain(|&idx| idx != event.alignment_idx);
+                }
+
+                prev_pos = Some(event.position);
+            }
+        }
+
+        // Progress reporting (every 10 samples or at the end)
+        if (sample_idx + 1) % 10 == 0 || sample_idx + 1 == total_samples {
+            let remaining = coverage.total_uncovered_length();
+            let covered_pct = 100.0 * (1.0 - remaining as f64 / initial_uncovered as f64);
+            info!(
+                "  Progress: {}/{} samples, {:.1}% covered, {} windows, {} cached trees",
+                sample_idx + 1,
+                total_samples,
+                covered_pct,
+                global_window_id,
+                impg.cached_tree_count()
+            );
+        }
+
+        // Clear tree cache after processing each sample to control memory usage
+        // Trees will be reloaded from disk as needed for subsequent samples
+        impg.clear_tree_cache();
+    }
+
+    // Phase 2: Output uncovered regions as depth=1
+    let final_uncovered = coverage.total_uncovered_length();
+    if final_uncovered > 0 {
+        let uncovered_pct = 100.0 * final_uncovered as f64 / initial_uncovered as f64;
+        info!(
+            "Phase 2: Outputting uncovered regions ({} bp, {:.2}%) as depth=1...",
+            final_uncovered, uncovered_pct
+        );
+
+        let mut gap_count = 0u64;
+
+        for sample in &sample_order {
+            let seqs = pool_seq_lengths.get_seqs_of_sample(sample);
+            for seq_name in seqs {
+                let uncovered = coverage.get_all_uncovered(sample, seq_name);
+                for (gap_start, gap_end) in uncovered {
+                    if gap_end <= gap_start {
+                        continue;
+                    }
+
+                    write!(writer, "{}\t1", global_window_id)?;
+                    for s in &sample_order {
+                        if s == sample {
+                            write!(writer, "\t{}:{}-{}", seq_name, gap_start, gap_end)?;
+                        } else {
+                            write!(writer, "\tNA")?;
+                        }
+                    }
+                    writeln!(writer)?;
+
+                    global_window_id += 1;
+                    gap_count += 1;
+                }
+            }
+        }
+
+        info!("  Generated {} gap windows", gap_count);
+    }
+
+    writer.flush()?;
+    info!(
+        "Output complete: {} windows, memory tracker: {} bytes",
+        global_window_id,
+        coverage.memory_usage()
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Streaming depth computation - memory efficient for large datasets
+// ============================================================================
+
+/// Coverage entry storing both reference and query coordinates
+#[derive(Debug, Clone)]
+struct CoverageEntry {
+    sample: String,
+    query_seq: String,
+    ref_start: i64,
+    ref_end: i64,
+    query_start: i64,
+    query_end: i64,
+    is_reverse: bool, // true if query is on reverse strand relative to ref
+}
+
+/// Streaming depth computation that iterates through index without loading all trees.
+/// Memory usage is O(ref_genome_size × num_samples) instead of O(total_alignments).
+///
+/// Key insight: We load one tree at a time, extract coverage info, then release it.
+/// Uses parallel processing for scanning trees.
+pub fn compute_depth_streaming(
+    impg: &Impg,
+    ref_sample: &str,
+    separator: &str,
+    output_prefix: Option<&str>,
+    merge_adjacent: bool,
+    fai_list: Option<&str>,
+) -> io::Result<()> {
+    info!(
+        "Computing depth (streaming mode) for reference sample: {}",
+        ref_sample
+    );
+
+    // Phase 1: Identify reference sequences and collect all samples
+    info!("Phase 1: Identifying reference sequences...");
+
+    let seq_lengths = SequenceLengths::from_impg(impg, separator);
+    let all_samples = seq_lengths.get_samples();
+
+    // Get reference sequence IDs
+    let ref_seq_ids: Vec<(u32, String, i64)> = (0..impg.seq_index.len() as u32)
+        .filter_map(|id| {
+            let name = impg.seq_index.get_name(id)?;
+            let sample = extract_sample(name, separator);
+            if sample == ref_sample {
+                let len = impg.seq_index.get_len_from_id(id)? as i64;
+                Some((id, name.to_string(), len))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if ref_seq_ids.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("No sequences found for reference sample '{}'", ref_sample),
+        ));
+    }
+
+    // If FAI list provided, use it to get complete sequence lengths
+    let ref_seq_lengths: FxHashMap<String, i64> = if let Some(fai_path) = fai_list {
+        info!("  Loading sequence lengths from FAI files...");
+        let fai_lengths = load_fai_lengths_for_sample(fai_path, ref_sample, separator)?;
+        info!("  Loaded {} sequences from FAI", fai_lengths.len());
+        fai_lengths
+    } else {
+        ref_seq_ids.iter().map(|(_, name, len)| (name.clone(), *len)).collect()
+    };
+
+    info!(
+        "  Found {} reference sequences, {} total samples",
+        ref_seq_ids.len(),
+        all_samples.len()
+    );
+
+    // Phase 2: Parallel scan of index to accumulate coverage
+    info!("Phase 2: Scanning index for coverage (parallel)...");
+
+    // Create a set of reference sequence IDs for quick lookup
+    let ref_id_set: FxHashSet<u32> = ref_seq_ids.iter().map(|(id, _, _)| *id).collect();
+    let ref_id_to_name: FxHashMap<u32, String> = ref_seq_ids.iter().map(|(id, name, _)| (*id, name.clone())).collect();
+
+    // Get all target IDs from forest map
+    let all_target_ids: Vec<u32> = impg.get_all_target_ids();
+    let total_trees = all_target_ids.len();
+    info!(
+        "  Processing {} trees in parallel with {} threads...",
+        total_trees,
+        rayon::current_num_threads()
+    );
+
+    // Progress tracking for Phase 2
+    let processed_trees = AtomicUsize::new(0);
+
+    // Parallel processing: each target_id is processed independently
+    let parallel_results: Vec<(FxHashMap<String, Vec<CoverageEntry>>, u64)> = all_target_ids
+        .par_iter()
+        .map(|&target_id| {
+            let mut local_coverage: FxHashMap<String, Vec<CoverageEntry>> = FxHashMap::default();
+            let mut local_alignments = 0u64;
+
+            // Progress logging every 1000 trees
+            let count = processed_trees.fetch_add(1, Ordering::Relaxed);
+            if count % 1000 == 0 || count < 10 {
+                debug!(
+                    "    Progress: {}/{} trees (thread {:?})",
+                    count,
+                    total_trees,
+                    std::thread::current().id()
+                );
+            }
+
+            {
+                let target_name = match impg.seq_index.get_name(target_id) {
+                    Some(n) => n.to_string(),
+                    None => return (local_coverage, local_alignments),
+                };
+                let target_sample = extract_sample(&target_name, separator);
+                let target_is_ref = ref_id_set.contains(&target_id);
+
+                // Load tree without caching (avoids write lock contention in parallel)
+                let tree = match impg.load_tree_no_cache(target_id) {
+                    Some(t) => t,
+                    None => return (local_coverage, local_alignments),
+                };
+
+                // Iterate through all alignments in this tree
+                for interval in tree.iter() {
+                    let query_id = interval.metadata.query_id();
+                    let query_name = match impg.seq_index.get_name(query_id) {
+                        Some(n) => n.to_string(),
+                        None => continue,
+                    };
+                    let query_sample = extract_sample(&query_name, separator);
+
+                    let target_start = interval.first as i64;
+                    let target_end = interval.last as i64;
+                    let is_reverse = interval.metadata.query_start() > interval.metadata.query_end();
+                    let query_start = interval.metadata.query_start().min(interval.metadata.query_end()) as i64;
+                    let query_end = interval.metadata.query_start().max(interval.metadata.query_end()) as i64;
+
+                    // Case 1: target is reference -> query sample covers target region
+                    if target_is_ref {
+                        local_coverage
+                            .entry(target_name.clone())
+                            .or_default()
+                            .push(CoverageEntry {
+                                sample: query_sample.clone(),
+                                query_seq: query_name.clone(),
+                                ref_start: target_start,
+                                ref_end: target_end,
+                                query_start,
+                                query_end,
+                                is_reverse,
+                            });
+                        local_alignments += 1;
+                    }
+
+                    // Case 2: query is reference -> target sample covers query region
+                    if ref_id_set.contains(&query_id) {
+                        if let Some(ref_name) = ref_id_to_name.get(&query_id) {
+                            local_coverage
+                                .entry(ref_name.clone())
+                                .or_default()
+                                .push(CoverageEntry {
+                                    sample: target_sample.clone(),
+                                    query_seq: target_name.clone(),
+                                    ref_start: query_start,
+                                    ref_end: query_end,
+                                    query_start: target_start,
+                                    query_end: target_end,
+                                    is_reverse,
+                                });
+                            local_alignments += 1;
+                        }
+                    }
+                }
+            }
+
+            (local_coverage, local_alignments)
+        })
+        .collect();
+
+    // Note: No need to clear tree cache since load_tree_no_cache doesn't cache
+
+    // Merge results from all threads
+    let mut coverage: FxHashMap<String, Vec<CoverageEntry>> = FxHashMap::default();
+    for (_, name, _) in &ref_seq_ids {
+        coverage.insert(name.clone(), Vec::new());
+    }
+
+    let mut alignments_found = 0u64;
+    for (local_coverage, local_alignments) in parallel_results {
+        alignments_found += local_alignments;
+        for (ref_seq, entries) in local_coverage {
+            coverage
+                .entry(ref_seq)
+                .or_default()
+                .extend(entries);
+        }
+    }
+
+    info!(
+        "  Processed {} trees, found {} relevant alignments",
+        total_trees, alignments_found
+    );
+
+    // Add self-coverage for reference sample
+    for (ref_seq, seq_len) in &ref_seq_lengths {
+        if let Some(entries) = coverage.get_mut(ref_seq) {
+            entries.push(CoverageEntry {
+                sample: ref_sample.to_string(),
+                query_seq: ref_seq.clone(),
+                ref_start: 0,
+                ref_end: *seq_len,
+                query_start: 0,
+                query_end: *seq_len,
+                is_reverse: false, // self-coverage is always forward
+            });
+        }
+    }
+
+    // Phase 3: Generate depth output using sweep-line (parallel with chunking)
+    info!("Phase 3: Generating depth output (parallel)...");
+
+    // Sort samples for consistent output, with reference sample first
+    let mut sample_order: Vec<String> = all_samples;
+    sample_order.sort_by(|a, b| {
+        // Reference sample comes first
+        if a == ref_sample {
+            std::cmp::Ordering::Less
+        } else if b == ref_sample {
+            std::cmp::Ordering::Greater
+        } else {
+            a.cmp(b)
+        }
+    });
+
+    // Sort reference sequences for consistent output
+    let mut ref_seq_list: Vec<(String, i64)> = ref_seq_lengths.into_iter().collect();
+    ref_seq_list.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Chunk size for parallel processing (10MB)
+    const CHUNK_SIZE: i64 = 10_000_000;
+
+    // Build list of all chunks across all reference sequences
+    // Each chunk is (ref_seq_idx, chunk_idx, chunk_start, chunk_end)
+    let mut all_chunks: Vec<(usize, usize, i64, i64)> = Vec::new();
+    for (ref_idx, (_, seq_len)) in ref_seq_list.iter().enumerate() {
+        let num_chunks = ((*seq_len + CHUNK_SIZE - 1) / CHUNK_SIZE) as usize;
+        for chunk_idx in 0..num_chunks {
+            let chunk_start = (chunk_idx as i64) * CHUNK_SIZE;
+            let chunk_end = ((chunk_idx as i64 + 1) * CHUNK_SIZE).min(*seq_len);
+            all_chunks.push((ref_idx, chunk_idx, chunk_start, chunk_end));
+        }
+    }
+
+    info!(
+        "  Processing {} chunks across {} sequences with {} threads",
+        all_chunks.len(),
+        ref_seq_list.len(),
+        rayon::current_num_threads()
+    );
+
+    // Create temp directory for parallel output files
+    let temp_dir = tempfile::tempdir()?;
+    let temp_dir_path = temp_dir.path().to_path_buf();
+
+    // Parallel processing: each chunk writes to its own temp file
+    // Returns (ref_seq_idx, chunk_idx, temp_file_path, window_count)
+    let processed_chunks = AtomicUsize::new(0);
+    let total_chunks = all_chunks.len();
+
+    let chunk_results: Vec<(usize, usize, std::path::PathBuf, usize)> = all_chunks
+        .par_iter()
+        .map(|&(ref_idx, chunk_idx, chunk_start, chunk_end)| {
+            let temp_path = temp_dir_path.join(format!("depth_{:06}_{:06}.tmp", ref_idx, chunk_idx));
+            let mut window_count = 0usize;
+
+            let (ref_seq, seq_len) = &ref_seq_list[ref_idx];
+
+            // Progress logging every 100 chunks
+            let count = processed_chunks.fetch_add(1, Ordering::Relaxed);
+            if count % 100 == 0 || count < 10 {
+                debug!(
+                    "    Progress: {}/{} chunks (thread {:?})",
+                    count,
+                    total_chunks,
+                    std::thread::current().id()
+                );
+            }
+            let entries = match coverage.get(ref_seq) {
+                Some(e) => e,
+                None => return (ref_idx, chunk_idx, temp_path, 0),
+            };
+
+            if entries.is_empty() {
+                return (ref_idx, chunk_idx, temp_path, 0);
+            }
+
+            // Find entries that overlap this chunk
+            let chunk_entries: Vec<(usize, &CoverageEntry)> = entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| e.ref_start < chunk_end && e.ref_end > chunk_start)
+                .collect();
+
+            if chunk_entries.is_empty() {
+                // No coverage in this chunk - output self-coverage only if this is part of ref
+                let file = match std::fs::File::create(&temp_path) {
+                    Ok(f) => f,
+                    Err(_) => return (ref_idx, chunk_idx, temp_path, 0),
+                };
+                let mut temp_writer = std::io::BufWriter::new(file);
+
+                // Output uncovered region with depth=1 (self only)
+                let _ = write!(temp_writer, "1");
+                for s in &sample_order {
+                    if s == ref_sample {
+                        let _ = write!(temp_writer, "\t{}:{}-{}", ref_seq, chunk_start, chunk_end);
+                    } else {
+                        let _ = write!(temp_writer, "\tNA");
+                    }
+                }
+                let _ = writeln!(temp_writer);
+                let _ = temp_writer.flush();
+                return (ref_idx, chunk_idx, temp_path, 1);
+            }
+
+            // Create temp file writer
+            let file = match std::fs::File::create(&temp_path) {
+                Ok(f) => f,
+                Err(_) => return (ref_idx, chunk_idx, temp_path, 0),
+            };
+            let mut temp_writer = std::io::BufWriter::new(file);
+
+            // Build sweep-line events for this chunk
+            // Include events at chunk boundaries for entries that span the boundary
+            let mut events: Vec<(i64, bool, usize)> = Vec::new();
+            for &(orig_idx, entry) in &chunk_entries {
+                // Event for entry start (or chunk start if entry started earlier)
+                let effective_start = entry.ref_start.max(chunk_start);
+                // Event for entry end (or chunk end if entry extends beyond)
+                let effective_end = entry.ref_end.min(chunk_end);
+
+                if effective_start < effective_end {
+                    events.push((effective_start, true, orig_idx));
+                    events.push((effective_end, false, orig_idx));
+                }
+            }
+
+            // Sort events: by position, then ends before starts at same position
+            events.sort_by(|a, b| {
+                a.0.cmp(&b.0)
+                    .then_with(|| a.1.cmp(&b.1))
+            });
+
+            // Sweep-line processing
+            let mut active_entries: FxHashMap<String, usize> = FxHashMap::default();
+            let mut prev_pos: Option<i64> = None;
+            let mut prev_active: Option<FxHashMap<String, usize>> = None;
+
+            for (pos, is_start, entry_idx) in events {
+                if let Some(prev) = prev_pos {
+                    if pos > prev && !active_entries.is_empty() {
+                        let should_output = if merge_adjacent {
+                            match &prev_active {
+                                Some(pa) => {
+                                    pa.len() != active_entries.len()
+                                    || !pa.keys().all(|k| active_entries.contains_key(k))
+                                }
+                                None => true,
+                            }
+                        } else {
+                            true
+                        };
+
+                        if should_output {
+                            let depth = active_entries.len();
+                            let _ = write!(temp_writer, "{}", depth);
+
+                            for s in &sample_order {
+                                if let Some(&eidx) = active_entries.get(s) {
+                                    let entry = &entries[eidx];
+                                    let ref_len = entry.ref_end - entry.ref_start;
+                                    let query_len = entry.query_end - entry.query_start;
+
+                                    let window_ref_start = prev.max(entry.ref_start);
+                                    let window_ref_end = pos.min(entry.ref_end);
+
+                                    let ratio_start = if ref_len > 0 {
+                                        (window_ref_start - entry.ref_start) as f64 / ref_len as f64
+                                    } else {
+                                        0.0
+                                    };
+                                    let ratio_end = if ref_len > 0 {
+                                        (window_ref_end - entry.ref_start) as f64 / ref_len as f64
+                                    } else {
+                                        1.0
+                                    };
+
+                                    let (wqs, wqe) = if entry.is_reverse {
+                                        // Reverse strand: moving forward in ref means moving backward in query
+                                        let s = entry.query_end - (query_len as f64 * ratio_start) as i64;
+                                        let e = entry.query_end - (query_len as f64 * ratio_end) as i64;
+                                        (s, e)
+                                    } else {
+                                        // Forward strand: simple linear mapping
+                                        let s = entry.query_start + (query_len as f64 * ratio_start) as i64;
+                                        let e = entry.query_start + (query_len as f64 * ratio_end) as i64;
+                                        (s, e)
+                                    };
+                                    // Always ensure output has start < end
+                                    let (window_query_start, window_query_end) = (wqs.min(wqe), wqs.max(wqe));
+
+                                    let _ = write!(temp_writer, "\t{}:{}-{}", entry.query_seq, window_query_start, window_query_end);
+                                } else {
+                                    let _ = write!(temp_writer, "\tNA");
+                                }
+                            }
+                            let _ = writeln!(temp_writer);
+                            window_count += 1;
+
+                            if merge_adjacent {
+                                prev_active = Some(active_entries.clone());
+                            }
+                        }
+                    }
+                }
+
+                // Update active entries
+                let entry = &entries[entry_idx];
+                if is_start {
+                    active_entries
+                        .entry(entry.sample.clone())
+                        .and_modify(|existing_idx| {
+                            let existing = &entries[*existing_idx];
+                            let existing_len = existing.ref_end - existing.ref_start;
+                            let new_len = entry.ref_end - entry.ref_start;
+                            if new_len > existing_len {
+                                *existing_idx = entry_idx;
+                            }
+                        })
+                        .or_insert(entry_idx);
+                } else if let Some(&active_idx) = active_entries.get(&entry.sample) {
+                    if active_idx == entry_idx {
+                        active_entries.remove(&entry.sample);
+                    }
+                }
+
+                prev_pos = Some(pos);
+            }
+
+            // Handle uncovered tail region within this chunk
+            let last_covered_pos = prev_pos.unwrap_or(chunk_start);
+            if last_covered_pos < chunk_end {
+                // Check if this is the last chunk for this sequence
+                let is_last_chunk = chunk_end >= *seq_len;
+                if is_last_chunk || last_covered_pos < chunk_end {
+                    let _ = write!(temp_writer, "1");
+                    for s in &sample_order {
+                        if s == ref_sample {
+                            let _ = write!(temp_writer, "\t{}:{}-{}", ref_seq, last_covered_pos, chunk_end);
+                        } else {
+                            let _ = write!(temp_writer, "\tNA");
+                        }
+                    }
+                    let _ = writeln!(temp_writer);
+                    window_count += 1;
+                }
+            }
+
+            let _ = temp_writer.flush();
+            (ref_idx, chunk_idx, temp_path, window_count)
+        })
+        .collect();
+
+    // Sort results by (ref_idx, chunk_idx) to ensure correct ordering
+    let mut sorted_results = chunk_results;
+    sorted_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    // Convert to the format expected by merge step
+    let temp_files: Vec<(std::path::PathBuf, usize)> = sorted_results
+        .into_iter()
+        .map(|(_, _, path, count)| (path, count))
+        .collect();
+
+    // Merge temp files into final output with global window IDs
+    // Also handle deduplication at chunk boundaries
+    info!("  Merging {} temp files...", temp_files.len());
+
+    let writer: Box<dyn Write> = if let Some(prefix) = output_prefix {
+        let path = format!("{}.depth.tsv", prefix);
+        Box::new(std::io::BufWriter::new(std::fs::File::create(&path)?))
+    } else {
+        Box::new(std::io::BufWriter::new(std::io::stdout()))
+    };
+    let mut writer = std::io::BufWriter::new(writer);
+
+    // Write header
+    write!(writer, "window_id\tdepth")?;
+    for sample in &sample_order {
+        write!(writer, "\t{}", sample)?;
+    }
+    writeln!(writer)?;
+
+    // Helper function to extract coverage signature (depth + which samples have coverage)
+    // Returns (depth, Vec<bool>) where bool indicates if sample has coverage (not NA)
+    fn get_coverage_signature(line: &str) -> (String, Vec<bool>) {
+        let parts: Vec<&str> = line.split('\t').collect();
+        let depth = parts.first().map(|s| s.to_string()).unwrap_or_default();
+        let has_coverage: Vec<bool> = parts.iter().skip(1).map(|s| *s != "NA").collect();
+        (depth, has_coverage)
+    }
+
+    let mut global_window_id: usize = 0;
+    let mut prev_line: Option<String> = None;
+    let mut prev_signature: Option<(String, Vec<bool>)> = None;
+    let mut at_chunk_boundary = false;
+    let mut merged_count: usize = 0;
+
+    for (temp_path, window_count) in &temp_files {
+        if *window_count == 0 {
+            at_chunk_boundary = true;
+            continue;
+        }
+
+        let file = std::fs::File::open(temp_path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut first_line_of_chunk = true;
+
+        for line in reader.lines() {
+            let line = line?;
+            let current_signature = get_coverage_signature(&line);
+
+            // Check for duplicate at chunk boundary
+            let is_duplicate = if at_chunk_boundary && first_line_of_chunk {
+                if let Some(ref prev_sig) = prev_signature {
+                    // Same depth and same coverage pattern -> likely duplicate at boundary
+                    prev_sig.0 == current_signature.0 && prev_sig.1 == current_signature.1
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
+            if is_duplicate {
+                // Skip this line as it's a duplicate at chunk boundary
+                merged_count += 1;
+            } else {
+                // Output the previous line if exists
+                if let Some(ref prev) = prev_line {
+                    writeln!(writer, "{}\t{}", global_window_id, prev)?;
+                    global_window_id += 1;
+                }
+                prev_line = Some(line);
+                prev_signature = Some(current_signature);
+            }
+
+            first_line_of_chunk = false;
+        }
+
+        at_chunk_boundary = true;
+    }
+
+    // Output the last line
+    if let Some(ref prev) = prev_line {
+        writeln!(writer, "{}\t{}", global_window_id, prev)?;
+        global_window_id += 1;
+    }
+
+    writer.flush()?;
+
+    // Temp directory and files are automatically cleaned up when temp_dir goes out of scope
+    drop(temp_dir);
+
+    if merged_count > 0 {
+        info!(
+            "  Merged {} duplicate windows at chunk boundaries",
+            merged_count
+        );
+    }
+    info!("Output complete: {} windows", global_window_id);
+
+    Ok(())
+}
+
+/// Global streaming depth computation - processes all samples as reference one by one.
+/// Each sample's sequences are processed once, ensuring complete coverage without overlap.
+///
+/// Algorithm:
+/// 1. Get all unique samples from the index
+/// 2. For each sample (in sorted order), compute coverage for its sequences
+/// 3. Output combined results with reference sample first if specified
+pub fn compute_depth_global_streaming(
+    impg: &Impg,
+    separator: &str,
+    output_prefix: Option<&str>,
+    merge_adjacent: bool,
+    fai_list: Option<&str>,
+    ref_sample_first: Option<&str>,  // Optional: put this sample's columns first
+) -> io::Result<()> {
+    info!("Computing depth (global streaming mode)...");
+
+    // Phase 1: Get all samples and their sequences
+    info!("Phase 1: Collecting all samples and sequences...");
+
+    let seq_lengths = SequenceLengths::from_impg(impg, separator);
+    let mut all_samples: Vec<String> = seq_lengths.get_samples();
+
+    // Sort samples: ref_sample_first comes first if specified, then alphabetical
+    all_samples.sort_by(|a, b| {
+        if let Some(ref_first) = ref_sample_first {
+            if a == ref_first {
+                return std::cmp::Ordering::Less;
+            } else if b == ref_first {
+                return std::cmp::Ordering::Greater;
+            }
+        }
+        a.cmp(b)
+    });
+
+    info!("  Found {} samples to process", all_samples.len());
+
+    // Build mapping of sample -> sequences
+    let mut sample_seq_ids: FxHashMap<String, Vec<(u32, String, i64)>> = FxHashMap::default();
+    for id in 0..impg.seq_index.len() as u32 {
+        if let Some(name) = impg.seq_index.get_name(id) {
+            let sample = extract_sample(name, separator);
+            if let Some(len) = impg.seq_index.get_len_from_id(id) {
+                sample_seq_ids
+                    .entry(sample.to_string())
+                    .or_default()
+                    .push((id, name.to_string(), len as i64));
+            }
+        }
+    }
+
+    // Load FAI lengths if provided
+    let fai_lengths: Option<FxHashMap<String, i64>> = if let Some(fai_path) = fai_list {
+        info!("  Loading sequence lengths from FAI files...");
+        let fai_seq_lengths = SequenceLengths::from_fai_list(fai_path, separator)?;
+        info!(
+            "  FAI: {} samples, {} sequences",
+            fai_seq_lengths.sample_to_seqs.len(),
+            fai_seq_lengths.lengths.len()
+        );
+        Some(fai_seq_lengths.lengths)
+    } else {
+        None
+    };
+
+    // Phase 2: Process each sample's sequences
+    info!("Phase 2: Scanning index for coverage...");
+
+    // Get all target IDs once
+    let all_target_ids: Vec<u32> = impg.get_all_target_ids();
+    let total_trees = all_target_ids.len();
+    info!(
+        "  {} trees to scan, {} threads available",
+        total_trees,
+        rayon::current_num_threads()
+    );
+
+    // Build a global mapping: for each sequence ID, record all overlapping alignments
+    // This is done once and used for all samples
+    let processed_trees = AtomicUsize::new(0);
+
+    // Collect all coverage entries in parallel
+    // Key: (ref_seq_name) -> Vec<CoverageEntry>
+    let parallel_results: Vec<FxHashMap<String, Vec<CoverageEntry>>> = all_target_ids
+        .par_iter()
+        .map(|&target_id| {
+            let mut local_coverage: FxHashMap<String, Vec<CoverageEntry>> = FxHashMap::default();
+
+            let count = processed_trees.fetch_add(1, Ordering::Relaxed);
+            if count % 1000 == 0 || count < 10 {
+                debug!(
+                    "    Progress: {}/{} trees (thread {:?})",
+                    count,
+                    total_trees,
+                    std::thread::current().id()
+                );
+            }
+
+            let target_name = match impg.seq_index.get_name(target_id) {
+                Some(n) => n.to_string(),
+                None => return local_coverage,
+            };
+            let target_sample = extract_sample(&target_name, separator);
+
+            // Load tree
+            let tree = match impg.load_tree_no_cache(target_id) {
+                Some(t) => t,
+                None => return local_coverage,
+            };
+
+            // For each alignment in this tree
+            for interval in tree.iter() {
+                let query_id = interval.metadata.query_id();
+                let query_name = match impg.seq_index.get_name(query_id) {
+                    Some(n) => n.to_string(),
+                    None => continue,
+                };
+                let query_sample = extract_sample(&query_name, separator);
+
+                // Skip same-sample alignments (self-coverage added separately)
+                if target_sample == query_sample {
+                    continue;
+                }
+
+                let target_start = interval.first as i64;
+                let target_end = interval.last as i64;
+                let is_reverse = interval.metadata.query_start() > interval.metadata.query_end();
+                let query_start = interval.metadata.query_start().min(interval.metadata.query_end()) as i64;
+                let query_end = interval.metadata.query_start().max(interval.metadata.query_end()) as i64;
+
+                // Record coverage bidirectionally for complete coverage
+                // 1. On target's sequence: query sample provides coverage
+                local_coverage
+                    .entry(target_name.clone())
+                    .or_default()
+                    .push(CoverageEntry {
+                        sample: query_sample.to_string(),
+                        query_seq: query_name.clone(),
+                        ref_start: target_start,
+                        ref_end: target_end,
+                        query_start,
+                        query_end,
+                        is_reverse,
+                    });
+
+                // 2. On query's sequence: target sample provides coverage (reverse direction)
+                // This ensures the window can be output from the alphabetically-first sample's perspective
+                local_coverage
+                    .entry(query_name)  // Move instead of clone
+                    .or_default()
+                    .push(CoverageEntry {
+                        sample: target_sample.to_string(),
+                        query_seq: target_name.clone(),
+                        ref_start: query_start,
+                        ref_end: query_end,
+                        query_start: target_start,
+                        query_end: target_end,
+                        is_reverse, // same relative orientation
+                    });
+            }
+
+            local_coverage
+        })
+        .collect();
+
+    // Merge parallel results
+    info!("  Merging coverage data...");
+    let mut coverage: FxHashMap<String, Vec<CoverageEntry>> = FxHashMap::default();
+    for local in parallel_results {
+        for (seq_name, entries) in local {
+            coverage
+                .entry(seq_name)
+                .or_default()
+                .extend(entries);
+        }
+    }
+
+    // Add self-coverage for each sequence
+    for (sample, seqs) in &sample_seq_ids {
+        for (_, seq_name, seq_len) in seqs {
+            let len = if let Some(ref fai) = fai_lengths {
+                *fai.get(seq_name).unwrap_or(seq_len)
+            } else {
+                *seq_len
+            };
+
+            coverage
+                .entry(seq_name.clone())
+                .or_default()
+                .push(CoverageEntry {
+                    sample: sample.clone(),
+                    query_seq: seq_name.clone(),
+                    ref_start: 0,
+                    ref_end: len,
+                    query_start: 0,
+                    query_end: len,
+                    is_reverse: false, // self-coverage is always forward
+                });
+        }
+    }
+
+    info!(
+        "  Coverage data collected for {} sequences",
+        coverage.len()
+    );
+
+    // Phase 3: Generate depth output
+    info!("Phase 3: Generating depth output (parallel with chunking)...");
+
+    // Chunk size for parallel processing
+    const CHUNK_SIZE: i64 = 10_000_000;
+
+    // Build list of all sequences to process, grouped by sample
+    // Process in sample order (ref_sample_first if specified)
+    let mut all_seq_list: Vec<(String, String, i64)> = Vec::new();  // (sample, seq_name, seq_len)
+    for sample in &all_samples {
+        if let Some(seqs) = sample_seq_ids.get(sample) {
+            for (_, seq_name, seq_len) in seqs {
+                let len = if let Some(ref fai) = fai_lengths {
+                    *fai.get(seq_name).unwrap_or(seq_len)
+                } else {
+                    *seq_len
+                };
+                all_seq_list.push((sample.clone(), seq_name.clone(), len));
+            }
+        }
+    }
+
+    // Sort sequences: by sample order, then by sequence name
+    all_seq_list.sort_by(|a, b| {
+        let sample_order_a = all_samples.iter().position(|s| s == &a.0).unwrap_or(usize::MAX);
+        let sample_order_b = all_samples.iter().position(|s| s == &b.0).unwrap_or(usize::MAX);
+        sample_order_a.cmp(&sample_order_b).then_with(|| a.1.cmp(&b.1))
+    });
+
+    // Build chunks for all sequences
+    let mut all_chunks: Vec<(usize, usize, String, i64, i64)> = Vec::new();  // (seq_idx, chunk_idx, seq_name, chunk_start, chunk_end)
+    for (seq_idx, (_, seq_name, seq_len)) in all_seq_list.iter().enumerate() {
+        let num_chunks = ((*seq_len + CHUNK_SIZE - 1) / CHUNK_SIZE) as usize;
+        for chunk_idx in 0..num_chunks.max(1) {
+            let chunk_start = (chunk_idx as i64) * CHUNK_SIZE;
+            let chunk_end = ((chunk_idx as i64 + 1) * CHUNK_SIZE).min(*seq_len);
+            all_chunks.push((seq_idx, chunk_idx, seq_name.clone(), chunk_start, chunk_end));
+        }
+    }
+
+    info!(
+        "  Processing {} chunks across {} sequences with {} threads",
+        all_chunks.len(),
+        all_seq_list.len(),
+        rayon::current_num_threads()
+    );
+
+    // Create temp directory
+    let temp_dir = tempfile::tempdir()?;
+    let temp_dir_path = temp_dir.path().to_path_buf();
+
+    // Process chunks in parallel
+    let processed_chunks = AtomicUsize::new(0);
+    let total_chunks = all_chunks.len();
+
+    let chunk_results: Vec<(usize, usize, std::path::PathBuf, usize)> = all_chunks
+        .par_iter()
+        .map(|(seq_idx, chunk_idx, seq_name, chunk_start, chunk_end)| {
+            let temp_path = temp_dir_path.join(format!("depth_{:06}_{:06}.tmp", seq_idx, chunk_idx));
+            let mut window_count = 0usize;
+
+            let count = processed_chunks.fetch_add(1, Ordering::Relaxed);
+            if count % 100 == 0 || count < 10 {
+                debug!(
+                    "    Progress: {}/{} chunks (thread {:?})",
+                    count,
+                    total_chunks,
+                    std::thread::current().id()
+                );
+            }
+
+            // Extract the reference sample from the sequence name
+            let ref_sample = extract_sample(seq_name, separator);
+
+            let entries = match coverage.get(seq_name) {
+                Some(e) => e,
+                None => return (*seq_idx, *chunk_idx, temp_path, 0),
+            };
+
+            if entries.is_empty() {
+                return (*seq_idx, *chunk_idx, temp_path, 0);
+            }
+
+            // Find entries that overlap this chunk
+            let chunk_entries: Vec<(usize, &CoverageEntry)> = entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| e.ref_start < *chunk_end && e.ref_end > *chunk_start)
+                .collect();
+
+            if chunk_entries.is_empty() {
+                return (*seq_idx, *chunk_idx, temp_path, 0);
+            }
+
+            // Create temp file
+            let file = match std::fs::File::create(&temp_path) {
+                Ok(f) => f,
+                Err(_) => return (*seq_idx, *chunk_idx, temp_path, 0),
+            };
+            let mut temp_writer = std::io::BufWriter::new(file);
+
+            // Build sweep-line events
+            let mut events: Vec<(i64, bool, usize)> = Vec::new();
+            for &(orig_idx, entry) in &chunk_entries {
+                let effective_start = entry.ref_start.max(*chunk_start);
+                let effective_end = entry.ref_end.min(*chunk_end);
+                if effective_start < effective_end {
+                    events.push((effective_start, true, orig_idx));
+                    events.push((effective_end, false, orig_idx));
+                }
+            }
+
+            events.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+            // Sweep-line processing
+            let mut active_entries: FxHashMap<String, usize> = FxHashMap::default();
+            let mut prev_pos: Option<i64> = None;
+            let mut prev_active: Option<FxHashMap<String, usize>> = None;
+
+            for (pos, is_start, entry_idx) in events {
+                if let Some(prev) = prev_pos {
+                    if pos > prev && !active_entries.is_empty() {
+                        let should_output = if merge_adjacent {
+                            match &prev_active {
+                                Some(pa) => {
+                                    pa.len() != active_entries.len()
+                                        || !pa.keys().all(|k| active_entries.contains_key(k))
+                                }
+                                None => true,
+                            }
+                        } else {
+                            true
+                        };
+
+                        if should_output {
+                            // Deduplication: only output if ref_sample is the first (alphabetically)
+                            // among all samples covering this window. This ensures each homologous
+                            // region is output exactly once.
+                            // Note: ref_sample is not in active_entries (it's implicit), so we
+                            // compare it against the first covering sample.
+                            let first_covering = active_entries.keys().min().map(|s| s.as_str());
+                            let is_first = match first_covering {
+                                Some(first) => ref_sample.as_str() <= first,
+                                None => true, // Only ref_sample covers this region
+                            };
+                            if !is_first {
+                                prev_pos = Some(pos);
+                                continue;
+                            }
+
+                            let depth = active_entries.len();
+                            let _ = write!(temp_writer, "{}", depth);
+
+                            for s in &all_samples {
+                                // For the reference sample, use window coordinates directly
+                                // This ensures contiguous coverage without overlaps
+                                if s.as_str() == ref_sample {
+                                    let _ = write!(
+                                        temp_writer,
+                                        "\t{}:{}-{}",
+                                        seq_name, prev, pos
+                                    );
+                                } else if let Some(&eidx) = active_entries.get(s) {
+                                    let entry = &entries[eidx];
+                                    let ref_len = entry.ref_end - entry.ref_start;
+                                    let query_len = entry.query_end - entry.query_start;
+
+                                    let window_ref_start = prev.max(entry.ref_start);
+                                    let window_ref_end = pos.min(entry.ref_end);
+
+                                    let ratio_start = if ref_len > 0 {
+                                        (window_ref_start - entry.ref_start) as f64 / ref_len as f64
+                                    } else {
+                                        0.0
+                                    };
+                                    let ratio_end = if ref_len > 0 {
+                                        (window_ref_end - entry.ref_start) as f64 / ref_len as f64
+                                    } else {
+                                        1.0
+                                    };
+
+                                    let (wqs, wqe) = if entry.is_reverse {
+                                        // Reverse strand: moving forward in ref means moving backward in query
+                                        let s = entry.query_end - (query_len as f64 * ratio_start) as i64;
+                                        let e = entry.query_end - (query_len as f64 * ratio_end) as i64;
+                                        (s, e)
+                                    } else {
+                                        // Forward strand: simple linear mapping
+                                        let s = entry.query_start + (query_len as f64 * ratio_start) as i64;
+                                        let e = entry.query_start + (query_len as f64 * ratio_end) as i64;
+                                        (s, e)
+                                    };
+                                    // Always ensure output has start < end
+                                    let (window_query_start, window_query_end) = (wqs.min(wqe), wqs.max(wqe));
+
+                                    let _ = write!(
+                                        temp_writer,
+                                        "\t{}:{}-{}",
+                                        entry.query_seq, window_query_start, window_query_end
+                                    );
+                                } else {
+                                    let _ = write!(temp_writer, "\tNA");
+                                }
+                            }
+                            let _ = writeln!(temp_writer);
+                            window_count += 1;
+
+                            if merge_adjacent {
+                                prev_active = Some(active_entries.clone());
+                            }
+                        }
+                    }
+                }
+
+                // Update active entries
+                let entry = &entries[entry_idx];
+                if is_start {
+                    active_entries
+                        .entry(entry.sample.clone())
+                        .and_modify(|existing_idx| {
+                            let existing = &entries[*existing_idx];
+                            let existing_len = existing.ref_end - existing.ref_start;
+                            let new_len = entry.ref_end - entry.ref_start;
+                            if new_len > existing_len {
+                                *existing_idx = entry_idx;
+                            }
+                        })
+                        .or_insert(entry_idx);
+                } else if let Some(&active_idx) = active_entries.get(&entry.sample) {
+                    if active_idx == entry_idx {
+                        active_entries.remove(&entry.sample);
+                    }
+                }
+
+                prev_pos = Some(pos);
+            }
+
+            let _ = temp_writer.flush();
+            (*seq_idx, *chunk_idx, temp_path, window_count)
+        })
+        .collect();
+
+    // Sort results
+    let mut sorted_results = chunk_results;
+    sorted_results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let temp_files: Vec<(std::path::PathBuf, usize)> = sorted_results
+        .into_iter()
+        .map(|(_, _, path, count)| (path, count))
+        .collect();
+
+    // Merge and output
+    info!("  Merging {} temp files...", temp_files.len());
+
+    let writer: Box<dyn Write> = if let Some(prefix) = output_prefix {
+        let path = format!("{}.depth.tsv", prefix);
+        Box::new(std::io::BufWriter::new(std::fs::File::create(&path)?))
+    } else {
+        Box::new(std::io::BufWriter::new(std::io::stdout()))
+    };
+    let mut writer = std::io::BufWriter::new(writer);
+
+    // Write header
+    write!(writer, "window_id\tdepth")?;
+    for sample in &all_samples {
+        write!(writer, "\t{}", sample)?;
+    }
+    writeln!(writer)?;
+
+    // Merge with deduplication
+    fn get_coverage_signature(line: &str) -> (String, Vec<bool>) {
+        let parts: Vec<&str> = line.split('\t').collect();
+        let depth = parts.first().map(|s| s.to_string()).unwrap_or_default();
+        let has_coverage: Vec<bool> = parts.iter().skip(1).map(|s| *s != "NA").collect();
+        (depth, has_coverage)
+    }
+
+    let mut global_window_id: usize = 0;
+    let mut prev_line: Option<String> = None;
+    let mut prev_signature: Option<(String, Vec<bool>)> = None;
+    let mut at_chunk_boundary = false;
+    let mut merged_count: usize = 0;
+
+    for (temp_path, window_count) in &temp_files {
+        if *window_count == 0 {
+            at_chunk_boundary = true;
+            continue;
+        }
+
+        let file = std::fs::File::open(temp_path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut first_line_of_chunk = true;
+
+        for line in reader.lines() {
+            let line = line?;
+            let current_signature = get_coverage_signature(&line);
+
+            let is_duplicate = if at_chunk_boundary && first_line_of_chunk {
+                if let Some(ref prev_sig) = prev_signature {
+                    prev_sig.0 == current_signature.0 && prev_sig.1 == current_signature.1
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
+            if is_duplicate {
+                merged_count += 1;
+            } else {
+                if let Some(ref prev) = prev_line {
+                    writeln!(writer, "{}\t{}", global_window_id, prev)?;
+                    global_window_id += 1;
+                }
+                prev_line = Some(line);
+                prev_signature = Some(current_signature);
+            }
+
+            first_line_of_chunk = false;
+        }
+
+        at_chunk_boundary = true;
+    }
+
+    if let Some(ref prev) = prev_line {
+        writeln!(writer, "{}\t{}", global_window_id, prev)?;
+        global_window_id += 1;
+    }
+
+    writer.flush()?;
+    drop(temp_dir);
+
+    if merged_count > 0 {
+        info!(
+            "  Merged {} duplicate windows at chunk boundaries",
+            merged_count
+        );
+    }
+    info!("Output complete: {} windows", global_window_id);
+
+    Ok(())
+}
+
+/// Load sequence lengths from FAI files for a specific sample
+fn load_fai_lengths_for_sample(
+    fai_list_path: &str,
+    ref_sample: &str,
+    separator: &str,
+) -> io::Result<FxHashMap<String, i64>> {
+    let mut lengths: FxHashMap<String, i64> = FxHashMap::default();
+
+    let content = std::fs::read_to_string(fai_list_path).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Failed to read FAI list file '{}': {}", fai_list_path, e),
+        )
+    })?;
+
+    for line in content.lines() {
+        let fai_path = line.trim();
+        if fai_path.is_empty() || fai_path.starts_with('#') {
+            continue;
+        }
+
+        let fai_content = std::fs::read_to_string(fai_path).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Failed to read FAI file '{}': {}", fai_path, e),
+            )
+        })?;
+
+        for fai_line in fai_content.lines() {
+            let parts: Vec<&str> = fai_line.split('\t').collect();
+            if parts.len() >= 2 {
+                let seq_name = parts[0];
+                let seq_len: i64 = parts[1].parse().unwrap_or(0);
+                let sample = extract_sample(seq_name, separator);
+
+                if sample == ref_sample {
+                    lengths.insert(seq_name.to_string(), seq_len);
+                }
+            }
+        }
+    }
+
+    Ok(lengths)
+}
+
+// ============================================================================
+// New depth functions: stats mode and region query mode
+// ============================================================================
+
+/// Alignment info for sweep-line processing (tracks all alignments per sample)
+#[derive(Debug, Clone)]
+struct AlignmentInfoMulti {
+    sample: String,
+    query_name: String,
+    query_start: i64,
+    query_end: i64,
+    target_start: i64,
+    target_end: i64,
+    is_reverse: bool,
+}
+
+/// Event for sweep-line algorithm (used in new depth functions)
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DepthEventMulti {
+    position: i64,
+    is_start: bool,
+    sample: String,
+    alignment_idx: usize,
+}
+
+impl Ord for DepthEventMulti {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.position
+            .cmp(&other.position)
+            .then_with(|| other.is_start.cmp(&self.is_start)) // Starts before ends at same position
+            .then_with(|| self.sample.cmp(&other.sample))
+    }
+}
+
+impl PartialOrd for DepthEventMulti {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Compute global depth statistics across all sequences
+///
+/// Algorithm:
+/// 1. For each sample in the filter (or all samples if no filter):
+///    a. For each sequence belonging to this sample:
+///       - Find all alignments FROM other samples TO this sequence (forward)
+///       - Find all alignments FROM this sequence TO other samples (reverse)
+///    b. Use sweep-line algorithm to compute depth intervals
+/// 2. Aggregate statistics across all sequences
+/// 3. Output summary and per-depth BED files
+pub fn compute_depth_stats(
+    impg: &Impg,
+    config: &DepthConfig,
+    separator: &str,
+    output_prefix: &str,
+    sample_filter: Option<&SampleFilter>,
+    fai_list: Option<&str>,
+    ref_sample: Option<&str>,
+) -> io::Result<DepthStats> {
+    info!("Computing depth statistics (stats mode) - parallelized");
+
+    // Build sequence lengths
+    let seq_lengths = if let Some(fai_path) = fai_list {
+        info!("Loading sequence lengths from FAI files...");
+        SequenceLengths::from_fai_list(fai_path, separator)?
+    } else {
+        SequenceLengths::from_impg(impg, separator)
+    };
+
+    info!(
+        "Found {} samples, {} sequences",
+        seq_lengths.sample_to_seqs.len(),
+        seq_lengths.lengths.len()
+    );
+
+    // Get samples to process
+    // If ref_sample is specified, only process that sample's sequences (single reference mode)
+    // Otherwise, apply sample_filter if present (global mode)
+    let samples_to_process: Vec<String> = if let Some(ref_name) = ref_sample {
+        info!("Single reference mode: only processing sequences from '{}'", ref_name);
+        if seq_lengths.sample_to_seqs.contains_key(ref_name) {
+            vec![ref_name.to_string()]
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Reference sample '{}' not found in alignment data", ref_name),
+            ));
+        }
+    } else {
+        seq_lengths
+            .get_samples()
+            .into_iter()
+            .filter(|s| sample_filter.map_or(true, |f| f.includes(s)))
+            .collect()
+    };
+
+    if ref_sample.is_some() {
+        info!(
+            "Single reference mode: processing {} sample",
+            samples_to_process.len()
+        );
+    } else if sample_filter.is_some() {
+        info!(
+            "Sample filter active: processing {} of {} samples",
+            samples_to_process.len(),
+            seq_lengths.sample_to_seqs.len()
+        );
+    }
+
+    // Flatten all sequences to process into a single list for parallel iteration
+    let all_seqs: Vec<(String, String, i64)> = samples_to_process
+        .iter()
+        .flat_map(|sample| {
+            seq_lengths
+                .get_seqs_of_sample(sample)
+                .iter()
+                .filter_map(|seq| {
+                    seq_lengths.get_length(seq).map(|len| (sample.clone(), seq.clone(), len))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let total_seqs = all_seqs.len();
+    info!("Processing {} sequences in parallel", total_seqs);
+
+    let processed_counter = AtomicUsize::new(0);
+
+    // Process sequences in parallel and collect partial stats
+    let partial_stats: Vec<DepthStats> = all_seqs
+        .par_iter()
+        .map(|(anchor_sample, anchor_seq, seq_len)| {
+            let mut local_stats = DepthStats::new();
+
+            let count = processed_counter.fetch_add(1, Ordering::Relaxed) + 1;
+            if count % 50 == 0 || count == total_seqs {
+                debug!("Progress: {}/{} sequences processed", count, total_seqs);
+            }
+
+            let seq_id = match impg.seq_index.get_id(anchor_seq) {
+                Some(id) => id,
+                None => {
+                    // Sequence not in alignment index, depth = 1 (self only)
+                    local_stats.add_interval(anchor_seq, 0, *seq_len, 1);
+                    return local_stats;
+                }
+            };
+
+            // Collect samples covering this sequence (using lightweight representation)
+            let mut sample_intervals: Vec<(i64, i64, String)> = Vec::new();
+
+            // Forward direction: where anchor_seq is TARGET
+            let overlaps = if config.transitive {
+                if config.transitive_dfs {
+                    impg.query_transitive_dfs(
+                        seq_id,
+                        0,
+                        *seq_len as i32,
+                        None,
+                        config.max_depth,
+                        config.min_transitive_len,
+                        config.min_distance_between_ranges,
+                        None,
+                        false,
+                        None,
+                        None,
+                        config.approximate_mode,
+                        None,
+                    )
+                } else {
+                    impg.query_transitive_bfs(
+                        seq_id,
+                        0,
+                        *seq_len as i32,
+                        None,
+                        config.max_depth,
+                        config.min_transitive_len,
+                        config.min_distance_between_ranges,
+                        None,
+                        false,
+                        None,
+                        None,
+                        config.approximate_mode,
+                        None,
+                    )
+                }
+            } else {
+                impg.query(seq_id, 0, *seq_len as i32, false, None, None, config.approximate_mode)
+            };
+
+            for overlap in &overlaps {
+                let query_interval = &overlap.0;
+                let target_interval = &overlap.2;
+
+                let query_name = match impg.seq_index.get_name(query_interval.metadata) {
+                    Some(name) => name,
+                    None => continue,
+                };
+                let sample = extract_sample(query_name, separator);
+
+                // Apply sample filter
+                if let Some(filter) = sample_filter {
+                    if !filter.includes(&sample) {
+                        continue;
+                    }
+                }
+
+                let target_start = target_interval.first.min(target_interval.last) as i64;
+                let target_end = target_interval.first.max(target_interval.last) as i64;
+
+                sample_intervals.push((target_start, target_end, sample));
+            }
+
+            // Reverse direction: where anchor_seq is QUERY
+            let reverse_alignments = impg.query_reverse_for_depth(seq_id);
+            for (ref_start, ref_end, target_id) in reverse_alignments {
+                if let Some(target_name) = impg.seq_index.get_name(target_id) {
+                    let sample = extract_sample(target_name, separator);
+
+                    // Skip self
+                    if sample == *anchor_sample {
+                        continue;
+                    }
+
+                    // Apply sample filter
+                    if let Some(filter) = sample_filter {
+                        if !filter.includes(&sample) {
+                            continue;
+                        }
+                    }
+
+                    sample_intervals.push((ref_start as i64, ref_end as i64, sample));
+                }
+            }
+
+            // Add self (anchor sample)
+            sample_intervals.push((0, *seq_len, anchor_sample.clone()));
+
+            // Fast sweep-line to compute depth (only counts unique samples, no position tracking)
+            let depth_windows = compute_sweep_line_depth_fast(anchor_seq, *seq_len, &sample_intervals);
+
+            for (start, end, depth) in depth_windows {
+                local_stats.add_interval(anchor_seq, start, end, depth);
+            }
+
+            local_stats
+        })
+        .collect();
+
+    // Merge all partial stats
+    info!("Merging results from {} sequences...", partial_stats.len());
+    let mut stats = DepthStats::new();
+    for partial in partial_stats {
+        stats.merge(&partial);
+    }
+
+    // Write outputs
+    info!("Writing depth statistics...");
+
+    // Write summary
+    let summary_path = format!("{}.summary.txt", output_prefix);
+    let summary_file = std::fs::File::create(&summary_path)?;
+    let mut summary_writer = BufWriter::new(summary_file);
+    stats.write_summary(&mut summary_writer)?;
+    summary_writer.flush()?;
+    info!("Wrote summary to {}", summary_path);
+
+    // Also print to stdout
+    stats.write_summary(&mut std::io::stdout())?;
+
+    // Write per-depth BED files
+    stats.write_depth_bed_files(output_prefix)?;
+
+    info!(
+        "Stats complete: {} total bases, max depth = {}",
+        stats.total_bases,
+        stats.max_depth()
+    );
+
+    Ok(stats)
+}
+
+/// Compute depth statistics with sample tracking for combined output
+/// This is similar to compute_depth_stats but tracks which samples cover each interval
+/// merge_tolerance: fraction (0.0-1.0) for merging adjacent intervals with similar depth
+///                  e.g., 0.05 = 5% tolerance, merge if (max-min)/max <= 0.05
+pub fn compute_depth_stats_with_samples(
+    impg: &Impg,
+    config: &DepthConfig,
+    separator: &str,
+    output_prefix: &str,
+    sample_filter: Option<&SampleFilter>,
+    fai_list: Option<&str>,
+    ref_sample: Option<&str>,
+    merge_tolerance: f64,
+) -> io::Result<DepthStatsWithSamples> {
+    info!("Computing depth statistics with sample tracking (combined output mode)");
+
+    // Build sequence lengths
+    let seq_lengths = if let Some(fai_path) = fai_list {
+        info!("Loading sequence lengths from FAI files...");
+        SequenceLengths::from_fai_list(fai_path, separator)?
+    } else {
+        SequenceLengths::from_impg(impg, separator)
+    };
+
+    info!(
+        "Found {} samples, {} sequences",
+        seq_lengths.sample_to_seqs.len(),
+        seq_lengths.lengths.len()
+    );
+
+    // Get samples to process
+    let samples_to_process: Vec<String> = if let Some(ref_name) = ref_sample {
+        info!("Single reference mode: only processing sequences from '{}'", ref_name);
+        if seq_lengths.sample_to_seqs.contains_key(ref_name) {
+            vec![ref_name.to_string()]
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Reference sample '{}' not found in alignment data", ref_name),
+            ));
+        }
+    } else {
+        seq_lengths
+            .get_samples()
+            .into_iter()
+            .filter(|s| sample_filter.map_or(true, |f| f.includes(s)))
+            .collect()
+    };
+
+    if ref_sample.is_some() {
+        info!(
+            "Single reference mode: processing {} sample",
+            samples_to_process.len()
+        );
+    } else if sample_filter.is_some() {
+        info!(
+            "Sample filter active: processing {} of {} samples",
+            samples_to_process.len(),
+            seq_lengths.sample_to_seqs.len()
+        );
+    }
+
+    // Flatten all sequences to process
+    let all_seqs: Vec<(String, String, i64)> = samples_to_process
+        .iter()
+        .flat_map(|sample| {
+            seq_lengths
+                .get_seqs_of_sample(sample)
+                .iter()
+                .filter_map(|seq| {
+                    seq_lengths.get_length(seq).map(|len| (sample.clone(), seq.clone(), len))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let total_seqs = all_seqs.len();
+    info!("Processing {} sequences in parallel (with sample tracking)", total_seqs);
+
+    let processed_counter = AtomicUsize::new(0);
+
+    // Process sequences in parallel and collect partial stats
+    let partial_stats: Vec<DepthStatsWithSamples> = all_seqs
+        .par_iter()
+        .map(|(anchor_sample, anchor_seq, seq_len)| {
+            let mut local_stats = DepthStatsWithSamples::new();
+
+            let count = processed_counter.fetch_add(1, Ordering::Relaxed) + 1;
+            if count % 50 == 0 || count == total_seqs {
+                debug!("Progress: {}/{} sequences processed", count, total_seqs);
+            }
+
+            let seq_id = match impg.seq_index.get_id(anchor_seq) {
+                Some(id) => id,
+                None => {
+                    // Sequence not in alignment index, depth = 1 (self only)
+                    local_stats.add_interval(anchor_seq, 0, *seq_len, 1, vec![anchor_sample.clone()]);
+                    return local_stats;
+                }
+            };
+
+            // Collect samples covering this sequence
+            let mut sample_intervals: Vec<(i64, i64, String)> = Vec::new();
+
+            // Forward direction: where anchor_seq is TARGET
+            let overlaps = if config.transitive {
+                if config.transitive_dfs {
+                    impg.query_transitive_dfs(
+                        seq_id,
+                        0,
+                        *seq_len as i32,
+                        None,
+                        config.max_depth,
+                        config.min_transitive_len,
+                        config.min_distance_between_ranges,
+                        None,
+                        false,
+                        None,
+                        None,
+                        config.approximate_mode,
+                        None,
+                    )
+                } else {
+                    impg.query_transitive_bfs(
+                        seq_id,
+                        0,
+                        *seq_len as i32,
+                        None,
+                        config.max_depth,
+                        config.min_transitive_len,
+                        config.min_distance_between_ranges,
+                        None,
+                        false,
+                        None,
+                        None,
+                        config.approximate_mode,
+                        None,
+                    )
+                }
+            } else {
+                impg.query(seq_id, 0, *seq_len as i32, false, None, None, config.approximate_mode)
+            };
+
+            for overlap in &overlaps {
+                let query_interval = &overlap.0;
+                let target_interval = &overlap.2;
+
+                let query_name = match impg.seq_index.get_name(query_interval.metadata) {
+                    Some(name) => name,
+                    None => continue,
+                };
+                let sample = extract_sample(query_name, separator);
+
+                // Apply sample filter
+                if let Some(filter) = sample_filter {
+                    if !filter.includes(&sample) {
+                        continue;
+                    }
+                }
+
+                let target_start = target_interval.first.min(target_interval.last) as i64;
+                let target_end = target_interval.first.max(target_interval.last) as i64;
+
+                sample_intervals.push((target_start, target_end, sample));
+            }
+
+            // Reverse direction: where anchor_seq is QUERY
+            let reverse_alignments = impg.query_reverse_for_depth(seq_id);
+            for (ref_start, ref_end, target_id) in reverse_alignments {
+                if let Some(target_name) = impg.seq_index.get_name(target_id) {
+                    let sample = extract_sample(target_name, separator);
+
+                    // Skip self
+                    if sample == *anchor_sample {
+                        continue;
+                    }
+
+                    // Apply sample filter
+                    if let Some(filter) = sample_filter {
+                        if !filter.includes(&sample) {
+                            continue;
+                        }
+                    }
+
+                    sample_intervals.push((ref_start as i64, ref_end as i64, sample));
+                }
+            }
+
+            // Add self (anchor sample)
+            sample_intervals.push((0, *seq_len, anchor_sample.clone()));
+
+            // Sweep-line with sample tracking
+            let depth_windows = compute_sweep_line_depth_with_samples(anchor_seq, *seq_len, &sample_intervals);
+
+            for (start, end, depth, samples) in depth_windows {
+                local_stats.add_interval(anchor_seq, start, end, depth, samples);
+            }
+
+            local_stats
+        })
+        .collect();
+
+    // Merge all partial stats
+    info!("Merging results from {} sequences...", partial_stats.len());
+    let mut stats = DepthStatsWithSamples::new();
+    for partial in partial_stats {
+        stats.merge(partial);
+    }
+
+    // Write outputs
+    info!("Writing depth statistics with sample lists...");
+    if merge_tolerance > 0.0 {
+        info!("Merge tolerance: {:.1}%", merge_tolerance * 100.0);
+    }
+
+    // Write summary
+    let summary_path = format!("{}.summary.txt", output_prefix);
+    let summary_file = std::fs::File::create(&summary_path)?;
+    let mut summary_writer = BufWriter::new(summary_file);
+    stats.write_summary(&mut summary_writer)?;
+    summary_writer.flush()?;
+    info!("Wrote summary to {}", summary_path);
+
+    // Also print to stdout
+    stats.write_summary(&mut std::io::stdout())?;
+
+    // Write combined output file (with optional merging)
+    stats.write_combined_output(output_prefix, merge_tolerance)?;
+
+    info!(
+        "Stats complete: {} total bases, {} intervals, max depth = {}",
+        stats.total_bases,
+        stats.intervals.len(),
+        stats.max_depth()
+    );
+
+    Ok(stats)
+}
+
+/// Fast sweep-line algorithm for stats mode (only computes depth, no sample position tracking)
+/// Returns Vec<(start, end, depth)>
+fn compute_sweep_line_depth_fast(
+    _anchor_seq: &str,
+    seq_len: i64,
+    sample_intervals: &[(i64, i64, String)],
+) -> Vec<(i64, i64, usize)> {
+    if sample_intervals.is_empty() {
+        return vec![(0, seq_len, 0)];
+    }
+
+    // Create events: (position, is_start, sample_name)
+    let mut events: Vec<(i64, bool, &str)> = Vec::with_capacity(sample_intervals.len() * 2);
+    for (start, end, sample) in sample_intervals {
+        events.push((*start, true, sample.as_str()));
+        events.push((*end, false, sample.as_str()));
+    }
+
+    // Sort by position, with end events before start events at same position
+    events.sort_by(|a, b| {
+        a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1))
+    });
+
+    let mut results: Vec<(i64, i64, usize)> = Vec::new();
+    let mut active_samples: FxHashMap<&str, usize> = FxHashMap::default();
+    let mut prev_pos: Option<i64> = None;
+
+    for (pos, is_start, sample) in events {
+        if let Some(prev) = prev_pos {
+            if pos > prev {
+                // Emit window from prev to pos with current depth
+                let depth = active_samples.len();
+                if depth > 0 {
+                    results.push((prev, pos, depth));
+                }
+            }
+        }
+
+        // Update active samples
+        if is_start {
+            *active_samples.entry(sample).or_insert(0) += 1;
+        } else if let Some(count) = active_samples.get_mut(sample) {
+            *count -= 1;
+            if *count == 0 {
+                active_samples.remove(sample);
+            }
+        }
+
+        prev_pos = Some(pos);
+    }
+
+    // Merge adjacent windows with same depth
+    if results.len() <= 1 {
+        return results;
+    }
+
+    let mut merged: Vec<(i64, i64, usize)> = Vec::with_capacity(results.len());
+    let mut current = results[0];
+
+    for &(start, end, depth) in &results[1..] {
+        if current.1 == start && current.2 == depth {
+            // Merge
+            current.1 = end;
+        } else {
+            merged.push(current);
+            current = (start, end, depth);
+        }
+    }
+    merged.push(current);
+
+    merged
+}
+
+/// Sweep-line algorithm to compute depth windows (tracking all alignments per sample)
+fn compute_sweep_line_depth_multi(
+    anchor_seq: &str,
+    _seq_len: i64,
+    alignments: &[AlignmentInfoMulti],
+    config: &DepthConfig,
+) -> Vec<RegionDepthResult> {
+    if alignments.is_empty() {
+        return Vec::new();
+    }
+
+    // Create events
+    let mut events: Vec<DepthEventMulti> = Vec::new();
+    for (idx, aln) in alignments.iter().enumerate() {
+        events.push(DepthEventMulti {
+            position: aln.target_start,
+            is_start: true,
+            sample: aln.sample.clone(),
+            alignment_idx: idx,
+        });
+        events.push(DepthEventMulti {
+            position: aln.target_end,
+            is_start: false,
+            sample: aln.sample.clone(),
+            alignment_idx: idx,
+        });
+    }
+    events.sort();
+
+    // Sweep-line
+    let mut results: Vec<RegionDepthResult> = Vec::new();
+    let mut active_alignments: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut prev_pos: Option<i64> = None;
+
+    for event in events {
+        if let Some(prev) = prev_pos {
+            if event.position > prev {
+                // Create window from prev to event.position
+                let mut result = RegionDepthResult::new(
+                    anchor_seq.to_string(),
+                    prev,
+                    event.position,
+                );
+
+                // Collect all active samples and their alignments
+                for (sample, aln_indices) in &active_alignments {
+                    if aln_indices.is_empty() {
+                        continue;
+                    }
+                    for &idx in aln_indices {
+                        let aln = &alignments[idx];
+                        // Map target coords to query coords (linear interpolation)
+                        let (q_start, q_end) = map_coords_linear(
+                            aln.target_start,
+                            aln.target_end,
+                            aln.query_start,
+                            aln.query_end,
+                            prev,
+                            event.position,
+                            aln.is_reverse,
+                        );
+                        result.add_sample_position(sample, &aln.query_name, q_start, q_end);
+                    }
+                }
+
+                result.update_depth();
+                if result.depth > 0 {
+                    results.push(result);
+                }
+            }
+        }
+
+        // Update active alignments
+        if event.is_start {
+            active_alignments
+                .entry(event.sample.clone())
+                .or_default()
+                .push(event.alignment_idx);
+        } else {
+            if let Some(alns) = active_alignments.get_mut(&event.sample) {
+                alns.retain(|&idx| idx != event.alignment_idx);
+            }
+        }
+
+        prev_pos = Some(event.position);
+    }
+
+    // Merge adjacent windows with same depth if configured
+    if config.merge_adjacent {
+        results = merge_adjacent_results(results);
+    }
+
+    results
+}
+
+/// Linear interpolation for coordinate mapping
+fn map_coords_linear(
+    aln_target_start: i64,
+    aln_target_end: i64,
+    aln_query_start: i64,
+    aln_query_end: i64,
+    window_target_start: i64,
+    window_target_end: i64,
+    is_reverse: bool,
+) -> (i64, i64) {
+    let target_len = aln_target_end - aln_target_start;
+    let query_len = aln_query_end - aln_query_start;
+
+    if target_len == 0 {
+        return (aln_query_start, aln_query_end);
+    }
+
+    let start_offset = window_target_start.max(aln_target_start) - aln_target_start;
+    let end_offset = window_target_end.min(aln_target_end) - aln_target_start;
+
+    let ratio = query_len as f64 / target_len as f64;
+
+    if is_reverse {
+        let q_end = aln_query_end - (start_offset as f64 * ratio) as i64;
+        let q_start = aln_query_end - (end_offset as f64 * ratio) as i64;
+        (q_start.min(q_end), q_start.max(q_end))
+    } else {
+        let q_start = aln_query_start + (start_offset as f64 * ratio) as i64;
+        let q_end = aln_query_start + (end_offset as f64 * ratio) as i64;
+        (q_start.min(q_end), q_start.max(q_end))
+    }
+}
+
+/// Merge adjacent results with same depth
+fn merge_adjacent_results(mut results: Vec<RegionDepthResult>) -> Vec<RegionDepthResult> {
+    if results.len() <= 1 {
+        return results;
+    }
+
+    let mut merged: Vec<RegionDepthResult> = Vec::new();
+    let mut current = results.remove(0);
+
+    for next in results {
+        // Check if adjacent and same depth
+        if current.ref_end == next.ref_start
+            && current.depth == next.depth
+            && current.ref_seq == next.ref_seq
+        {
+            // Merge
+            current.ref_end = next.ref_end;
+            // Merge sample positions
+            for (sample, positions) in next.sample_positions {
+                current
+                    .sample_positions
+                    .entry(sample)
+                    .or_default()
+                    .extend(positions);
+            }
+        } else {
+            merged.push(current);
+            current = next;
+        }
+    }
+    merged.push(current);
+
+    merged
+}
+
+/// Query depth for a specific region with per-sample position tracking
+///
+/// Algorithm:
+/// 1. Parse the target region (seq_name:start-end)
+/// 2. Find all alignments overlapping this region
+/// 3. For each overlapping alignment, track the sample and its position
+/// 4. If sample has multiple alignments, track all of them
+/// 5. Output in tabular format with per-sample columns
+pub fn query_region_depth(
+    impg: &Impg,
+    config: &DepthConfig,
+    target_seq: &str,
+    target_start: i32,
+    target_end: i32,
+    separator: &str,
+    sample_filter: Option<&SampleFilter>,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+) -> io::Result<Vec<RegionDepthResult>> {
+    debug!(
+        "Querying region depth: {}:{}-{}",
+        target_seq, target_start, target_end
+    );
+
+    let target_id = impg.seq_index.get_id(target_seq).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Sequence '{}' not found in index", target_seq),
+        )
+    })?;
+
+    let target_sample = extract_sample(target_seq, separator);
+
+    // Collect all alignments for this region
+    let mut alignments: Vec<AlignmentInfoMulti> = Vec::new();
+
+    // Forward direction: where target_seq is TARGET
+    let overlaps = if config.transitive {
+        if config.transitive_dfs {
+            impg.query_transitive_dfs(
+                target_id,
+                target_start,
+                target_end,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                config.approximate_mode,
+                None,
+            )
+        } else {
+            impg.query_transitive_bfs(
+                target_id,
+                target_start,
+                target_end,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                config.approximate_mode,
+                None,
+            )
+        }
+    } else {
+        impg.query(
+            target_id,
+            target_start,
+            target_end,
+            false,
+            None,
+            sequence_index,
+            config.approximate_mode,
+        )
+    };
+
+    for overlap in &overlaps {
+        let query_interval = &overlap.0;
+        let target_interval = &overlap.2;
+
+        let query_name = match impg.seq_index.get_name(query_interval.metadata) {
+            Some(name) => name,
+            None => continue,
+        };
+        let sample = extract_sample(query_name, separator);
+
+        // Apply sample filter
+        if let Some(filter) = sample_filter {
+            if !filter.includes(&sample) {
+                continue;
+            }
+        }
+
+        let is_reverse = query_interval.first > query_interval.last;
+        let query_start = query_interval.first.min(query_interval.last) as i64;
+        let query_end = query_interval.first.max(query_interval.last) as i64;
+        let t_start = target_interval.first.min(target_interval.last) as i64;
+        let t_end = target_interval.first.max(target_interval.last) as i64;
+
+        alignments.push(AlignmentInfoMulti {
+            sample,
+            query_name: query_name.to_string(),
+            query_start,
+            query_end,
+            target_start: t_start,
+            target_end: t_end,
+            is_reverse,
+        });
+    }
+
+    // Reverse direction: where target_seq is QUERY
+    let reverse_alignments = impg.query_reverse_for_depth(target_id);
+    for (ref_start, ref_end, other_id) in reverse_alignments {
+        // Check if overlaps with query region
+        if ref_end <= target_start || ref_start >= target_end {
+            continue;
+        }
+
+        if let Some(other_name) = impg.seq_index.get_name(other_id) {
+            let sample = extract_sample(other_name, separator);
+
+            // Skip self
+            if sample == target_sample {
+                continue;
+            }
+
+            // Apply sample filter
+            if let Some(filter) = sample_filter {
+                if !filter.includes(&sample) {
+                    continue;
+                }
+            }
+
+            alignments.push(AlignmentInfoMulti {
+                sample,
+                query_name: other_name.to_string(),
+                query_start: ref_start as i64,
+                query_end: ref_end as i64,
+                target_start: ref_start as i64,
+                target_end: ref_end as i64,
+                is_reverse: false,
+            });
+        }
+    }
+
+    // Add self (target sample) if in filter
+    if sample_filter.map_or(true, |f| f.includes(&target_sample)) {
+        alignments.push(AlignmentInfoMulti {
+            sample: target_sample,
+            query_name: target_seq.to_string(),
+            query_start: target_start as i64,
+            query_end: target_end as i64,
+            target_start: target_start as i64,
+            target_end: target_end as i64,
+            is_reverse: false,
+        });
+    }
+
+    // Compute depth windows using sweep-line
+    let seq_len = impg.seq_index.get_len_from_id(target_id).unwrap_or(0) as i64;
+    let results = compute_sweep_line_depth_multi(target_seq, seq_len, &alignments, config);
+
+    // Filter results to only include the query region
+    let filtered_results: Vec<RegionDepthResult> = results
+        .into_iter()
+        .filter(|r| r.ref_end > target_start as i64 && r.ref_start < target_end as i64)
+        .map(|mut r| {
+            // Clip to query region
+            r.ref_start = r.ref_start.max(target_start as i64);
+            r.ref_end = r.ref_end.min(target_end as i64);
+            r
+        })
+        .collect();
+
+    Ok(filtered_results)
+}
+
+/// Parse target range string in format "seq_name:start-end"
+pub fn parse_target_range_depth(target_range: &str) -> io::Result<(String, i32, i32)> {
+    // Handle format: seq_name:start-end
+    // Note: seq_name may contain colons (e.g., sample#hap#chr)
+    let parts: Vec<&str> = target_range.rsplitn(2, ':').collect();
+    if parts.len() != 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid target range format '{}'. Expected format: seq_name:start-end",
+                target_range
+            ),
+        ));
+    }
+
+    let range_str = parts[0];
+    let seq_name = parts[1].to_string();
+
+    let range_parts: Vec<&str> = range_str.split('-').collect();
+    if range_parts.len() != 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid range format '{}'. Expected format: start-end",
+                range_str
+            ),
+        ));
+    }
+
+    let start: i32 = range_parts[0].parse().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid start position: {}", range_parts[0]),
+        )
+    })?;
+
+    let end: i32 = range_parts[1].parse().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid end position: {}", range_parts[1]),
+        )
+    })?;
+
+    if start >= end {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Start ({}) must be less than end ({})", start, end),
+        ));
+    }
+
+    Ok((seq_name, start, end))
+}
+
+/// Parse BED file for region queries
+pub fn parse_bed_file_depth(bed_path: &str) -> io::Result<Vec<(String, i32, i32)>> {
+    let content = std::fs::read_to_string(bed_path)?;
+    let mut regions = Vec::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() < 3 {
+            continue;
+        }
+
+        let seq_name = parts[0].to_string();
+        let start: i32 = parts[1].parse().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid start position in BED file: {}", parts[1]),
+            )
+        })?;
+        let end: i32 = parts[2].parse().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid end position in BED file: {}", parts[2]),
+            )
+        })?;
+
+        regions.push((seq_name, start, end));
+    }
+
+    Ok(regions)
 }

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -2318,9 +2318,9 @@ const TRANSITIVE_CHUNK_SIZE: i64 = 5_000_000;
 ///
 /// Key properties:
 /// - Every base processed exactly once (no double-counting)
-/// - No reference bias: longest sequences naturally become anchors
-/// - --ref is an ordering hint (process this sample first)
-/// - --ref-only filters output to only ref sample's sequences
+/// - Hub-first ordering: high-connectivity sequences anchor first (auto-detected or via --ref)
+/// - --ref: ref-anchored mode, guarantees ref sample's coordinate system for covered regions
+/// - --ref-only: ref-only mode, output filtered to ref sample's anchored regions only
 pub fn compute_depth_global(
     impg: &impl ImpgIndex,
     config: &DepthConfig,
@@ -2381,9 +2381,9 @@ pub fn compute_depth_global(
             )
         })?;
         if ref_only {
-            info!("Reference sample: '{}' (ref-only: output filtered to this sample)", ref_name);
+            info!("Ref-only mode: '{}' (output filtered to this sample's anchored regions)", ref_name);
         } else {
-            info!("Reference sample: '{}' (ordering priority)", ref_name);
+            info!("Ref-anchored mode: '{}' (Phase 1 anchor, coordinate system priority)", ref_name);
         }
         Some(id)
     } else {

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -1,0 +1,586 @@
+use crate::impg::{AdjustedInterval, Impg};
+use crate::sequence_index::UnifiedSequenceIndex;
+use log::{debug, info};
+use rayon::prelude::*;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::io::{self, BufWriter, Write};
+
+/// Configuration for the depth command
+pub struct DepthConfig {
+    pub transitive: bool,
+    pub transitive_dfs: bool,
+    pub max_depth: u16,
+    pub min_transitive_len: i32,
+    pub min_distance_between_ranges: i32,
+    pub merge_adjacent: bool,
+    pub approximate_mode: bool,
+}
+
+/// Tracks processed regions for each haplotype to avoid duplicate output
+#[derive(Default)]
+pub struct ProcessedRegions {
+    /// haplotype_name -> sorted list of (start, end) intervals
+    regions: FxHashMap<String, Vec<(i64, i64)>>,
+}
+
+impl ProcessedRegions {
+    pub fn new() -> Self {
+        Self {
+            regions: FxHashMap::default(),
+        }
+    }
+
+    /// Check if a region overlaps with any processed region for this haplotype
+    /// Returns the unprocessed portion, or None if fully processed
+    pub fn get_unprocessed(&self, haplotype: &str, start: i64, end: i64) -> Option<(i64, i64)> {
+        if let Some(intervals) = self.regions.get(haplotype) {
+            let mut current_start = start;
+
+            for &(proc_start, proc_end) in intervals {
+                if proc_end <= current_start {
+                    continue; // Processed region is before our region
+                }
+                if proc_start >= end {
+                    break; // Processed region is after our region
+                }
+
+                // There's overlap
+                if proc_start <= current_start {
+                    // Our start is inside a processed region
+                    current_start = proc_end;
+                    if current_start >= end {
+                        return None; // Fully processed
+                    }
+                } else {
+                    // There's an unprocessed gap before this processed region
+                    return Some((current_start, proc_start.min(end)));
+                }
+            }
+
+            if current_start < end {
+                Some((current_start, end))
+            } else {
+                None
+            }
+        } else {
+            Some((start, end))
+        }
+    }
+
+    /// Mark a region as processed for a haplotype
+    pub fn mark_processed(&mut self, haplotype: &str, start: i64, end: i64) {
+        let intervals = self.regions.entry(haplotype.to_string()).or_default();
+
+        // Insert and merge overlapping intervals
+        let mut new_start = start;
+        let mut new_end = end;
+        let mut merged_indices = Vec::new();
+
+        for (i, &(s, e)) in intervals.iter().enumerate() {
+            if e < new_start {
+                continue; // Before our region
+            }
+            if s > new_end {
+                break; // After our region
+            }
+            // Overlapping or adjacent - merge
+            new_start = new_start.min(s);
+            new_end = new_end.max(e);
+            merged_indices.push(i);
+        }
+
+        // Remove merged intervals (in reverse order to preserve indices)
+        for i in merged_indices.into_iter().rev() {
+            intervals.remove(i);
+        }
+
+        // Insert the new merged interval at the correct position
+        let pos = intervals
+            .iter()
+            .position(|&(s, _)| s > new_start)
+            .unwrap_or(intervals.len());
+        intervals.insert(pos, (new_start, new_end));
+    }
+
+    /// Check if a region is completely processed
+    pub fn is_fully_processed(&self, haplotype: &str, start: i64, end: i64) -> bool {
+        self.get_unprocessed(haplotype, start, end).is_none()
+    }
+}
+
+/// Represents a depth window - a region with a specific coverage depth
+#[derive(Debug, Clone)]
+pub struct DepthWindow {
+    pub window_id: usize,
+    pub depth: usize,
+    pub ref_name: String,
+    pub ref_start: i64,
+    pub ref_end: i64,
+    /// haplotype_name -> (start, end) position on the reference
+    pub haplotype_positions: FxHashMap<String, (i64, i64)>,
+}
+
+/// Event for sweep-line algorithm to compute depth
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DepthEvent {
+    position: i64,
+    is_start: bool,
+    haplotype: String,
+}
+
+impl Ord for DepthEvent {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.position
+            .cmp(&other.position)
+            .then_with(|| other.is_start.cmp(&self.is_start)) // Starts before ends at same position
+            .then_with(|| self.haplotype.cmp(&other.haplotype))
+    }
+}
+
+impl PartialOrd for DepthEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Extract sample from PanSN format sequence name (sample#haplotype#chr -> sample)
+pub fn extract_sample(seq_name: &str, separator: &str) -> String {
+    let parts: Vec<&str> = seq_name.split(separator).collect();
+    if !parts.is_empty() {
+        parts[0].to_string()
+    } else {
+        seq_name.to_string()
+    }
+}
+/// Merge adjacent windows with the same depth and same haplotype set
+fn merge_adjacent_windows(mut windows: Vec<DepthWindow>) -> Vec<DepthWindow> {
+    if windows.len() <= 1 {
+        return windows;
+    }
+
+    let mut merged: Vec<DepthWindow> = Vec::new();
+    let mut current = windows.remove(0);
+
+    for window in windows {
+        // Check if windows are adjacent and have same haplotype set
+        let same_haplotypes = current.haplotype_positions.len() == window.haplotype_positions.len()
+            && current
+                .haplotype_positions
+                .keys()
+                .all(|k| window.haplotype_positions.contains_key(k));
+
+        if current.ref_end == window.ref_start
+            && current.depth == window.depth
+            && same_haplotypes
+            && current.ref_name == window.ref_name
+        {
+            // Merge windows
+            current.ref_end = window.ref_end;
+            // Update haplotype positions to span both windows
+            for (hap, (_, new_end)) in window.haplotype_positions {
+                if let Some(pos) = current.haplotype_positions.get_mut(&hap) {
+                    pos.1 = new_end;
+                }
+            }
+        } else {
+            merged.push(current);
+            current = window;
+        }
+    }
+    merged.push(current);
+
+    // Renumber window IDs
+    for (i, w) in merged.iter_mut().enumerate() {
+        w.window_id = i;
+    }
+
+    merged
+}
+
+/// Query overlaps for a single reference (used in parallel phase)
+fn query_overlaps_for_ref(
+    impg: &Impg,
+    ref_id: u32,
+    ref_length: i64,
+    config: &DepthConfig,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+) -> Vec<AdjustedInterval> {
+    if config.transitive {
+        if config.transitive_dfs {
+            impg.query_transitive_dfs(
+                ref_id,
+                0,
+                ref_length as i32,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                config.approximate_mode,
+            )
+        } else {
+            impg.query_transitive_bfs(
+                ref_id,
+                0,
+                ref_length as i32,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                config.approximate_mode,
+            )
+        }
+    } else {
+        impg.query(
+            ref_id,
+            0,
+            ref_length as i32,
+            false,
+            None,
+            sequence_index,
+            config.approximate_mode,
+        )
+    }
+}
+
+/// Process overlaps into depth windows (used in sequential phase with deduplication)
+fn process_overlaps_to_windows(
+    impg: &Impg,
+    _ref_id: u32,
+    ref_name: &str,
+    ref_length: i64,
+    overlaps: &[AdjustedInterval],
+    config: &DepthConfig,
+    processed_regions: &mut ProcessedRegions,
+    separator: &str,
+) -> Vec<DepthWindow> {
+    let ref_sample = extract_sample(ref_name, separator);
+
+    // Check if this reference region is already processed
+    if processed_regions.is_fully_processed(&ref_sample, 0, ref_length) {
+        debug!("Reference {} is fully processed, skipping", ref_name);
+        return Vec::new();
+    }
+
+    if overlaps.is_empty() {
+        debug!("No overlaps found for reference {}", ref_name);
+        processed_regions.mark_processed(&ref_sample, 0, ref_length);
+        return vec![DepthWindow {
+            window_id: 0,
+            depth: 1,
+            ref_name: ref_name.to_string(),
+            ref_start: 0,
+            ref_end: ref_length,
+            haplotype_positions: {
+                let mut map = FxHashMap::default();
+                map.insert(ref_sample.clone(), (0, ref_length));
+                map
+            },
+        }];
+    }
+
+    // Group overlaps by sample, collecting ALL intervals (union approach)
+    let mut sample_intervals: FxHashMap<String, Vec<(i64, i64)>> = FxHashMap::default();
+
+    for overlap in overlaps {
+        let query_interval = &overlap.0;
+        let target_interval = &overlap.2;
+
+        let query_name = impg.seq_index.get_name(query_interval.metadata).unwrap();
+        let sample = extract_sample(query_name, separator);
+
+        let target_start = target_interval.first.min(target_interval.last) as i64;
+        let target_end = target_interval.first.max(target_interval.last) as i64;
+
+        sample_intervals
+            .entry(sample)
+            .or_default()
+            .push((target_start, target_end));
+    }
+
+    // Add self (reference) as a sample
+    sample_intervals
+        .entry(ref_sample.clone())
+        .or_default()
+        .push((0, ref_length));
+
+    // Merge overlapping intervals for each sample and filter out processed regions
+    let mut filtered_intervals: FxHashMap<String, Vec<(i64, i64)>> = FxHashMap::default();
+    for (sample, mut intervals) in sample_intervals {
+        // Sort and merge overlapping intervals
+        intervals.sort_by_key(|(s, _)| *s);
+        let mut merged: Vec<(i64, i64)> = Vec::new();
+        for (start, end) in intervals {
+            if let Some(last) = merged.last_mut() {
+                if start <= last.1 {
+                    // Overlapping or adjacent, extend
+                    last.1 = last.1.max(end);
+                } else {
+                    merged.push((start, end));
+                }
+            } else {
+                merged.push((start, end));
+            }
+        }
+
+        // Filter out already processed regions
+        let mut unprocessed: Vec<(i64, i64)> = Vec::new();
+        for (start, end) in merged {
+            // Get all unprocessed portions of this interval
+            let mut current = start;
+            while current < end {
+                if let Some((unproc_start, unproc_end)) =
+                    processed_regions.get_unprocessed(&sample, current, end)
+                {
+                    unprocessed.push((unproc_start, unproc_end));
+                    current = unproc_end;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        if !unprocessed.is_empty() {
+            filtered_intervals.insert(sample, unprocessed);
+        }
+    }
+
+    if filtered_intervals.is_empty() {
+        debug!("All intervals for {} are already processed", ref_name);
+        return Vec::new();
+    }
+
+    // Create events for sweep-line algorithm (one pair per interval)
+    let mut events: Vec<DepthEvent> = Vec::new();
+    for (sample, intervals) in &filtered_intervals {
+        for (start, end) in intervals {
+            events.push(DepthEvent {
+                position: *start,
+                is_start: true,
+                haplotype: sample.clone(),
+            });
+            events.push(DepthEvent {
+                position: *end,
+                is_start: false,
+                haplotype: sample.clone(),
+            });
+        }
+    }
+    events.sort();
+
+    // Sweep-line to compute depth windows
+    // Use counter to track multiple overlapping intervals from same sample
+    let mut windows: Vec<DepthWindow> = Vec::new();
+    let mut active_sample_counts: FxHashMap<String, usize> = FxHashMap::default();
+    let mut prev_pos: Option<i64> = None;
+    let mut window_id = 0;
+
+    for event in events {
+        if let Some(prev) = prev_pos {
+            if event.position > prev {
+                // Collect samples that are currently active
+                let active_samples: Vec<&String> = active_sample_counts
+                    .iter()
+                    .filter(|(_, &count)| count > 0)
+                    .map(|(s, _)| s)
+                    .collect();
+
+                if !active_samples.is_empty() {
+                    let mut sample_positions: FxHashMap<String, (i64, i64)> = FxHashMap::default();
+                    for sample in &active_samples {
+                        // For this window, use the window boundaries as positions
+                        sample_positions.insert((*sample).clone(), (prev, event.position));
+                    }
+
+                    windows.push(DepthWindow {
+                        window_id,
+                        depth: sample_positions.len(),
+                        ref_name: ref_name.to_string(),
+                        ref_start: prev,
+                        ref_end: event.position,
+                        haplotype_positions: sample_positions,
+                    });
+                    window_id += 1;
+                }
+            }
+        }
+
+        // Update active counts
+        if event.is_start {
+            *active_sample_counts.entry(event.haplotype).or_insert(0) += 1;
+        } else {
+            if let Some(count) = active_sample_counts.get_mut(&event.haplotype) {
+                *count = count.saturating_sub(1);
+            }
+        }
+
+        prev_pos = Some(event.position);
+    }
+
+    // Mark all processed regions
+    for (sample, intervals) in &filtered_intervals {
+        for (start, end) in intervals {
+            processed_regions.mark_processed(sample, *start, *end);
+        }
+    }
+
+    // Optionally merge adjacent windows
+    if config.merge_adjacent {
+        windows = merge_adjacent_windows(windows);
+    }
+
+    windows
+}
+
+/// Main function to compute depth across all sequences
+pub fn compute_depth(
+    impg: &Impg,
+    config: &DepthConfig,
+    ref_order: Option<Vec<String>>,
+    sequence_index: Option<&UnifiedSequenceIndex>,
+    separator: &str,
+    output_prefix: Option<&str>,
+) -> io::Result<()> {
+    info!("Computing depth coverage");
+
+    // Determine processing order
+    let mut seq_order: Vec<(u32, String, i64)> = Vec::new();
+
+    // First add user-specified sequences
+    if let Some(order) = ref_order {
+        for name in order {
+            if let Some(id) = impg.seq_index.get_id(&name) {
+                let len = impg.seq_index.get_len_from_id(id).unwrap_or(0) as i64;
+                seq_order.push((id, name, len));
+            } else {
+                debug!("Sequence '{}' from ref-order not found in index", name);
+            }
+        }
+    }
+
+    // Add remaining sequences in alphabetical order
+    let mut all_seqs: Vec<(u32, String, i64)> = (0..impg.seq_index.len() as u32)
+        .filter_map(|id| {
+            let name = impg.seq_index.get_name(id)?;
+            let len = impg.seq_index.get_len_from_id(id)? as i64;
+            Some((id, name.to_string(), len))
+        })
+        .collect();
+    all_seqs.sort_by(|a, b| a.1.cmp(&b.1));
+
+    let specified_ids: FxHashSet<u32> = seq_order.iter().map(|(id, _, _)| *id).collect();
+    for (id, name, len) in all_seqs {
+        if !specified_ids.contains(&id) {
+            seq_order.push((id, name, len));
+        }
+    }
+
+    info!("Processing {} sequences as references", seq_order.len());
+
+    // Collect all unique samples for header
+    let mut all_samples: FxHashSet<String> = FxHashSet::default();
+    for (_, name, _) in &seq_order {
+        all_samples.insert(extract_sample(name, separator));
+    }
+    let mut sample_list: Vec<String> = all_samples.into_iter().collect();
+    sample_list.sort();
+
+    // Phase 1: Parallel query all overlaps
+    info!("Phase 1: Querying overlaps in parallel...");
+    let all_overlaps: Vec<Vec<AdjustedInterval>> = seq_order
+        .par_iter()
+        .map(|(ref_id, _ref_name, ref_len)| {
+            query_overlaps_for_ref(impg, *ref_id, *ref_len, config, sequence_index)
+        })
+        .collect();
+
+    // Phase 2: Sequential processing with deduplication
+    info!("Phase 2: Processing depth windows with deduplication...");
+    let mut processed_regions = ProcessedRegions::new();
+    let mut all_windows: Vec<DepthWindow> = Vec::new();
+    let mut global_window_id = 0;
+
+    for (i, (ref_id, ref_name, ref_len)) in seq_order.iter().enumerate() {
+        let mut windows = process_overlaps_to_windows(
+            impg,
+            *ref_id,
+            ref_name,
+            *ref_len,
+            &all_overlaps[i],
+            config,
+            &mut processed_regions,
+            separator,
+        );
+
+        // Update global window IDs
+        for w in &mut windows {
+            w.window_id = global_window_id;
+            global_window_id += 1;
+        }
+
+        all_windows.extend(windows);
+    }
+
+    info!("Generated {} depth windows", all_windows.len());
+
+    // Output results
+    output_depth_tsv(&all_windows, &sample_list, output_prefix)?;
+
+    Ok(())
+}
+
+/// Output depth windows as TSV
+fn output_depth_tsv(
+    windows: &[DepthWindow],
+    sample_list: &[String],
+    output_prefix: Option<&str>,
+) -> io::Result<()> {
+    let writer: Box<dyn Write> = if let Some(prefix) = output_prefix {
+        let path = format!("{}.depth.tsv", prefix);
+        Box::new(BufWriter::new(std::fs::File::create(&path)?))
+    } else {
+        Box::new(BufWriter::new(std::io::stdout()))
+    };
+    let mut writer = BufWriter::new(writer);
+
+    // Write header
+    write!(writer, "window_id\tdepth")?;
+    for sample in sample_list {
+        write!(writer, "\t{}", sample)?;
+    }
+    writeln!(writer)?;
+
+    // Write data rows
+    for window in windows {
+        write!(writer, "{}\t{}", window.window_id, window.depth)?;
+
+        for sample in sample_list {
+            if let Some((start, end)) = window.haplotype_positions.get(sample) {
+                write!(writer, "\t{}:{}-{}", window.ref_name, start, end)?;
+            } else {
+                write!(writer, "\tNA")?;
+            }
+        }
+        writeln!(writer)?;
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+/// Load reference order from file
+pub fn load_ref_order_file(path: &str) -> io::Result<Vec<String>> {
+    let content = std::fs::read_to_string(path)?;
+    Ok(content
+        .lines()
+        .filter(|line| !line.trim().is_empty() && !line.trim().starts_with('#'))
+        .map(|line| line.trim().to_string())
+        .collect())
+}

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -1,4 +1,4 @@
-use crate::impg::CigarOp;
+use crate::impg::{CigarOp, SortedRanges};
 use crate::impg_index::{ImpgIndex, RawAlignmentInterval};
 use indicatif::{ProgressBar, ProgressStyle};
 use crate::sequence_index::UnifiedSequenceIndex;
@@ -18,7 +18,9 @@ pub struct DepthConfig {
     pub min_transitive_len: i32,
     pub min_distance_between_ranges: i32,
     pub merge_adjacent: bool,
-    pub approximate_mode: bool,
+    /// When true, use CIGAR-precise BFS for transitive depth (--use-BFS).
+    /// When false (default), use raw-interval BFS with linear interpolation.
+    pub use_cigar_bfs: bool,
 }
 
 // ============================================================================
@@ -439,82 +441,6 @@ impl DepthStatsWithSamples {
         let diff = (new_max - new_min) as f64 / new_max as f64;
         diff <= tolerance
     }
-}
-
-/// Compute depth using sweep-line algorithm, tracking which samples cover each window
-fn compute_sweep_line_depth_with_samples(
-    _anchor_seq: &str,
-    seq_len: i64,
-    sample_intervals: &[(i64, i64, String)],
-) -> Vec<(i64, i64, usize, Vec<String>)> {
-    if sample_intervals.is_empty() {
-        return vec![(0, seq_len, 0, Vec::new())];
-    }
-
-    // Create events: (position, is_start, sample_name)
-    let mut events: Vec<(i64, bool, &str)> = Vec::with_capacity(sample_intervals.len() * 2);
-    for (start, end, sample) in sample_intervals {
-        events.push((*start, true, sample.as_str()));
-        events.push((*end, false, sample.as_str()));
-    }
-
-    // Sort by position, with end events before start events at same position
-    events.sort_by(|a, b| {
-        a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1))
-    });
-
-    let mut results: Vec<(i64, i64, usize, Vec<String>)> = Vec::new();
-    let mut active_samples: FxHashMap<&str, usize> = FxHashMap::default();
-    let mut prev_pos: Option<i64> = None;
-    let mut prev_sample_set: Vec<String> = Vec::new();
-
-    for (pos, is_start, sample) in events {
-        if let Some(prev) = prev_pos {
-            if pos > prev {
-                // Emit window from prev to pos with current depth and samples
-                let depth = active_samples.len();
-                if depth > 0 {
-                    results.push((prev, pos, depth, prev_sample_set.clone()));
-                }
-            }
-        }
-
-        // Update active samples
-        if is_start {
-            *active_samples.entry(sample).or_insert(0) += 1;
-        } else if let Some(count) = active_samples.get_mut(sample) {
-            *count -= 1;
-            if *count == 0 {
-                active_samples.remove(sample);
-            }
-        }
-
-        // Update sample set for next window
-        prev_sample_set = active_samples.keys().map(|s| s.to_string()).collect();
-        prev_sample_set.sort();  // Keep sorted for consistent output
-        prev_pos = Some(pos);
-    }
-
-    // Merge adjacent windows with same depth AND same sample set
-    if results.len() <= 1 {
-        return results;
-    }
-
-    let mut merged: Vec<(i64, i64, usize, Vec<String>)> = Vec::with_capacity(results.len());
-    let mut current = results[0].clone();
-
-    for (start, end, depth, samples) in results.into_iter().skip(1) {
-        if current.1 == start && current.2 == depth && current.3 == samples {
-            // Extend current window
-            current.1 = end;
-        } else {
-            merged.push(current);
-            current = (start, end, depth, samples);
-        }
-    }
-    merged.push(current);
-
-    merged
 }
 
 // ============================================================================
@@ -1321,12 +1247,12 @@ fn map_target_to_query_linear(
     let ratio = query_len as f64 / target_len as f64;
 
     if is_reverse {
-        let q_end = aln_query_end - (start_offset as f64 * ratio) as i64;
-        let q_start = aln_query_end - (end_offset as f64 * ratio) as i64;
+        let q_end = aln_query_end - (start_offset as f64 * ratio).round() as i64;
+        let q_start = aln_query_end - (end_offset as f64 * ratio).round() as i64;
         (q_start.min(q_end), q_start.max(q_end))
     } else {
-        let q_start = aln_query_start + (start_offset as f64 * ratio) as i64;
-        let q_end = aln_query_start + (end_offset as f64 * ratio) as i64;
+        let q_start = aln_query_start + (start_offset as f64 * ratio).round() as i64;
+        let q_end = aln_query_start + (end_offset as f64 * ratio).round() as i64;
         (q_start.min(q_end), q_start.max(q_end))
     }
 }
@@ -1667,15 +1593,318 @@ struct AnchorRegionResult {
     anchor_sample_id: u16,
 }
 
+/// A single hit from the depth-specific raw-interval BFS.
+/// Stores query and target coordinates plus orientation.
+struct DepthBfsHit {
+    query_id: u32,
+    query_start: i32,
+    query_end: i32,
+    target_id: u32,
+    target_start: i32,
+    target_end: i32,
+    is_reverse: bool,
+}
+
+/// Depth-specific raw-interval BFS using `query_raw_overlapping()` at each hop.
+///
+/// Unlike the CIGAR-based BFS in `impg.rs`, this uses raw alignment extents with
+/// linear interpolation to clip query coordinates. This is faster (no CIGAR walk)
+/// and avoids chunk boundary gaps from CIGAR-precise projection, making it better
+/// suited for depth computation where base-level precision is not needed.
+///
+/// Returns all discovered hits (excluding self-referential alignments).
+fn depth_transitive_bfs(
+    impg: &impl ImpgIndex,
+    target_id: u32,
+    range_start: i32,
+    range_end: i32,
+    max_depth: u16,
+    min_transitive_len: i32,
+    min_distance_between_ranges: i32,
+    _use_dfs: bool,
+) -> Vec<DepthBfsHit> {
+    use std::collections::VecDeque;
+
+    let mut results: Vec<DepthBfsHit> = Vec::new();
+
+    // Lazily allocated visited ranges per sequence (not pre-allocated for all sequences)
+    let mut visited_ranges: FxHashMap<u32, SortedRanges> = FxHashMap::default();
+
+    // Initialize visited for the starting target
+    let target_len = impg.seq_index().get_len_from_id(target_id).unwrap_or(0) as i32;
+    let target_sorted = visited_ranges
+        .entry(target_id)
+        .or_insert_with(|| SortedRanges::new(target_len, 0));
+    let filtered_input_range = target_sorted.insert((range_start, range_end));
+
+    // BFS queue: (seq_id, start, end, current_depth)
+    let mut queue: VecDeque<(u32, i32, i32, u16)> = VecDeque::new();
+    for (s, e) in filtered_input_range {
+        if (e - s).abs() >= min_transitive_len {
+            queue.push_back((target_id, s, e, 0));
+        }
+    }
+
+    while let Some((current_target_id, current_start, current_end, current_depth)) = queue.pop_front() {
+        if max_depth > 0 && current_depth >= max_depth {
+            continue;
+        }
+
+        let raw_alns = impg.query_raw_overlapping(current_target_id, current_start, current_end);
+
+        // Collect next-depth ranges to sort and merge before adding to queue
+        let mut next_ranges: Vec<(u32, i32, i32)> = Vec::new();
+
+        for aln in &raw_alns {
+            // Skip self-referential (same sequence)
+            if aln.query_id == current_target_id {
+                continue;
+            }
+
+            let aln_target_start = aln.target_start;
+            let aln_target_end = aln.target_end;
+
+            // Clip target to current range
+            let clipped_target_start = aln_target_start.max(current_start);
+            let clipped_target_end = aln_target_end.min(current_end);
+            if clipped_target_start >= clipped_target_end {
+                continue;
+            }
+
+            // Linear interpolation to compute query coordinates
+            let target_len_aln = aln_target_end - aln_target_start;
+            let query_len_aln = aln.query_end - aln.query_start;
+            let ratio = if target_len_aln > 0 {
+                query_len_aln as f64 / target_len_aln as f64
+            } else {
+                1.0
+            };
+
+            let (clipped_query_start, clipped_query_end) = if aln.is_reverse {
+                let cqe = aln.query_end - ((clipped_target_start - aln_target_start) as f64 * ratio) as i32;
+                let cqs = aln.query_end - ((clipped_target_end - aln_target_start) as f64 * ratio) as i32;
+                (cqs.min(cqe), cqs.max(cqe))
+            } else {
+                let cqs = aln.query_start + ((clipped_target_start - aln_target_start) as f64 * ratio) as i32;
+                let cqe = aln.query_start + ((clipped_target_end - aln_target_start) as f64 * ratio) as i32;
+                (cqs.min(cqe), cqs.max(cqe))
+            };
+
+            // Record this hit (clipped coordinates for depth calculation)
+            results.push(DepthBfsHit {
+                query_id: aln.query_id,
+                query_start: clipped_query_start,
+                query_end: clipped_query_end,
+                target_id: current_target_id,
+                target_start: clipped_target_start,
+                target_end: clipped_target_end,
+                is_reverse: aln.is_reverse,
+            });
+
+            // For BFS exploration: use FULL alignment query extent (not clipped).
+            // Linear interpolation can underestimate query range when indels are present,
+            // causing hop 2+ to miss alignments at range boundaries. Using the full
+            // extent guarantees we explore at least as widely as CIGAR-precise BFS.
+            // visited_ranges prevents re-exploration, bounding the cost.
+            let explore_start = aln.query_start.min(aln.query_end);
+            let explore_end = aln.query_start.max(aln.query_end);
+
+            let query_seq_len = impg.seq_index().get_len_from_id(aln.query_id).unwrap_or(0) as i32;
+            let ranges = visited_ranges
+                .entry(aln.query_id)
+                .or_insert_with(|| SortedRanges::new(query_seq_len, 0));
+
+            // Check proximity to existing ranges
+            let mut should_add = true;
+            if min_distance_between_ranges > 0 {
+                let (new_min, new_max) = (explore_start, explore_end);
+                let idx = match ranges.ranges.binary_search_by_key(&new_min, |&(start, _)| start) {
+                    Ok(i) => i,
+                    Err(i) => i,
+                };
+
+                if idx > 0 {
+                    let (_, prev_end) = ranges.ranges[idx - 1];
+                    if (new_min - prev_end).abs() < min_distance_between_ranges {
+                        should_add = false;
+                    }
+                }
+                if should_add && idx < ranges.ranges.len() {
+                    let (next_start, _) = ranges.ranges[idx];
+                    if (next_start - new_max).abs() < min_distance_between_ranges {
+                        should_add = false;
+                    }
+                }
+            }
+
+            if should_add {
+                let new_ranges = ranges.insert((explore_start, explore_end));
+                for (new_start, new_end) in new_ranges {
+                    if (new_end - new_start).abs() >= min_transitive_len {
+                        next_ranges.push((aln.query_id, new_start, new_end));
+                    }
+                }
+            }
+        }
+
+        // Sort and merge contiguous ranges before adding to queue
+        if !next_ranges.is_empty() {
+            next_ranges.sort_by_key(|(id, start, _)| (*id, *start));
+
+            let mut write = 0;
+            for read in 1..next_ranges.len() {
+                if next_ranges[write].0 == next_ranges[read].0
+                    && next_ranges[write].2 >= next_ranges[read].1
+                {
+                    next_ranges[write].2 = next_ranges[write].2.max(next_ranges[read].2);
+                } else {
+                    write += 1;
+                    next_ranges.swap(write, read);
+                }
+            }
+            next_ranges.truncate(write + 1);
+
+            for (seq_id, start, end) in next_ranges {
+                queue.push_back((seq_id, start, end, current_depth + 1));
+            }
+        }
+    }
+
+    results
+}
+
+/// Process a single anchor region using raw-interval BFS for transitive depth.
+///
+/// This is the default transitive path. Uses `depth_transitive_bfs()` which
+/// operates on raw alignment extents with linear interpolation, avoiding
+/// CIGAR walk overhead and chunk boundary gaps.
+fn process_anchor_region_transitive_raw(
+    impg: &impl ImpgIndex,
+    config: &DepthConfig,
+    compact_lengths: &CompactSequenceLengths,
+    num_samples: usize,
+    anchor_seq_id: u32,
+    anchor_sample_id: u16,
+    region_start: i64,
+    region_end: i64,
+    seq_included: &[bool],
+    min_seq_length: i64,
+) -> AnchorRegionResult {
+    let mut discovered_regions: Vec<(u32, i64, i64)> = Vec::new();
+    discovered_regions.push((anchor_seq_id, region_start, region_end));
+
+    let hits = depth_transitive_bfs(
+        impg,
+        anchor_seq_id,
+        region_start as i32,
+        region_end as i32,
+        config.max_depth,
+        config.min_transitive_len,
+        config.min_distance_between_ranges,
+        config.transitive_dfs,
+    );
+
+    let mut alignments: Vec<CompactAlignmentInfo> = Vec::new();
+
+    // Self alignment (anchor covers itself)
+    alignments.push(CompactAlignmentInfo::new(
+        anchor_sample_id, anchor_seq_id,
+        region_start, region_end, region_start, region_end, false,
+    ));
+
+    // Pass 1: Build anchor coverage map from hop 0 results (target on anchor)
+    let mut seq_anchor_coverage: FxHashMap<u32, (i64, i64, i64, i64)> = FxHashMap::default();
+    for hit in &hits {
+        if hit.target_id == anchor_seq_id {
+            let q_start = hit.query_start.min(hit.query_end) as i64;
+            let q_end = hit.query_start.max(hit.query_end) as i64;
+            let t_start = hit.target_start.min(hit.target_end) as i64;
+            let t_end = hit.target_start.max(hit.target_end) as i64;
+            let entry = seq_anchor_coverage.entry(hit.query_id).or_insert((q_start, q_end, t_start, t_end));
+            entry.0 = entry.0.min(q_start);
+            entry.1 = entry.1.max(q_end);
+            entry.2 = entry.2.min(t_start);
+            entry.3 = entry.3.max(t_end);
+        }
+    }
+
+    // Pass 2: Process all hits for depth
+    for hit in &hits {
+        // Filter by sequence inclusion (min_seq_length)
+        if min_seq_length > 0 && !seq_included.get(hit.query_id as usize).copied().unwrap_or(false) {
+            continue;
+        }
+
+        let query_sample_id = compact_lengths.get_sample_id(hit.query_id);
+
+        // Skip self-alignment (same sample)
+        if query_sample_id == anchor_sample_id {
+            continue;
+        }
+
+        let query_start = hit.query_start.min(hit.query_end) as i64;
+        let query_end = hit.query_start.max(hit.query_end) as i64;
+
+        discovered_regions.push((hit.query_id, query_start, query_end));
+
+        // Determine anchor coordinates
+        let (a_start, a_end) = if hit.target_id == anchor_seq_id {
+            let t_start = hit.target_start.min(hit.target_end) as i64;
+            let t_end = hit.target_start.max(hit.target_end) as i64;
+            (t_start.max(region_start), t_end.min(region_end))
+        } else {
+            let t_start = hit.target_start.min(hit.target_end) as i64;
+            let t_end = hit.target_start.max(hit.target_end) as i64;
+            if let Some(&(seq_start, seq_end, anc_start, anc_end)) =
+                seq_anchor_coverage.get(&hit.target_id)
+            {
+                let seq_len = seq_end - seq_start;
+                let anc_len = anc_end - anc_start;
+                if seq_len > 0 && anc_len > 0 {
+                    let frac_s = (t_start - seq_start) as f64 / seq_len as f64;
+                    let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
+                    let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
+                    let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
+                    (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                } else {
+                    (region_start, region_end)
+                }
+            } else {
+                (region_start, region_end)
+            }
+        };
+
+        if a_start >= a_end { continue; }
+
+        alignments.push(CompactAlignmentInfo::new(
+            query_sample_id, hit.query_id,
+            query_start, query_end,
+            a_start, a_end,
+            hit.is_reverse,
+        ));
+    }
+
+    // Sweep-line to compute depth intervals
+    let seq_intervals = sweep_line_depth(
+        &alignments, num_samples, region_start, region_end,
+    );
+
+    AnchorRegionResult {
+        intervals: seq_intervals,
+        discovered_regions,
+        anchor_seq_id,
+        anchor_sample_id,
+    }
+}
+
 /// Process a single anchor region: query alignments, compute depth via sweep-line.
 /// Returns depth intervals and all discovered regions (for marking as processed).
 ///
 /// Query strategy:
 /// - Non-transitive (default): direct query — O(log n), bounded results.
 ///   impg's bidirectional index means 1-hop already captures both alignment directions.
-/// - Transitive (-x): BFS — richer depth for sparse alignments, but heavier.
+/// - Transitive (-x): routes to raw BFS (default) or CIGAR BFS (--use-BFS).
 ///   Caller should pass bounded-size regions (see TRANSITIVE_CHUNK_SIZE).
-#[allow(dead_code)]
 fn process_anchor_region(
     impg: &impl ImpgIndex,
     config: &DepthConfig,
@@ -1685,63 +1914,58 @@ fn process_anchor_region(
     anchor_sample_id: u16,
     region_start: i64,
     region_end: i64,
+    seq_included: &[bool],
+    min_seq_length: i64,
 ) -> AnchorRegionResult {
-    let mut discovered_regions: Vec<(u32, i64, i64)> = Vec::new();
-
-    // Always mark the anchor region itself as discovered
-    discovered_regions.push((anchor_seq_id, region_start, region_end));
-
     let is_transitive = config.transitive || config.transitive_dfs;
 
-    // Query alignments overlapping this region
-    let overlaps = if is_transitive {
-        if config.transitive_dfs {
-            impg.query_transitive_dfs(
-                anchor_seq_id, region_start as i32, region_end as i32, None,
-                config.max_depth, config.min_transitive_len,
-                config.min_distance_between_ranges, None, false, None,
-                None, config.approximate_mode, None,
-            )
+    // Transitive mode: route to raw BFS (default) or CIGAR BFS (--use-BFS)
+    if is_transitive {
+        if config.use_cigar_bfs {
+            return process_anchor_region_transitive_cigar(
+                impg, config, compact_lengths, num_samples,
+                anchor_seq_id, anchor_sample_id, region_start, region_end,
+                seq_included, min_seq_length,
+            );
         } else {
-            impg.query_transitive_bfs(
-                anchor_seq_id, region_start as i32, region_end as i32, None,
-                config.max_depth, config.min_transitive_len,
-                config.min_distance_between_ranges, None, false, None,
-                None, config.approximate_mode, None,
-            )
+            return process_anchor_region_transitive_raw(
+                impg, config, compact_lengths, num_samples,
+                anchor_seq_id, anchor_sample_id, region_start, region_end,
+                seq_included, min_seq_length,
+            );
         }
-    } else {
-        // Direct query: fast O(log n) interval tree lookup.
-        // Bidirectional index ensures both forward and reverse alignments are found.
-        impg.query(
-            anchor_seq_id, region_start as i32, region_end as i32,
-            false, None, None, config.approximate_mode,
-        )
-    };
+    }
 
-    // Build alignments for sweep-line
+    // Non-transitive mode: direct 1-hop query + sweep-line
+    let mut discovered_regions: Vec<(u32, i64, i64)> = Vec::new();
+    discovered_regions.push((anchor_seq_id, region_start, region_end));
+
+    let overlaps = impg.query(
+        anchor_seq_id, region_start as i32, region_end as i32,
+        false, None, None, false,
+    );
+
     let mut alignments: Vec<CompactAlignmentInfo> = Vec::new();
 
     // Add self (anchor sample covers the range)
     alignments.push(CompactAlignmentInfo::new(
-        anchor_sample_id,
-        anchor_seq_id,
-        region_start,
-        region_end,
-        region_start,
-        region_end,
-        false,
+        anchor_sample_id, anchor_seq_id,
+        region_start, region_end, region_start, region_end, false,
     ));
 
-    // Add alignments from query results
     for overlap in &overlaps {
         let query_interval = &overlap.0;
         let target_interval = &overlap.2;
 
         let query_id = query_interval.metadata;
+
+        // Filter by sequence inclusion (min_seq_length)
+        if min_seq_length > 0 && !seq_included.get(query_id as usize).copied().unwrap_or(false) {
+            continue;
+        }
+
         let query_sample_id = compact_lengths.get_sample_id(query_id);
 
-        // Always filter self-alignments (same sample, different sequence)
         if is_self_alignment(query_sample_id, anchor_sample_id, query_id, anchor_seq_id) {
             continue;
         }
@@ -1752,7 +1976,7 @@ fn process_anchor_region(
         let target_start = target_interval.first.min(target_interval.last) as i64;
         let target_end = target_interval.first.max(target_interval.last) as i64;
 
-        // Clip to range boundaries
+        // Clip target to range boundaries
         let clipped_target_start = target_start.max(region_start);
         let clipped_target_end = target_end.min(region_end);
 
@@ -1760,141 +1984,35 @@ fn process_anchor_region(
             continue;
         }
 
-        // Proportionally adjust query coordinates
+        // Proportionally adjust query coordinates for clipped target
         let target_len = target_end - target_start;
         let query_len = query_end - query_start;
         let ratio = if target_len > 0 { query_len as f64 / target_len as f64 } else { 1.0 };
 
-        let clipped_query_start;
-        let clipped_query_end;
-        if is_reverse {
-            clipped_query_end = query_end - ((clipped_target_start - target_start) as f64 * ratio) as i64;
-            clipped_query_start = query_end - ((clipped_target_end - target_start) as f64 * ratio) as i64;
+        let (cq_start, cq_end) = if is_reverse {
+            let cqe = query_end - ((clipped_target_start - target_start) as f64 * ratio) as i64;
+            let cqs = query_end - ((clipped_target_end - target_start) as f64 * ratio) as i64;
+            (cqs.min(cqe), cqs.max(cqe))
         } else {
-            clipped_query_start = query_start + ((clipped_target_start - target_start) as f64 * ratio) as i64;
-            clipped_query_end = query_start + ((clipped_target_end - target_start) as f64 * ratio) as i64;
-        }
+            let cqs = query_start + ((clipped_target_start - target_start) as f64 * ratio) as i64;
+            let cqe = query_start + ((clipped_target_end - target_start) as f64 * ratio) as i64;
+            (cqs.min(cqe), cqs.max(cqe))
+        };
 
         alignments.push(CompactAlignmentInfo::new(
-            query_sample_id,
-            query_id,
-            clipped_query_start.min(clipped_query_end),
-            clipped_query_start.max(clipped_query_end),
-            clipped_target_start,
-            clipped_target_end,
+            query_sample_id, query_id,
+            cq_start, cq_end,
+            clipped_target_start, clipped_target_end,
             is_reverse,
         ));
 
-        // Record discovered query region for marking as processed
         discovered_regions.push((query_id, query_start, query_end));
     }
 
-    // Build sweep-line events
-    let mut events: Vec<CompactDepthEvent> = Vec::with_capacity(alignments.len() * 2);
-    for (idx, aln) in alignments.iter().enumerate() {
-        events.push(CompactDepthEvent {
-            position: aln.target_start,
-            is_start: true,
-            sample_id: aln.sample_id,
-            alignment_idx: idx,
-        });
-        events.push(CompactDepthEvent {
-            position: aln.target_end,
-            is_start: false,
-            sample_id: aln.sample_id,
-            alignment_idx: idx,
-        });
-    }
-    events.sort();
-
-    // Sweep-line to compute depth intervals with SPARSE storage
-    let mut seq_intervals: Vec<SparseDepthInterval> = Vec::new();
-    let mut active_bitmap = SampleBitmap::new(num_samples);
-    let mut active_alns: Vec<Vec<usize>> = vec![Vec::new(); num_samples];
-    let mut prev_pos: Option<i64> = None;
-
-    for event in events {
-        if let Some(prev) = prev_pos {
-            if event.position > prev && active_bitmap.depth() > 0 {
-                let interval_start = prev;
-                let interval_end = event.position;
-
-                // Clip to anchor region
-                let clipped_start = interval_start.max(region_start);
-                let clipped_end = interval_end.min(region_end);
-
-                if clipped_start < clipped_end {
-                    // Build SPARSE sample positions
-                    let mut samples: Vec<SamplePosition> = Vec::new();
-
-                    for sample_id in active_bitmap.active_samples() {
-                        let alns = &active_alns[sample_id as usize];
-                        if let Some(&best_idx) = alns.iter().max_by_key(|&&idx| {
-                            let aln = &alignments[idx];
-                            let overlap_start = clipped_start.max(aln.target_start);
-                            let overlap_end = clipped_end.min(aln.target_end);
-                            overlap_end - overlap_start
-                        }) {
-                            let aln = &alignments[best_idx];
-                            let (q_start, q_end) = map_target_to_query_linear(
-                                &[],
-                                aln.target_start, aln.target_end,
-                                aln.query_start, aln.query_end,
-                                clipped_start, clipped_end,
-                                aln.is_reverse,
-                            );
-                            samples.push((sample_id, aln.query_id, q_start, q_end));
-                        }
-                    }
-
-                    if !samples.is_empty() {
-                        samples.sort_by_key(|s| s.0);
-                        seq_intervals.push(SparseDepthInterval {
-                            start: clipped_start,
-                            end: clipped_end,
-                            samples,
-                        });
-                    }
-                }
-            }
-        }
-
-        // Update active samples
-        if event.is_start {
-            active_bitmap.add(event.sample_id);
-            active_alns[event.sample_id as usize].push(event.alignment_idx);
-        } else {
-            active_bitmap.remove(event.sample_id);
-            active_alns[event.sample_id as usize].retain(|&idx| idx != event.alignment_idx);
-        }
-
-        prev_pos = Some(event.position);
-    }
-
-    // Add depth=1 intervals for gaps (anchor only, not covered by any alignment)
-    let mut depth1_intervals: Vec<SparseDepthInterval> = Vec::new();
-    let mut covered_pos = region_start;
-    for interval in &seq_intervals {
-        if interval.start > covered_pos {
-            depth1_intervals.push(SparseDepthInterval {
-                start: covered_pos,
-                end: interval.start,
-                samples: vec![(anchor_sample_id, anchor_seq_id, covered_pos, interval.start)],
-            });
-        }
-        covered_pos = covered_pos.max(interval.end);
-    }
-    if covered_pos < region_end {
-        depth1_intervals.push(SparseDepthInterval {
-            start: covered_pos,
-            end: region_end,
-            samples: vec![(anchor_sample_id, anchor_seq_id, covered_pos, region_end)],
-        });
-    }
-    seq_intervals.extend(depth1_intervals);
-
-    // Sort intervals by position
-    seq_intervals.sort_by_key(|i| i.start);
+    // Sweep-line to compute depth intervals
+    let seq_intervals = sweep_line_depth(
+        &alignments, num_samples, region_start, region_end,
+    );
 
     AnchorRegionResult {
         intervals: seq_intervals,
@@ -1983,7 +2101,168 @@ fn process_anchor_region_raw(
     // Sweep-line to compute depth intervals
     let seq_intervals = sweep_line_depth(
         &alignments, num_samples, region_start, region_end,
+    );
+
+    AnchorRegionResult {
+        intervals: seq_intervals,
+        discovered_regions,
+        anchor_seq_id,
+        anchor_sample_id,
+    }
+}
+
+/// Process a single anchor region using query_transitive_bfs/dfs for discovery,
+/// then map results to anchor coordinates for the depth sweep-line.
+///
+/// Uses the same BFS as the query command (guaranteeing identical sample discovery).
+/// Anchor coordinate mapping:
+/// - Hop 0 results (target on anchor): precise CIGAR-projected coordinates
+/// - Hop 1+ results (target on intermediate): projected back via the intermediate's
+///   known anchor coverage from hop 0 results (linear interpolation)
+/// - Deeper hops with unknown intermediate: full anchor region as fallback
+fn process_anchor_region_transitive_cigar(
+    impg: &impl ImpgIndex,
+    config: &DepthConfig,
+    compact_lengths: &CompactSequenceLengths,
+    num_samples: usize,
+    anchor_seq_id: u32,
+    anchor_sample_id: u16,
+    region_start: i64,
+    region_end: i64,
+    seq_included: &[bool],
+    min_seq_length: i64,
+) -> AnchorRegionResult {
+    let mut discovered_regions: Vec<(u32, i64, i64)> = Vec::new();
+    discovered_regions.push((anchor_seq_id, region_start, region_end));
+
+    // Use the same CIGAR-precise BFS/DFS as the query command (--use-BFS path)
+    let overlaps = if config.transitive_dfs {
+        impg.query_transitive_dfs(
+            anchor_seq_id, region_start as i32, region_end as i32, None,
+            config.max_depth, config.min_transitive_len,
+            config.min_distance_between_ranges, None, false, None,
+            None, false, None,
+        )
+    } else {
+        impg.query_transitive_bfs(
+            anchor_seq_id, region_start as i32, region_end as i32, None,
+            config.max_depth, config.min_transitive_len,
+            config.min_distance_between_ranges, None, false, None,
+            None, false, None,
+        )
+    };
+
+    let mut alignments: Vec<CompactAlignmentInfo> = Vec::new();
+
+    // Self alignment (anchor covers itself)
+    alignments.push(CompactAlignmentInfo::new(
         anchor_sample_id, anchor_seq_id,
+        region_start, region_end, region_start, region_end, false,
+    ));
+
+    // Pass 1: Build anchor coverage map from hop 0 results (target on anchor)
+    let mut seq_anchor_coverage: FxHashMap<u32, (i64, i64, i64, i64)> = FxHashMap::default();
+    for overlap in &overlaps {
+        let query_interval = &overlap.0;
+        let target_interval = &overlap.2;
+        if target_interval.metadata == anchor_seq_id {
+            let query_id = query_interval.metadata;
+            let q_start = query_interval.first.min(query_interval.last) as i64;
+            let q_end = query_interval.first.max(query_interval.last) as i64;
+            let t_start = target_interval.first.min(target_interval.last) as i64;
+            let t_end = target_interval.first.max(target_interval.last) as i64;
+            let entry = seq_anchor_coverage.entry(query_id).or_insert((q_start, q_end, t_start, t_end));
+            entry.0 = entry.0.min(q_start);
+            entry.1 = entry.1.max(q_end);
+            entry.2 = entry.2.min(t_start);
+            entry.3 = entry.3.max(t_end);
+        }
+    }
+
+    // Pass 2: Process all results for depth
+    for overlap in &overlaps {
+        let query_interval = &overlap.0;
+        let target_interval = &overlap.2;
+
+        let query_id = query_interval.metadata;
+
+        // Filter by sequence inclusion (min_seq_length)
+        if min_seq_length > 0 && !seq_included.get(query_id as usize).copied().unwrap_or(false) {
+            continue;
+        }
+
+        let query_sample_id = compact_lengths.get_sample_id(query_id);
+
+        // Skip self-alignment (same sample)
+        if query_sample_id == anchor_sample_id {
+            continue;
+        }
+
+        let is_reverse = query_interval.first > query_interval.last;
+        let query_start = query_interval.first.min(query_interval.last) as i64;
+        let query_end = query_interval.first.max(query_interval.last) as i64;
+
+        discovered_regions.push((query_id, query_start, query_end));
+
+        // Determine anchor coordinates
+        let (a_start, a_end) = if target_interval.metadata == anchor_seq_id {
+            let t_start = target_interval.first.min(target_interval.last) as i64;
+            let t_end = target_interval.first.max(target_interval.last) as i64;
+            (t_start.max(region_start), t_end.min(region_end))
+        } else {
+            let t_start = target_interval.first.min(target_interval.last) as i64;
+            let t_end = target_interval.first.max(target_interval.last) as i64;
+            if let Some(&(seq_start, seq_end, anc_start, anc_end)) =
+                seq_anchor_coverage.get(&target_interval.metadata)
+            {
+                let seq_len = seq_end - seq_start;
+                let anc_len = anc_end - anc_start;
+                if seq_len > 0 && anc_len > 0 {
+                    let frac_s = (t_start - seq_start) as f64 / seq_len as f64;
+                    let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
+                    let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
+                    let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
+                    (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                } else {
+                    (region_start, region_end)
+                }
+            } else {
+                (region_start, region_end)
+            }
+        };
+
+        if a_start >= a_end { continue; }
+
+        alignments.push(CompactAlignmentInfo::new(
+            query_sample_id, query_id,
+            query_start, query_end,
+            a_start, a_end,
+            is_reverse,
+        ));
+    }
+
+    // Augment discovered_regions with raw alignment extents for direct (hop 0) overlaps.
+    // The BFS loop above records CIGAR-projected sub-ranges (line 1899) which may leave
+    // gaps at chunk boundaries due to indels. Raw extents ensure the full alignment
+    // coverage is marked as processed, preventing Phase 2 from re-processing these
+    // regions and producing duplicate output (e.g., CHM13 appearing in Phase 2 rows).
+    let raw_hop0 = impg.query_raw_overlapping(
+        anchor_seq_id, region_start as i32, region_end as i32,
+    );
+    for aln in &raw_hop0 {
+        if min_seq_length > 0 && !seq_included.get(aln.query_id as usize).copied().unwrap_or(false) {
+            continue;
+        }
+        let query_sample_id = compact_lengths.get_sample_id(aln.query_id);
+        if is_self_alignment(query_sample_id, anchor_sample_id, aln.query_id, anchor_seq_id) {
+            continue;
+        }
+        discovered_regions.push((aln.query_id, aln.query_start as i64, aln.query_end as i64));
+    }
+
+    // Sweep-line to compute depth intervals
+    let seq_intervals = sweep_line_depth(
+        &alignments, num_samples, region_start, region_end,
     );
 
     AnchorRegionResult {
@@ -1995,14 +2274,13 @@ fn process_anchor_region_raw(
 }
 
 /// Sweep-line algorithm: given alignments, produce depth intervals with sample tracking.
-/// Extracted as a shared helper for both raw and query-based paths.
+/// Callers must include the anchor sample as an alignment covering [region_start, region_end]
+/// so that depth naturally counts all samples (including the anchor itself).
 fn sweep_line_depth(
     alignments: &[CompactAlignmentInfo],
     num_samples: usize,
     region_start: i64,
     region_end: i64,
-    anchor_sample_id: u16,
-    anchor_seq_id: u32,
 ) -> Vec<SparseDepthInterval> {
     // Build sweep-line events
     let mut events: Vec<CompactDepthEvent> = Vec::with_capacity(alignments.len() * 2);
@@ -2086,215 +2364,7 @@ fn sweep_line_depth(
         prev_pos = Some(event.position);
     }
 
-    // Add depth=1 intervals for gaps (anchor only, not covered by any alignment)
-    let mut depth1_intervals: Vec<SparseDepthInterval> = Vec::new();
-    let mut covered_pos = region_start;
-    for interval in &seq_intervals {
-        if interval.start > covered_pos {
-            depth1_intervals.push(SparseDepthInterval {
-                start: covered_pos,
-                end: interval.start,
-                samples: vec![(anchor_sample_id, anchor_seq_id, covered_pos, interval.start)],
-            });
-        }
-        covered_pos = covered_pos.max(interval.end);
-    }
-    if covered_pos < region_end {
-        depth1_intervals.push(SparseDepthInterval {
-            start: covered_pos,
-            end: region_end,
-            samples: vec![(anchor_sample_id, anchor_seq_id, covered_pos, region_end)],
-        });
-    }
-    seq_intervals.extend(depth1_intervals);
-
-    // Sort intervals by position
-    seq_intervals.sort_by_key(|i| i.start);
-
     seq_intervals
-}
-
-/// Process a single anchor region using BFS with range-based interval queries.
-/// Discovers transitively connected regions without CIGAR projection.
-/// All results are projected back to anchor coordinates via chained linear interpolation.
-///
-/// Uses query_raw_overlapping() to fetch only intervals overlapping the current BFS region,
-/// achieving O(n+k) performance and minimal memory footprint (no full-sequence caching).
-fn process_anchor_region_transitive_raw(
-    impg: &(impl ImpgIndex + ?Sized),
-    compact_lengths: &CompactSequenceLengths,
-    num_samples: usize,
-    anchor_seq_id: u32,
-    anchor_sample_id: u16,
-    region_start: i64,
-    region_end: i64,
-    max_depth: u16,
-    min_transitive_len: i32,
-    seq_included: &[bool],
-    min_seq_length: i64,
-) -> AnchorRegionResult {
-    use std::collections::VecDeque;
-
-    // BFS entry: a region on some sequence with its projection onto the anchor
-    struct BfsEntry {
-        seq_id: u32,
-        start: i64,
-        end: i64,
-        anchor_start: i64,
-        anchor_end: i64,
-    }
-
-    let mut queue: VecDeque<(BfsEntry, u16)> = VecDeque::new();
-    // Visited tracking: per seq_id, list of visited ranges (to avoid infinite loops)
-    let mut visited: FxHashMap<u32, Vec<(i64, i64)>> = FxHashMap::default();
-    let mut discovered_regions: Vec<(u32, i64, i64)> = Vec::new();
-    let mut alignments: Vec<CompactAlignmentInfo> = Vec::new();
-
-    // Helper: check if a range is already mostly visited
-    let is_visited = |visited: &FxHashMap<u32, Vec<(i64, i64)>>, seq_id: u32, start: i64, end: i64| -> bool {
-        if let Some(ranges) = visited.get(&seq_id) {
-            let len = end - start;
-            if len <= 0 { return true; }
-            let mut covered = 0i64;
-            for &(vs, ve) in ranges {
-                let overlap_start = vs.max(start);
-                let overlap_end = ve.min(end);
-                if overlap_end > overlap_start {
-                    covered += overlap_end - overlap_start;
-                }
-            }
-            // Consider visited if >80% covered
-            covered as f64 / len as f64 > 0.8
-        } else {
-            false
-        }
-    };
-
-    // Mark a range as visited
-    let mark_visited = |visited: &mut FxHashMap<u32, Vec<(i64, i64)>>, seq_id: u32, start: i64, end: i64| {
-        visited.entry(seq_id).or_default().push((start, end));
-    };
-
-    // Start from anchor
-    queue.push_back((BfsEntry {
-        seq_id: anchor_seq_id,
-        start: region_start,
-        end: region_end,
-        anchor_start: region_start,
-        anchor_end: region_end,
-    }, 0));
-    mark_visited(&mut visited, anchor_seq_id, region_start, region_end);
-    discovered_regions.push((anchor_seq_id, region_start, region_end));
-
-    // Self alignment
-    alignments.push(CompactAlignmentInfo::new(
-        anchor_sample_id, anchor_seq_id,
-        region_start, region_end, region_start, region_end, false,
-    ));
-
-    while let Some((entry, depth)) = queue.pop_front() {
-        if max_depth > 0 && depth >= max_depth { continue; }
-
-        let entry_len = entry.end - entry.start;
-        let anchor_len = entry.anchor_end - entry.anchor_start;
-        if entry_len <= 0 || anchor_len <= 0 { continue; }
-
-        // Use query_raw_overlapping to fetch ONLY intervals overlapping [entry.start, entry.end)
-        // This is O(n+k) via coitrees range query, vastly more memory-efficient than loading all intervals
-        let mut raw_alns = impg.query_raw_overlapping(
-            entry.seq_id,
-            entry.start as i32,
-            entry.end as i32
-        );
-
-        // Filter by sequence inclusion if needed
-        if min_seq_length > 0 {
-            raw_alns.retain(|aln| {
-                seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
-            });
-        }
-
-        let current_sample_id = compact_lengths.get_sample_id(entry.seq_id);
-
-        // All returned intervals already overlap [entry.start, entry.end) by definition
-        for aln in &raw_alns {
-            let target_start = aln.target_start as i64;
-            let target_end = aln.target_end as i64;
-
-            let query_sample_id = compact_lengths.get_sample_id(aln.query_id);
-            if is_self_alignment(query_sample_id, current_sample_id, aln.query_id, entry.seq_id) {
-                continue;
-            }
-
-            let query_start = aln.query_start as i64;
-            let query_end = aln.query_end as i64;
-            let query_len = (query_end - query_start).abs();
-
-            // Min length filter
-            if min_transitive_len > 0 && query_len < min_transitive_len as i64 { continue; }
-
-            // Compute overlap on current sequence
-            let overlap_start = target_start.max(entry.start);
-            let overlap_end = target_end.min(entry.end);
-            if overlap_end <= overlap_start { continue; }
-
-            // Project overlap to anchor coordinates via linear interpolation
-            let frac_start = (overlap_start - entry.start) as f64 / entry_len as f64;
-            let frac_end = (overlap_end - entry.start) as f64 / entry_len as f64;
-            let anchor_proj_start = entry.anchor_start + (frac_start * anchor_len as f64) as i64;
-            let anchor_proj_end = entry.anchor_start + (frac_end * anchor_len as f64) as i64;
-
-            // Project overlap to query coordinates
-            let target_len = target_end - target_start;
-            let ratio = if target_len > 0 { (query_end - query_start) as f64 / target_len as f64 } else { 1.0 };
-            let (proj_query_start, proj_query_end) = if aln.is_reverse {
-                let cqe = query_end - ((overlap_start - target_start) as f64 * ratio) as i64;
-                let cqs = query_end - ((overlap_end - target_start) as f64 * ratio) as i64;
-                (cqs.min(cqe), cqs.max(cqe))
-            } else {
-                let cqs = query_start + ((overlap_start - target_start) as f64 * ratio) as i64;
-                let cqe = query_start + ((overlap_end - target_start) as f64 * ratio) as i64;
-                (cqs.min(cqe), cqs.max(cqe))
-            };
-
-            // Add alignment projected to anchor coordinates for sweep-line
-            let a_start = anchor_proj_start.min(anchor_proj_end);
-            let a_end = anchor_proj_start.max(anchor_proj_end);
-            alignments.push(CompactAlignmentInfo::new(
-                query_sample_id, aln.query_id,
-                proj_query_start, proj_query_end,
-                a_start, a_end,
-                aln.is_reverse,
-            ));
-
-            discovered_regions.push((aln.query_id, query_start, query_end));
-
-            // Add to BFS queue if not already visited
-            if !is_visited(&visited, aln.query_id, proj_query_start, proj_query_end) {
-                mark_visited(&mut visited, aln.query_id, proj_query_start, proj_query_end);
-                queue.push_back((BfsEntry {
-                    seq_id: aln.query_id,
-                    start: proj_query_start,
-                    end: proj_query_end,
-                    anchor_start: a_start,
-                    anchor_end: a_end,
-                }, depth + 1));
-            }
-        }
-    }
-
-    // Sweep-line
-    let seq_intervals = sweep_line_depth(
-        &alignments, num_samples, region_start, region_end,
-        anchor_sample_id, anchor_seq_id,
-    );
-
-    AnchorRegionResult {
-        intervals: seq_intervals,
-        discovered_regions,
-        anchor_seq_id,
-        anchor_sample_id,
-    }
 }
 
 /// Maximum region size for a single transitive BFS query (5 MB).
@@ -2332,6 +2402,8 @@ pub fn compute_depth_global(
     ref_sample: Option<&str>,
     ref_only: bool,
     min_seq_length: i64,
+    stats_mode: bool,
+    stats_combined: bool,
 ) -> io::Result<()> {
     let is_transitive = config.transitive || config.transitive_dfs;
     let user_window_size = window_size;
@@ -2408,8 +2480,14 @@ pub fn compute_depth_global(
     // Pre-scan: compute alignment degrees for all included sequences.
     // Used for automatic hub detection (when --ref is not specified) and
     // for sorting sequences by connectivity (hubs first) in all modes.
+    //
+    // Disable tree caching during pre-scan: with per-file indexing, 64 threads
+    // simultaneously loading all sub-indices and caching every interval tree
+    // causes 200+ GB RSS. Trees are only needed transiently here.
+    impg.set_tree_cache_enabled(false);
     info!("Pre-scanning alignment degrees...");
     let degrees = compute_alignment_degrees(impg, &compact_lengths, &seq_included);
+    impg.clear_sub_index_cache();
     let max_degree = degrees.iter().copied().max().unwrap_or(0);
     let included_count = seq_included.iter().filter(|&&v| v).count();
     info!(
@@ -2421,23 +2499,40 @@ pub fn compute_depth_global(
     let sequence_order = build_sequence_order(impg, &compact_lengths, ref_sample_id, &seq_included, &degrees);
     debug!("Sequence processing order: {} sequences", sequence_order.len());
 
-    // Prepare output (Send required for parallel streaming output)
-    let inner_writer: Box<dyn Write + Send> = if let Some(prefix) = output_prefix {
-        let path = format!("{}.depth.tsv", prefix);
-        Box::new(BufWriter::new(std::fs::File::create(&path)?))
-    } else {
-        Box::new(BufWriter::new(std::io::stdout()))
-    };
-    let mut writer = BufWriter::new(inner_writer);
+    // Prepare output: TSV writer for normal mode, stats accumulators for --stats add-on
+    let writer: Option<Mutex<BufWriter<Box<dyn Write + Send>>>> = if !stats_mode {
+        let inner_writer: Box<dyn Write + Send> = if let Some(prefix) = output_prefix {
+            let path = format!("{}.depth.tsv", prefix);
+            Box::new(BufWriter::new(std::fs::File::create(&path)?))
+        } else {
+            Box::new(BufWriter::new(std::io::stdout()))
+        };
+        let mut w = BufWriter::new(inner_writer);
 
-    // Write header: #id length depth Sample1 Sample2 ...
-    write!(writer, "#id\tlength\tdepth")?;
-    for sample_id in 0..num_samples as u16 {
-        if let Some(name) = sample_index.get_name(sample_id) {
-            write!(writer, "\t{}", name)?;
+        // Write header: #id length depth Sample1 Sample2 ...
+        write!(w, "#id\tlength\tdepth")?;
+        for sample_id in 0..num_samples as u16 {
+            if let Some(name) = sample_index.get_name(sample_id) {
+                write!(w, "\t{}", name)?;
+            }
         }
-    }
-    writeln!(writer)?;
+        writeln!(w)?;
+        Some(Mutex::new(w))
+    } else {
+        None
+    };
+
+    // Stats accumulators (only allocated in --stats mode)
+    let stats_accumulator: Option<Mutex<DepthStats>> = if stats_mode && !stats_combined {
+        Some(Mutex::new(DepthStats::new()))
+    } else {
+        None
+    };
+    let stats_combined_acc: Option<Mutex<DepthStatsWithSamples>> = if stats_mode && stats_combined {
+        Some(Mutex::new(DepthStatsWithSamples::new()))
+    } else {
+        None
+    };
 
     let total_sequences = sequence_order.len();
 
@@ -2498,11 +2593,24 @@ pub fn compute_depth_global(
     let processed_count = AtomicUsize::new(0);
     let row_counter = AtomicUsize::new(0);
     let intervals_counter = AtomicUsize::new(0);
-    let writer = Mutex::new(writer);
 
-    // Helper closure: format and write results for a batch of AnchorRegionResults
+    // Helper closure: format and write results for a batch of AnchorRegionResults.
+    // In stats mode: accumulates depth distribution + intervals into stats accumulators.
+    // In normal mode: formats TSV rows into buf for the caller to write.
     let write_results = |region_results: Vec<AnchorRegionResult>,
                          buf: &mut Vec<u8>| -> io::Result<()> {
+        // Thread-local accumulators (merged into global at end of batch)
+        let mut local_stats: Option<DepthStats> = if stats_accumulator.is_some() {
+            Some(DepthStats::new())
+        } else {
+            None
+        };
+        let mut local_combined: Option<DepthStatsWithSamples> = if stats_combined_acc.is_some() {
+            Some(DepthStatsWithSamples::new())
+        } else {
+            None
+        };
+
         for result in region_results {
             let seq_name = impg.seq_index().get_name(result.anchor_seq_id).unwrap_or("?");
             let anchor_sample_id = result.anchor_sample_id;
@@ -2530,26 +2638,56 @@ pub fn compute_depth_global(
             };
 
             for interval in &final_intervals {
-                let rid = row_counter.fetch_add(1, Ordering::Relaxed) + 1;
-
-                write!(buf, "{}\t{}\t{}",
-                       rid, interval.end - interval.start, interval.depth())?;
-
-                for sid in 0..num_samples as u16 {
-                    if sid == anchor_sample_id {
-                        write!(buf, "\t{}:{}-{}", seq_name, interval.start, interval.end)?;
-                    } else if let Some((query_id, start, end)) = interval.get_sample(sid) {
-                        let query_name = impg.seq_index().get_name(query_id).unwrap_or("?");
-                        write!(buf, "\t{}:{}-{}", query_name, start, end)?;
-                    } else {
-                        write!(buf, "\tNA")?;
+                if stats_mode {
+                    // Stats add-on: accumulate depth distribution and intervals
+                    let depth = interval.depth();
+                    if let Some(ref mut ls) = local_stats {
+                        ls.add_interval(seq_name, interval.start, interval.end, depth);
                     }
-                }
-                writeln!(buf)?;
+                    if let Some(ref mut lc) = local_combined {
+                        let sample_names: Vec<String> = interval.samples.iter()
+                            .filter_map(|&(sid, _, _, _)| {
+                                sample_index.get_name(sid).map(|s| s.to_string())
+                            })
+                            .collect();
+                        lc.add_interval(seq_name, interval.start, interval.end, depth, sample_names);
+                    }
+                } else {
+                    // Normal mode: write TSV row to buf
+                    let rid = row_counter.fetch_add(1, Ordering::Relaxed) + 1;
 
-                intervals_counter.fetch_add(1, Ordering::Relaxed);
+                    write!(buf, "{}\t{}\t{}",
+                           rid, interval.end - interval.start, interval.depth())?;
+
+                    for sid in 0..num_samples as u16 {
+                        if sid == anchor_sample_id {
+                            write!(buf, "\t{}:{}-{}", seq_name, interval.start, interval.end)?;
+                        } else if let Some((query_id, start, end)) = interval.get_sample(sid) {
+                            let query_name = impg.seq_index().get_name(query_id).unwrap_or("?");
+                            write!(buf, "\t{}:{}-{}", query_name, start, end)?;
+                        } else {
+                            write!(buf, "\tNA")?;
+                        }
+                    }
+                    writeln!(buf)?;
+
+                    intervals_counter.fetch_add(1, Ordering::Relaxed);
+                }
             }
         }
+
+        // Merge thread-local stats into global accumulators (one lock per batch)
+        if let Some(ls) = local_stats {
+            if let Some(ref acc) = stats_accumulator {
+                acc.lock().unwrap().merge(&ls);
+            }
+        }
+        if let Some(lc) = local_combined {
+            if let Some(ref acc) = stats_combined_acc {
+                acc.lock().unwrap().merge(lc);
+            }
+        }
+
         Ok(())
     };
 
@@ -2590,11 +2728,11 @@ pub fn compute_depth_global(
             let phase1_count = AtomicUsize::new(0);
 
             phase1_chunks.par_iter().try_for_each(|&(seq_id, sample_id, chunk_start, chunk_end)| -> io::Result<()> {
-                let result = process_anchor_region_transitive_raw(
+                let result = process_anchor_region(
                     impg,
+                    config,
                     &compact_lengths, num_samples,
                     seq_id, sample_id, chunk_start, chunk_end,
-                    config.max_depth, config.min_transitive_len,
                     &seq_included, min_seq_length,
                 );
 
@@ -2603,8 +2741,9 @@ pub fn compute_depth_global(
                 let mut buf: Vec<u8> = Vec::new();
                 write_results(vec![result], &mut buf)?;
                 if !buf.is_empty() {
-                    let mut w = writer.lock().unwrap();
-                    w.write_all(&buf)?;
+                    if let Some(ref w) = writer {
+                        w.lock().unwrap().write_all(&buf)?;
+                    }
                 }
 
                 impg.clear_sub_index_cache();
@@ -2662,8 +2801,9 @@ pub fn compute_depth_global(
                 let mut buf: Vec<u8> = Vec::new();
                 write_results(vec![result], &mut buf)?;
                 if !buf.is_empty() {
-                    let mut w = writer.lock().unwrap();
-                    w.write_all(&buf)?;
+                    if let Some(ref w) = writer {
+                        w.lock().unwrap().write_all(&buf)?;
+                    }
                 }
 
                 let count = phase1_count.fetch_add(1, Ordering::Relaxed) + 1;
@@ -2721,47 +2861,75 @@ pub fn compute_depth_global(
 
         let sample_id = compact_lengths.get_sample_id(seq_id);
 
+        // Non-transitive: load raw intervals once per sequence (not per gap)
+        let raw_alns_cached = if !is_transitive {
+            let mut raw_alns = impg.query_raw_intervals(seq_id);
+            if min_seq_length > 0 {
+                raw_alns.retain(|aln| {
+                    seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
+                });
+                raw_alns.shrink_to_fit();
+            }
+            raw_alns.sort_unstable_by_key(|aln| aln.target_start);
+            Some(raw_alns)
+        } else {
+            None
+        };
+
         for (region_start, region_end) in unprocessed {
             let region_results = if is_transitive {
-                let mut results = Vec::new();
-                if (region_end - region_start) > TRANSITIVE_CHUNK_SIZE {
+                let gap_len = region_end - region_start;
+
+                // Fast path: gaps smaller than min_transitive_len can't trigger
+                // transitive hops, so BFS setup (visited_ranges allocation for all
+                // sequences, sub-index loading) is wasted. Use raw intervals instead.
+                if gap_len < config.min_transitive_len as i64 {
+                    let mut raw_alns = impg.query_raw_overlapping(
+                        seq_id, region_start as i32, region_end as i32,
+                    );
+                    if min_seq_length > 0 {
+                        raw_alns.retain(|aln| {
+                            seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
+                        });
+                    }
+                    raw_alns.sort_unstable_by_key(|aln| aln.target_start);
+                    let result = process_anchor_region_raw(
+                        &raw_alns, &compact_lengths, num_samples,
+                        seq_id, sample_id, region_start, region_end,
+                    );
+                    tracker.mark_processed_batch(&result.discovered_regions);
+                    vec![result]
+                } else if gap_len > TRANSITIVE_CHUNK_SIZE {
+                    let mut results = Vec::new();
                     let mut pos = region_start;
                     while pos < region_end {
                         let chunk_end = (pos + TRANSITIVE_CHUNK_SIZE).min(region_end);
-                        let result = process_anchor_region_transitive_raw(
+                        let result = process_anchor_region(
                             impg,
+                            config,
                             &compact_lengths, num_samples,
                             seq_id, sample_id, pos, chunk_end,
-                            config.max_depth, config.min_transitive_len,
                             &seq_included, min_seq_length,
                         );
                         tracker.mark_processed_batch(&result.discovered_regions);
                         results.push(result);
                         pos = chunk_end;
                     }
+                    results
                 } else {
-                    let result = process_anchor_region_transitive_raw(
+                    let result = process_anchor_region(
                         impg,
+                        config,
                         &compact_lengths, num_samples,
                         seq_id, sample_id, region_start, region_end,
-                        config.max_depth, config.min_transitive_len,
                         &seq_included, min_seq_length,
                     );
                     tracker.mark_processed_batch(&result.discovered_regions);
-                    results.push(result);
+                    vec![result]
                 }
-                results
             } else {
-                let mut raw_alns = impg.query_raw_intervals(seq_id);
-                if min_seq_length > 0 {
-                    raw_alns.retain(|aln| {
-                        seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
-                    });
-                    raw_alns.shrink_to_fit();
-                }
-                raw_alns.sort_unstable_by_key(|aln| aln.target_start);
                 let result = process_anchor_region_raw(
-                    &raw_alns, &compact_lengths, num_samples,
+                    raw_alns_cached.as_ref().unwrap(), &compact_lengths, num_samples,
                     seq_id, sample_id, region_start, region_end,
                 );
                 tracker.mark_processed_batch(&result.discovered_regions);
@@ -2772,32 +2940,31 @@ pub fn compute_depth_global(
             let mut buf: Vec<u8> = Vec::new();
             write_results(region_results, &mut buf)?;
             if !buf.is_empty() {
-                let mut w = writer.lock().unwrap();
-                w.write_all(&buf)?;
+                if let Some(ref w) = writer {
+                    w.lock().unwrap().write_all(&buf)?;
+                }
             }
         }
 
-        // Clear sub-index cache after each sequence to bound memory
+        // Phase 2: do NOT clear sub-index cache after each sequence.
+        // Unlike Phase 1 (which processes large hub regions and can accumulate many trees),
+        // Phase 2 sequences are mostly small/partially-processed. Keeping sub-indices loaded
+        // across sequences avoids repeated disk deserialization — the total memory is bounded
+        // by num_alignment_files × sub_index_size regardless of how many sequences we process.
         let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
-        if is_transitive {
-            impg.clear_sub_index_cache();
-        }
         pb_depth.set_position(count as u64);
 
         Ok(())
     })?;
 
+    // Clear sub-index cache once after all Phase 2 processing
+    if is_transitive {
+        impg.clear_sub_index_cache();
+    }
+
     pb_depth.finish_and_clear();
 
-    let total_intervals = intervals_counter.load(Ordering::Relaxed);
-    let mut writer = writer.into_inner().unwrap();
-
-    info!(
-        "Depth complete: {} sequences, {} intervals output",
-        total_sequences, total_intervals
-    );
-
-    // Handle FAI sequences not in alignment index
+    // Handle FAI sequences not in alignment index (depth=1 for unaligned sequences)
     if let Some(ref fai) = fai_seq_lengths {
         let indexed_seqs: FxHashSet<&str> = (0..impg.seq_index().len() as u32)
             .filter_map(|id| impg.seq_index().get_name(id))
@@ -2819,34 +2986,105 @@ pub fn compute_depth_global(
                 }
             }
 
-            let rid = row_counter.fetch_add(1, Ordering::Relaxed) + 1;
-
-            // Output as depth=1 for entire sequence
-            write!(writer, "{}\t{}\t1", rid, seq_len)?;
-            for sample_id in 0..num_samples as u16 {
-                let current_sample = sample_index.get_name(sample_id).unwrap_or("");
-                if current_sample == sample_name {
-                    write!(writer, "\t{}:0-{}", seq_name, seq_len)?;
-                } else {
-                    write!(writer, "\tNA")?;
+            if stats_mode {
+                // Add depth=1 to stats accumulators
+                if let Some(ref acc) = stats_accumulator {
+                    acc.lock().unwrap().add_interval(seq_name, 0, seq_len, 1);
                 }
+                if let Some(ref acc) = stats_combined_acc {
+                    acc.lock().unwrap().add_interval(
+                        seq_name, 0, seq_len, 1,
+                        vec![sample_name.to_string()],
+                    );
+                }
+            } else if let Some(ref w) = writer {
+                let rid = row_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                let mut w = w.lock().unwrap();
+
+                // Output as depth=1 for entire sequence
+                write!(w, "{}\t{}\t1", rid, seq_len)?;
+                for sample_id in 0..num_samples as u16 {
+                    let current_sample = sample_index.get_name(sample_id).unwrap_or("");
+                    if current_sample == sample_name {
+                        write!(w, "\t{}:0-{}", seq_name, seq_len)?;
+                    } else {
+                        write!(w, "\tNA")?;
+                    }
+                }
+                writeln!(w)?;
             }
-            writeln!(writer)?;
         }
     }
 
-    writer.flush()?;
-    let total_intervals = row_counter.load(Ordering::Relaxed);
-    info!(
-        "Done (global): {} intervals output",
-        total_intervals
-    );
+    // Finalize output
+    if stats_mode {
+        let prefix = output_prefix.unwrap_or("depth_stats");
+
+        if let Some(acc) = stats_accumulator {
+            let stats = acc.into_inner().unwrap();
+
+            // Write summary
+            let summary_path = format!("{}.summary.txt", prefix);
+            let mut summary_writer = BufWriter::new(std::fs::File::create(&summary_path)?);
+            stats.write_summary(&mut summary_writer)?;
+            summary_writer.flush()?;
+            info!("Wrote summary to {}", summary_path);
+
+            // Print summary to stdout
+            stats.write_summary(&mut std::io::stdout())?;
+
+            // Write per-depth BED files
+            stats.write_depth_bed_files(prefix)?;
+
+            info!(
+                "Stats complete: {} total bases, max depth = {}",
+                stats.total_bases,
+                stats.max_depth()
+            );
+        }
+
+        if let Some(acc) = stats_combined_acc {
+            let mut stats = acc.into_inner().unwrap();
+
+            // Write summary
+            let summary_path = format!("{}.summary.txt", prefix);
+            let mut summary_writer = BufWriter::new(std::fs::File::create(&summary_path)?);
+            stats.write_summary(&mut summary_writer)?;
+            summary_writer.flush()?;
+            info!("Wrote summary to {}", summary_path);
+
+            // Print summary to stdout
+            stats.write_summary(&mut std::io::stdout())?;
+
+            // Write combined output file (with optional merging)
+            stats.write_combined_output(prefix, merge_tolerance)?;
+
+            info!(
+                "Stats complete: {} total bases, {} intervals, max depth = {}",
+                stats.total_bases,
+                stats.intervals.len(),
+                stats.max_depth()
+            );
+        }
+    } else {
+        // Normal mode: flush TSV writer
+        if let Some(w) = writer {
+            let mut w = w.into_inner().unwrap();
+            w.flush()?;
+        }
+
+        let total_intervals = row_counter.load(Ordering::Relaxed);
+        info!(
+            "Depth complete: {} sequences, {} intervals output",
+            total_sequences, total_intervals
+        );
+    }
 
     Ok(())
 }
 
 // ============================================================================
-// New depth functions: stats mode and region query mode
+// Region query mode and sweep-line helpers
 // ============================================================================
 
 /// Alignment info for sweep-line processing (tracks all alignments per sample)
@@ -2883,560 +3121,6 @@ impl PartialOrd for DepthEventMulti {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
-}
-
-/// Compute global depth statistics across all sequences
-///
-/// Algorithm:
-/// 1. For each sample in the filter (or all samples if no filter):
-///    a. For each sequence belonging to this sample:
-///       - Find all alignments FROM other samples TO this sequence (forward)
-///       - Find all alignments FROM this sequence TO other samples (reverse)
-///    b. Use sweep-line algorithm to compute depth intervals
-/// 2. Aggregate statistics across all sequences
-/// 3. Output summary and per-depth BED files
-pub fn compute_depth_stats(
-    impg: &impl ImpgIndex,
-    config: &DepthConfig,
-    separator: &str,
-    output_prefix: &str,
-    sample_filter: Option<&SampleFilter>,
-    fai_list: Option<&str>,
-    ref_sample: Option<&str>,
-) -> io::Result<DepthStats> {
-    info!("Computing depth statistics (stats mode)...");
-
-    // Build sequence lengths
-    let seq_lengths = if let Some(fai_path) = fai_list {
-        debug!("Loading sequence lengths from FAI files...");
-        SequenceLengths::from_fai_list(fai_path, separator)?
-    } else {
-        SequenceLengths::from_impg(impg, separator)
-    };
-
-    debug!(
-        "Found {} samples, {} sequences",
-        seq_lengths.sample_to_seqs.len(),
-        seq_lengths.lengths.len()
-    );
-
-    // Get samples to process
-    // If ref_sample is specified, only process that sample's sequences (single reference mode)
-    // Otherwise, apply sample_filter if present (global mode)
-    let samples_to_process: Vec<String> = if let Some(ref_name) = ref_sample {
-        debug!("Single reference mode: only processing sequences from '{}'", ref_name);
-        if seq_lengths.sample_to_seqs.contains_key(ref_name) {
-            vec![ref_name.to_string()]
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Reference sample '{}' not found in alignment data", ref_name),
-            ));
-        }
-    } else {
-        seq_lengths
-            .get_samples()
-            .into_iter()
-            .filter(|s| sample_filter.map_or(true, |f| f.includes(s)))
-            .collect()
-    };
-
-    if ref_sample.is_some() {
-        debug!(
-            "Single reference mode: processing {} sample",
-            samples_to_process.len()
-        );
-    } else if sample_filter.is_some() {
-        debug!(
-            "Sample filter active: processing {} of {} samples",
-            samples_to_process.len(),
-            seq_lengths.sample_to_seqs.len()
-        );
-    }
-
-    // Flatten all sequences to process into a single list for parallel iteration
-    let all_seqs: Vec<(String, String, i64)> = samples_to_process
-        .iter()
-        .flat_map(|sample| {
-            seq_lengths
-                .get_seqs_of_sample(sample)
-                .iter()
-                .filter_map(|seq| {
-                    seq_lengths.get_length(seq).map(|len| (sample.clone(), seq.clone(), len))
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect();
-
-    let total_seqs = all_seqs.len();
-    debug!("Processing {} sequences in parallel", total_seqs);
-
-    let processed_counter = AtomicUsize::new(0);
-
-    // Process sequences in parallel and collect partial stats
-    let partial_stats: Vec<DepthStats> = all_seqs
-        .par_iter()
-        .map(|(anchor_sample, anchor_seq, seq_len)| {
-            let mut local_stats = DepthStats::new();
-
-            let count = processed_counter.fetch_add(1, Ordering::Relaxed) + 1;
-            if count % 50 == 0 || count == total_seqs {
-                debug!("Progress: {}/{} sequences processed", count, total_seqs);
-            }
-
-            let seq_id = match impg.seq_index().get_id(anchor_seq) {
-                Some(id) => id,
-                None => {
-                    // Sequence not in alignment index, depth = 1 (self only)
-                    local_stats.add_interval(anchor_seq, 0, *seq_len, 1);
-                    return local_stats;
-                }
-            };
-
-            // Collect samples covering this sequence (using lightweight representation)
-            let mut sample_intervals: Vec<(i64, i64, String)> = Vec::new();
-
-            // Forward direction: where anchor_seq is TARGET
-            let overlaps = if config.transitive {
-                if config.transitive_dfs {
-                    impg.query_transitive_dfs(
-                        seq_id,
-                        0,
-                        *seq_len as i32,
-                        None,
-                        config.max_depth,
-                        config.min_transitive_len,
-                        config.min_distance_between_ranges,
-                        None,
-                        false,
-                        None,
-                        None,
-                        config.approximate_mode,
-                        None,
-                    )
-                } else {
-                    impg.query_transitive_bfs(
-                        seq_id,
-                        0,
-                        *seq_len as i32,
-                        None,
-                        config.max_depth,
-                        config.min_transitive_len,
-                        config.min_distance_between_ranges,
-                        None,
-                        false,
-                        None,
-                        None,
-                        config.approximate_mode,
-                        None,
-                    )
-                }
-            } else {
-                impg.query(seq_id, 0, *seq_len as i32, false, None, None, config.approximate_mode)
-            };
-
-            for overlap in &overlaps {
-                let query_interval = &overlap.0;
-                let target_interval = &overlap.2;
-
-                let query_name = match impg.seq_index().get_name(query_interval.metadata) {
-                    Some(name) => name,
-                    None => continue,
-                };
-                let sample = extract_sample(query_name, separator);
-
-                // Apply sample filter
-                if let Some(filter) = sample_filter {
-                    if !filter.includes(&sample) {
-                        continue;
-                    }
-                }
-
-                let target_start = target_interval.first.min(target_interval.last) as i64;
-                let target_end = target_interval.first.max(target_interval.last) as i64;
-
-                sample_intervals.push((target_start, target_end, sample));
-            }
-
-            // Reverse direction: where anchor_seq is QUERY
-            let reverse_alignments = impg.query_reverse_for_depth(seq_id);
-            for (ref_start, ref_end, target_id) in reverse_alignments {
-                if let Some(target_name) = impg.seq_index().get_name(target_id) {
-                    let sample = extract_sample(target_name, separator);
-
-                    // Skip self
-                    if sample == *anchor_sample {
-                        continue;
-                    }
-
-                    // Apply sample filter
-                    if let Some(filter) = sample_filter {
-                        if !filter.includes(&sample) {
-                            continue;
-                        }
-                    }
-
-                    sample_intervals.push((ref_start as i64, ref_end as i64, sample));
-                }
-            }
-
-            // Add self (anchor sample)
-            sample_intervals.push((0, *seq_len, anchor_sample.clone()));
-
-            // Fast sweep-line to compute depth (only counts unique samples, no position tracking)
-            let depth_windows = compute_sweep_line_depth_fast(anchor_seq, *seq_len, &sample_intervals);
-
-            for (start, end, depth) in depth_windows {
-                local_stats.add_interval(anchor_seq, start, end, depth);
-            }
-
-            local_stats
-        })
-        .collect();
-
-    // Merge all partial stats
-    debug!("Merging results from {} sequences...", partial_stats.len());
-    let mut stats = DepthStats::new();
-    for partial in partial_stats {
-        stats.merge(&partial);
-    }
-
-    // Write outputs
-    debug!("Writing depth statistics...");
-
-    // Write summary
-    let summary_path = format!("{}.summary.txt", output_prefix);
-    let summary_file = std::fs::File::create(&summary_path)?;
-    let mut summary_writer = BufWriter::new(summary_file);
-    stats.write_summary(&mut summary_writer)?;
-    summary_writer.flush()?;
-    debug!("Wrote summary to {}", summary_path);
-
-    // Also print to stdout
-    stats.write_summary(&mut std::io::stdout())?;
-
-    // Write per-depth BED files
-    stats.write_depth_bed_files(output_prefix)?;
-
-    debug!(
-        "Stats complete: {} total bases, max depth = {}",
-        stats.total_bases,
-        stats.max_depth()
-    );
-
-    Ok(stats)
-}
-
-/// Compute depth statistics with sample tracking for combined output
-/// This is similar to compute_depth_stats but tracks which samples cover each interval
-/// merge_tolerance: fraction (0.0-1.0) for merging adjacent intervals with similar depth
-///                  e.g., 0.05 = 5% tolerance, merge if (max-min)/max <= 0.05
-pub fn compute_depth_stats_with_samples(
-    impg: &impl ImpgIndex,
-    config: &DepthConfig,
-    separator: &str,
-    output_prefix: &str,
-    sample_filter: Option<&SampleFilter>,
-    fai_list: Option<&str>,
-    ref_sample: Option<&str>,
-    merge_tolerance: f64,
-) -> io::Result<DepthStatsWithSamples> {
-    info!("Computing depth statistics with sample tracking...");
-
-    // Build sequence lengths
-    let seq_lengths = if let Some(fai_path) = fai_list {
-        debug!("Loading sequence lengths from FAI files...");
-        SequenceLengths::from_fai_list(fai_path, separator)?
-    } else {
-        SequenceLengths::from_impg(impg, separator)
-    };
-
-    debug!(
-        "Found {} samples, {} sequences",
-        seq_lengths.sample_to_seqs.len(),
-        seq_lengths.lengths.len()
-    );
-
-    // Get samples to process
-    let samples_to_process: Vec<String> = if let Some(ref_name) = ref_sample {
-        debug!("Single reference mode: only processing sequences from '{}'", ref_name);
-        if seq_lengths.sample_to_seqs.contains_key(ref_name) {
-            vec![ref_name.to_string()]
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Reference sample '{}' not found in alignment data", ref_name),
-            ));
-        }
-    } else {
-        seq_lengths
-            .get_samples()
-            .into_iter()
-            .filter(|s| sample_filter.map_or(true, |f| f.includes(s)))
-            .collect()
-    };
-
-    if ref_sample.is_some() {
-        debug!(
-            "Single reference mode: processing {} sample",
-            samples_to_process.len()
-        );
-    } else if sample_filter.is_some() {
-        debug!(
-            "Sample filter active: processing {} of {} samples",
-            samples_to_process.len(),
-            seq_lengths.sample_to_seqs.len()
-        );
-    }
-
-    // Flatten all sequences to process
-    let all_seqs: Vec<(String, String, i64)> = samples_to_process
-        .iter()
-        .flat_map(|sample| {
-            seq_lengths
-                .get_seqs_of_sample(sample)
-                .iter()
-                .filter_map(|seq| {
-                    seq_lengths.get_length(seq).map(|len| (sample.clone(), seq.clone(), len))
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect();
-
-    let total_seqs = all_seqs.len();
-    debug!("Processing {} sequences in parallel (with sample tracking)", total_seqs);
-
-    let processed_counter = AtomicUsize::new(0);
-
-    // Process sequences in parallel and collect partial stats
-    let partial_stats: Vec<DepthStatsWithSamples> = all_seqs
-        .par_iter()
-        .map(|(anchor_sample, anchor_seq, seq_len)| {
-            let mut local_stats = DepthStatsWithSamples::new();
-
-            let count = processed_counter.fetch_add(1, Ordering::Relaxed) + 1;
-            if count % 50 == 0 || count == total_seqs {
-                debug!("Progress: {}/{} sequences processed", count, total_seqs);
-            }
-
-            let seq_id = match impg.seq_index().get_id(anchor_seq) {
-                Some(id) => id,
-                None => {
-                    // Sequence not in alignment index, depth = 1 (self only)
-                    local_stats.add_interval(anchor_seq, 0, *seq_len, 1, vec![anchor_sample.clone()]);
-                    return local_stats;
-                }
-            };
-
-            // Collect samples covering this sequence
-            let mut sample_intervals: Vec<(i64, i64, String)> = Vec::new();
-
-            // Forward direction: where anchor_seq is TARGET
-            let overlaps = if config.transitive {
-                if config.transitive_dfs {
-                    impg.query_transitive_dfs(
-                        seq_id,
-                        0,
-                        *seq_len as i32,
-                        None,
-                        config.max_depth,
-                        config.min_transitive_len,
-                        config.min_distance_between_ranges,
-                        None,
-                        false,
-                        None,
-                        None,
-                        config.approximate_mode,
-                        None,
-                    )
-                } else {
-                    impg.query_transitive_bfs(
-                        seq_id,
-                        0,
-                        *seq_len as i32,
-                        None,
-                        config.max_depth,
-                        config.min_transitive_len,
-                        config.min_distance_between_ranges,
-                        None,
-                        false,
-                        None,
-                        None,
-                        config.approximate_mode,
-                        None,
-                    )
-                }
-            } else {
-                impg.query(seq_id, 0, *seq_len as i32, false, None, None, config.approximate_mode)
-            };
-
-            for overlap in &overlaps {
-                let query_interval = &overlap.0;
-                let target_interval = &overlap.2;
-
-                let query_name = match impg.seq_index().get_name(query_interval.metadata) {
-                    Some(name) => name,
-                    None => continue,
-                };
-                let sample = extract_sample(query_name, separator);
-
-                // Apply sample filter
-                if let Some(filter) = sample_filter {
-                    if !filter.includes(&sample) {
-                        continue;
-                    }
-                }
-
-                let target_start = target_interval.first.min(target_interval.last) as i64;
-                let target_end = target_interval.first.max(target_interval.last) as i64;
-
-                sample_intervals.push((target_start, target_end, sample));
-            }
-
-            // Reverse direction: where anchor_seq is QUERY
-            let reverse_alignments = impg.query_reverse_for_depth(seq_id);
-            for (ref_start, ref_end, target_id) in reverse_alignments {
-                if let Some(target_name) = impg.seq_index().get_name(target_id) {
-                    let sample = extract_sample(target_name, separator);
-
-                    // Skip self
-                    if sample == *anchor_sample {
-                        continue;
-                    }
-
-                    // Apply sample filter
-                    if let Some(filter) = sample_filter {
-                        if !filter.includes(&sample) {
-                            continue;
-                        }
-                    }
-
-                    sample_intervals.push((ref_start as i64, ref_end as i64, sample));
-                }
-            }
-
-            // Add self (anchor sample)
-            sample_intervals.push((0, *seq_len, anchor_sample.clone()));
-
-            // Sweep-line with sample tracking
-            let depth_windows = compute_sweep_line_depth_with_samples(anchor_seq, *seq_len, &sample_intervals);
-
-            for (start, end, depth, samples) in depth_windows {
-                local_stats.add_interval(anchor_seq, start, end, depth, samples);
-            }
-
-            local_stats
-        })
-        .collect();
-
-    // Merge all partial stats
-    debug!("Merging results from {} sequences...", partial_stats.len());
-    let mut stats = DepthStatsWithSamples::new();
-    for partial in partial_stats {
-        stats.merge(partial);
-    }
-
-    // Write outputs
-    debug!("Writing depth statistics with sample lists...");
-    if merge_tolerance > 0.0 {
-        debug!("Merge tolerance: {:.1}%", merge_tolerance * 100.0);
-    }
-
-    // Write summary
-    let summary_path = format!("{}.summary.txt", output_prefix);
-    let summary_file = std::fs::File::create(&summary_path)?;
-    let mut summary_writer = BufWriter::new(summary_file);
-    stats.write_summary(&mut summary_writer)?;
-    summary_writer.flush()?;
-    debug!("Wrote summary to {}", summary_path);
-
-    // Also print to stdout
-    stats.write_summary(&mut std::io::stdout())?;
-
-    // Write combined output file (with optional merging)
-    stats.write_combined_output(output_prefix, merge_tolerance)?;
-
-    debug!(
-        "Stats complete: {} total bases, {} intervals, max depth = {}",
-        stats.total_bases,
-        stats.intervals.len(),
-        stats.max_depth()
-    );
-
-    Ok(stats)
-}
-
-/// Fast sweep-line algorithm for stats mode (only computes depth, no sample position tracking)
-/// Returns Vec<(start, end, depth)>
-fn compute_sweep_line_depth_fast(
-    _anchor_seq: &str,
-    seq_len: i64,
-    sample_intervals: &[(i64, i64, String)],
-) -> Vec<(i64, i64, usize)> {
-    if sample_intervals.is_empty() {
-        return vec![(0, seq_len, 0)];
-    }
-
-    // Create events: (position, is_start, sample_name)
-    let mut events: Vec<(i64, bool, &str)> = Vec::with_capacity(sample_intervals.len() * 2);
-    for (start, end, sample) in sample_intervals {
-        events.push((*start, true, sample.as_str()));
-        events.push((*end, false, sample.as_str()));
-    }
-
-    // Sort by position, with end events before start events at same position
-    events.sort_by(|a, b| {
-        a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1))
-    });
-
-    let mut results: Vec<(i64, i64, usize)> = Vec::new();
-    let mut active_samples: FxHashMap<&str, usize> = FxHashMap::default();
-    let mut prev_pos: Option<i64> = None;
-
-    for (pos, is_start, sample) in events {
-        if let Some(prev) = prev_pos {
-            if pos > prev {
-                // Emit window from prev to pos with current depth
-                let depth = active_samples.len();
-                if depth > 0 {
-                    results.push((prev, pos, depth));
-                }
-            }
-        }
-
-        // Update active samples
-        if is_start {
-            *active_samples.entry(sample).or_insert(0) += 1;
-        } else if let Some(count) = active_samples.get_mut(sample) {
-            *count -= 1;
-            if *count == 0 {
-                active_samples.remove(sample);
-            }
-        }
-
-        prev_pos = Some(pos);
-    }
-
-    // Merge adjacent windows with same depth
-    if results.len() <= 1 {
-        return results;
-    }
-
-    let mut merged: Vec<(i64, i64, usize)> = Vec::with_capacity(results.len());
-    let mut current = results[0];
-
-    for &(start, end, depth) in &results[1..] {
-        if current.1 == start && current.2 == depth {
-            // Merge
-            current.1 = end;
-        } else {
-            merged.push(current);
-            current = (start, end, depth);
-        }
-    }
-    merged.push(current);
-
-    merged
 }
 
 /// Sweep-line algorithm to compute depth windows (tracking all alignments per sample)
@@ -3557,12 +3241,12 @@ fn map_coords_linear(
     let ratio = query_len as f64 / target_len as f64;
 
     if is_reverse {
-        let q_end = aln_query_end - (start_offset as f64 * ratio) as i64;
-        let q_start = aln_query_end - (end_offset as f64 * ratio) as i64;
+        let q_end = aln_query_end - (start_offset as f64 * ratio).round() as i64;
+        let q_start = aln_query_end - (end_offset as f64 * ratio).round() as i64;
         (q_start.min(q_end), q_start.max(q_end))
     } else {
-        let q_start = aln_query_start + (start_offset as f64 * ratio) as i64;
-        let q_end = aln_query_start + (end_offset as f64 * ratio) as i64;
+        let q_start = aln_query_start + (start_offset as f64 * ratio).round() as i64;
+        let q_end = aln_query_start + (end_offset as f64 * ratio).round() as i64;
         (q_start.min(q_end), q_start.max(q_end))
     }
 }
@@ -3637,85 +3321,298 @@ pub fn query_region_depth(
     // Collect all alignments for this region
     let mut alignments: Vec<AlignmentInfoMulti> = Vec::new();
 
+    let is_transitive = config.transitive || config.transitive_dfs;
+
     // Forward direction: where target_seq is TARGET
-    let overlaps = if config.transitive {
-        if config.transitive_dfs {
+    if is_transitive && config.use_cigar_bfs {
+        // CIGAR-precise BFS (--use-BFS): identical to query command's BFS
+        let overlaps = if config.transitive_dfs {
             impg.query_transitive_dfs(
-                target_id,
-                target_start,
-                target_end,
-                None,
-                config.max_depth,
-                config.min_transitive_len,
-                config.min_distance_between_ranges,
-                None,
-                false,
-                None,
-                sequence_index,
-                config.approximate_mode,
-                None,
+                target_id, target_start, target_end, None,
+                config.max_depth, config.min_transitive_len,
+                config.min_distance_between_ranges, None, false, None,
+                sequence_index, false, None,
             )
         } else {
             impg.query_transitive_bfs(
-                target_id,
-                target_start,
-                target_end,
-                None,
-                config.max_depth,
-                config.min_transitive_len,
-                config.min_distance_between_ranges,
-                None,
-                false,
-                None,
-                sequence_index,
-                config.approximate_mode,
-                None,
+                target_id, target_start, target_end, None,
+                config.max_depth, config.min_transitive_len,
+                config.min_distance_between_ranges, None, false, None,
+                sequence_index, false, None,
             )
-        }
-    } else {
-        impg.query(
-            target_id,
-            target_start,
-            target_end,
-            false,
-            None,
-            sequence_index,
-            config.approximate_mode,
-        )
-    };
-
-    for overlap in &overlaps {
-        let query_interval = &overlap.0;
-        let target_interval = &overlap.2;
-
-        let query_name = match impg.seq_index().get_name(query_interval.metadata) {
-            Some(name) => name,
-            None => continue,
         };
-        let sample = extract_sample(query_name, separator);
 
-        // Apply sample filter
-        if let Some(filter) = sample_filter {
-            if !filter.includes(&sample) {
-                continue;
+        let region_start = target_start as i64;
+        let region_end = target_end as i64;
+
+        // Pass 1: Build a map of each sequence's anchor coverage from hop 0 results
+        let mut seq_anchor_coverage: FxHashMap<u32, (i64, i64, i64, i64)> = FxHashMap::default();
+        for overlap in &overlaps {
+            let query_interval = &overlap.0;
+            let target_interval = &overlap.2;
+            if target_interval.metadata == target_id {
+                let query_id = query_interval.metadata;
+                let q_start = query_interval.first.min(query_interval.last) as i64;
+                let q_end = query_interval.first.max(query_interval.last) as i64;
+                let t_start = target_interval.first.min(target_interval.last) as i64;
+                let t_end = target_interval.first.max(target_interval.last) as i64;
+                let entry = seq_anchor_coverage.entry(query_id).or_insert((q_start, q_end, t_start, t_end));
+                entry.0 = entry.0.min(q_start);
+                entry.1 = entry.1.max(q_end);
+                entry.2 = entry.2.min(t_start);
+                entry.3 = entry.3.max(t_end);
             }
         }
 
-        let is_reverse = query_interval.first > query_interval.last;
-        let query_start = query_interval.first.min(query_interval.last) as i64;
-        let query_end = query_interval.first.max(query_interval.last) as i64;
-        let t_start = target_interval.first.min(target_interval.last) as i64;
-        let t_end = target_interval.first.max(target_interval.last) as i64;
+        // Pass 2: Process all results for depth
+        for overlap in &overlaps {
+            let query_interval = &overlap.0;
+            let target_interval = &overlap.2;
 
-        alignments.push(AlignmentInfoMulti {
-            sample,
-            query_name: query_name.to_string(),
-            query_start,
-            query_end,
-            target_start: t_start,
-            target_end: t_end,
-            is_reverse,
-        });
+            let query_id = query_interval.metadata;
+            let query_name = match impg.seq_index().get_name(query_id) {
+                Some(name) => name,
+                None => continue,
+            };
+            let sample = extract_sample(query_name, separator);
+
+            if sample == target_sample {
+                continue;
+            }
+
+            if let Some(filter) = sample_filter {
+                if !filter.includes(&sample) {
+                    continue;
+                }
+            }
+
+            let is_reverse = query_interval.first > query_interval.last;
+            let q_start = query_interval.first.min(query_interval.last) as i64;
+            let q_end = query_interval.first.max(query_interval.last) as i64;
+
+            let (a_start, a_end) = if target_interval.metadata == target_id {
+                let t_start = target_interval.first.min(target_interval.last) as i64;
+                let t_end = target_interval.first.max(target_interval.last) as i64;
+                (t_start.max(region_start), t_end.min(region_end))
+            } else {
+                let t_start = target_interval.first.min(target_interval.last) as i64;
+                let t_end = target_interval.first.max(target_interval.last) as i64;
+                if let Some(&(seq_start, seq_end, anc_start, anc_end)) =
+                    seq_anchor_coverage.get(&target_interval.metadata)
+                {
+                    let seq_len = seq_end - seq_start;
+                    let anc_len = anc_end - anc_start;
+                    if seq_len > 0 && anc_len > 0 {
+                        let frac_s = (t_start - seq_start) as f64 / seq_len as f64;
+                        let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
+                        let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
+                        let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
+                        (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                    } else {
+                        (region_start, region_end)
+                    }
+                } else {
+                    (region_start, region_end)
+                }
+            };
+
+            if a_start >= a_end { continue; }
+
+            alignments.push(AlignmentInfoMulti {
+                sample,
+                query_name: query_name.to_string(),
+                query_start: q_start,
+                query_end: q_end,
+                target_start: a_start,
+                target_end: a_end,
+                is_reverse,
+            });
+        }
+    } else if is_transitive {
+        // Default transitive: raw-interval BFS with linear interpolation
+        let hits = depth_transitive_bfs(
+            impg,
+            target_id,
+            target_start,
+            target_end,
+            config.max_depth,
+            config.min_transitive_len,
+            config.min_distance_between_ranges,
+            config.transitive_dfs,
+        );
+
+        let region_start = target_start as i64;
+        let region_end = target_end as i64;
+
+        // Pass 1: Build anchor coverage map from hop 0 results
+        let mut seq_anchor_coverage: FxHashMap<u32, (i64, i64, i64, i64)> = FxHashMap::default();
+        for hit in &hits {
+            if hit.target_id == target_id {
+                let q_start = hit.query_start.min(hit.query_end) as i64;
+                let q_end = hit.query_start.max(hit.query_end) as i64;
+                let t_start = hit.target_start.min(hit.target_end) as i64;
+                let t_end = hit.target_start.max(hit.target_end) as i64;
+                let entry = seq_anchor_coverage.entry(hit.query_id).or_insert((q_start, q_end, t_start, t_end));
+                entry.0 = entry.0.min(q_start);
+                entry.1 = entry.1.max(q_end);
+                entry.2 = entry.2.min(t_start);
+                entry.3 = entry.3.max(t_end);
+            }
+        }
+
+        // Pass 2: Process all hits for depth
+        for hit in &hits {
+            let query_name = match impg.seq_index().get_name(hit.query_id) {
+                Some(name) => name,
+                None => continue,
+            };
+            let sample = extract_sample(query_name, separator);
+
+            if sample == target_sample {
+                continue;
+            }
+
+            if let Some(filter) = sample_filter {
+                if !filter.includes(&sample) {
+                    continue;
+                }
+            }
+
+            let q_start = hit.query_start.min(hit.query_end) as i64;
+            let q_end = hit.query_start.max(hit.query_end) as i64;
+
+            let (a_start, a_end) = if hit.target_id == target_id {
+                let t_start = hit.target_start.min(hit.target_end) as i64;
+                let t_end = hit.target_start.max(hit.target_end) as i64;
+                (t_start.max(region_start), t_end.min(region_end))
+            } else {
+                let t_start = hit.target_start.min(hit.target_end) as i64;
+                let t_end = hit.target_start.max(hit.target_end) as i64;
+                if let Some(&(seq_start, seq_end, anc_start, anc_end)) =
+                    seq_anchor_coverage.get(&hit.target_id)
+                {
+                    let seq_len = seq_end - seq_start;
+                    let anc_len = anc_end - anc_start;
+                    if seq_len > 0 && anc_len > 0 {
+                        let frac_s = (t_start - seq_start) as f64 / seq_len as f64;
+                        let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
+                        let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
+                        let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
+                        (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                    } else {
+                        (region_start, region_end)
+                    }
+                } else {
+                    (region_start, region_end)
+                }
+            };
+
+            if a_start >= a_end { continue; }
+
+            alignments.push(AlignmentInfoMulti {
+                sample,
+                query_name: query_name.to_string(),
+                query_start: q_start,
+                query_end: q_end,
+                target_start: a_start,
+                target_end: a_end,
+                is_reverse: hit.is_reverse,
+            });
+        }
+    } else if config.use_cigar_bfs {
+        // Non-transitive with --use-BFS: CIGAR-precise query
+        let overlaps = impg.query(
+            target_id, target_start, target_end,
+            false, None, sequence_index, false,
+        );
+
+        for overlap in &overlaps {
+            let query_interval = &overlap.0;
+            let target_interval = &overlap.2;
+
+            let query_name = match impg.seq_index().get_name(query_interval.metadata) {
+                Some(name) => name,
+                None => continue,
+            };
+            let sample = extract_sample(query_name, separator);
+
+            if let Some(filter) = sample_filter {
+                if !filter.includes(&sample) {
+                    continue;
+                }
+            }
+
+            let is_reverse = query_interval.first > query_interval.last;
+            let query_start = query_interval.first.min(query_interval.last) as i64;
+            let query_end = query_interval.first.max(query_interval.last) as i64;
+            let t_start = target_interval.first.min(target_interval.last) as i64;
+            let t_end = target_interval.first.max(target_interval.last) as i64;
+
+            alignments.push(AlignmentInfoMulti {
+                sample,
+                query_name: query_name.to_string(),
+                query_start,
+                query_end,
+                target_start: t_start,
+                target_end: t_end,
+                is_reverse,
+            });
+        }
+    } else {
+        // Default non-transitive: raw intervals + linear interpolation
+        let mut raw_alns = impg.query_raw_overlapping(target_id, target_start, target_end);
+        raw_alns.sort_unstable_by_key(|a| a.target_start);
+
+        let region_start = target_start as i64;
+        let region_end = target_end as i64;
+
+        for aln in &raw_alns {
+            let query_name = match impg.seq_index().get_name(aln.query_id) {
+                Some(name) => name,
+                None => continue,
+            };
+            let sample = extract_sample(query_name, separator);
+
+            if let Some(filter) = sample_filter {
+                if !filter.includes(&sample) {
+                    continue;
+                }
+            }
+
+            let aln_target_start = aln.target_start as i64;
+            let aln_target_end = aln.target_end as i64;
+            let aln_query_start = aln.query_start as i64;
+            let aln_query_end = aln.query_end as i64;
+
+            // Clip target to region
+            let clipped_target_start = aln_target_start.max(region_start);
+            let clipped_target_end = aln_target_end.min(region_end);
+
+            // Proportional query coordinate clipping (linear interpolation)
+            let target_len = aln_target_end - aln_target_start;
+            let query_len = aln_query_end - aln_query_start;
+            let ratio = if target_len > 0 { query_len as f64 / target_len as f64 } else { 1.0 };
+
+            let (clipped_query_start, clipped_query_end) = if aln.is_reverse {
+                let cqe = aln_query_end - ((clipped_target_start - aln_target_start) as f64 * ratio) as i64;
+                let cqs = aln_query_end - ((clipped_target_end - aln_target_start) as f64 * ratio) as i64;
+                (cqs, cqe)
+            } else {
+                let cqs = aln_query_start + ((clipped_target_start - aln_target_start) as f64 * ratio) as i64;
+                let cqe = aln_query_start + ((clipped_target_end - aln_target_start) as f64 * ratio) as i64;
+                (cqs, cqe)
+            };
+
+            alignments.push(AlignmentInfoMulti {
+                sample,
+                query_name: query_name.to_string(),
+                query_start: clipped_query_start.min(clipped_query_end),
+                query_end: clipped_query_start.max(clipped_query_end),
+                target_start: clipped_target_start,
+                target_end: clipped_target_end,
+                is_reverse: aln.is_reverse,
+            });
+        }
     }
 
     // Reverse direction: where target_seq is QUERY

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -100,12 +100,16 @@ impl Default for SampleFilter {
 /// Statistics for depth distribution across all sequences
 #[derive(Debug, Clone, Default)]
 pub struct DepthStats {
-    /// Total bases analyzed
+    /// Total bases analyzed (anchor perspective: sum of anchor interval lengths)
     pub total_bases: i64,
-    /// Distribution: depth -> total bases at that depth
+    /// Distribution: depth -> total bases at that depth (anchor perspective)
     pub depth_distribution: FxHashMap<usize, i64>,
     /// Per-depth intervals for output files: depth -> Vec<(seq_name, start, end)>
     pub depth_intervals: FxHashMap<usize, Vec<(String, i64, i64)>>,
+    /// Total pangenome bases: sum of all samples' actual query bases (union per sample)
+    pub pangenome_total_bases: i64,
+    /// Pangenome distribution: depth -> total pangenome bases at that depth
+    pub pangenome_depth_distribution: FxHashMap<usize, i64>,
 }
 
 impl DepthStats {
@@ -114,8 +118,8 @@ impl DepthStats {
         Self::default()
     }
 
-    /// Add an interval with a specific depth
-    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize) {
+    /// Add an interval with a specific depth and pangenome bases
+    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize, pangenome_bases: i64) {
         let length = end - start;
         if length <= 0 {
             return;
@@ -126,6 +130,8 @@ impl DepthStats {
             .entry(depth)
             .or_default()
             .push((seq_name.to_string(), start, end));
+        self.pangenome_total_bases += pangenome_bases;
+        *self.pangenome_depth_distribution.entry(depth).or_insert(0) += pangenome_bases;
     }
 
     /// Merge another DepthStats into this one
@@ -139,6 +145,10 @@ impl DepthStats {
                 .entry(*depth)
                 .or_default()
                 .extend(intervals.iter().cloned());
+        }
+        self.pangenome_total_bases += other.pangenome_total_bases;
+        for (&depth, &bases) in &other.pangenome_depth_distribution {
+            *self.pangenome_depth_distribution.entry(depth).or_insert(0) += bases;
         }
     }
 
@@ -160,11 +170,26 @@ impl DepthStats {
 
     /// Write summary to a writer
     pub fn write_summary<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-        writeln!(writer, "Total bases: {}", self.total_bases)?;
-        writeln!(writer, "Depth distribution:")?;
+        writeln!(writer, "Anchor-perspective depth distribution:")?;
+        writeln!(writer, "Total anchor bases: {}", self.total_bases)?;
         for (depth, bases) in self.get_sorted_distribution() {
             let pct = if self.total_bases > 0 {
                 100.0 * bases as f64 / self.total_bases as f64
+            } else {
+                0.0
+            };
+            writeln!(writer, "  depth={}: {} bp ({:.2}%)", depth, bases, pct)?;
+        }
+        writeln!(writer)?;
+        writeln!(writer, "Pangenome-wide depth distribution:")?;
+        writeln!(writer, "Total pangenome bases: {}", self.pangenome_total_bases)?;
+        let mut pg_dist: Vec<_> = self.pangenome_depth_distribution.iter()
+            .map(|(&d, &c)| (d, c))
+            .collect();
+        pg_dist.sort_by_key(|&(d, _)| d);
+        for (depth, bases) in pg_dist {
+            let pct = if self.pangenome_total_bases > 0 {
+                100.0 * bases as f64 / self.pangenome_total_bases as f64
             } else {
                 0.0
             };
@@ -223,12 +248,16 @@ impl DepthIntervalWithSamples {
 /// Statistics with sample tracking for combined output
 #[derive(Debug, Clone, Default)]
 pub struct DepthStatsWithSamples {
-    /// Total bases analyzed
+    /// Total bases analyzed (anchor perspective)
     pub total_bases: i64,
-    /// Distribution: depth -> total bases at that depth
+    /// Distribution: depth -> total bases at that depth (anchor perspective)
     pub depth_distribution: FxHashMap<usize, i64>,
     /// All intervals with samples (unsorted, to be sorted at output time)
     pub intervals: Vec<DepthIntervalWithSamples>,
+    /// Total pangenome bases: sum of all samples' actual query bases
+    pub pangenome_total_bases: i64,
+    /// Pangenome distribution: depth -> total pangenome bases at that depth
+    pub pangenome_depth_distribution: FxHashMap<usize, i64>,
 }
 
 impl DepthStatsWithSamples {
@@ -236,8 +265,8 @@ impl DepthStatsWithSamples {
         Self::default()
     }
 
-    /// Add an interval with depth and sample list
-    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize, samples: Vec<String>) {
+    /// Add an interval with depth, sample list, and pangenome bases
+    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize, samples: Vec<String>, pangenome_bases: i64) {
         let length = end - start;
         if length <= 0 {
             return;
@@ -251,6 +280,8 @@ impl DepthStatsWithSamples {
             depth,
             samples,
         ));
+        self.pangenome_total_bases += pangenome_bases;
+        *self.pangenome_depth_distribution.entry(depth).or_insert(0) += pangenome_bases;
     }
 
     /// Merge another DepthStatsWithSamples into this one
@@ -260,6 +291,10 @@ impl DepthStatsWithSamples {
             *self.depth_distribution.entry(depth).or_insert(0) += bases;
         }
         self.intervals.extend(other.intervals);
+        self.pangenome_total_bases += other.pangenome_total_bases;
+        for (&depth, &bases) in &other.pangenome_depth_distribution {
+            *self.pangenome_depth_distribution.entry(depth).or_insert(0) += bases;
+        }
     }
 
     /// Get sorted list of depths with their base counts
@@ -280,11 +315,26 @@ impl DepthStatsWithSamples {
 
     /// Write summary to a writer
     pub fn write_summary<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-        writeln!(writer, "Total bases: {}", self.total_bases)?;
-        writeln!(writer, "Depth distribution:")?;
+        writeln!(writer, "Anchor-perspective depth distribution:")?;
+        writeln!(writer, "Total anchor bases: {}", self.total_bases)?;
         for (depth, bases) in self.get_sorted_distribution() {
             let pct = if self.total_bases > 0 {
                 100.0 * bases as f64 / self.total_bases as f64
+            } else {
+                0.0
+            };
+            writeln!(writer, "  depth={}: {} bp ({:.2}%)", depth, bases, pct)?;
+        }
+        writeln!(writer)?;
+        writeln!(writer, "Pangenome-wide depth distribution:")?;
+        writeln!(writer, "Total pangenome bases: {}", self.pangenome_total_bases)?;
+        let mut pg_dist: Vec<_> = self.pangenome_depth_distribution.iter()
+            .map(|(&d, &c)| (d, c))
+            .collect();
+        pg_dist.sort_by_key(|&(d, _)| d);
+        for (depth, bases) in pg_dist {
+            let pct = if self.pangenome_total_bases > 0 {
+                100.0 * bases as f64 / self.pangenome_total_bases as f64
             } else {
                 0.0
             };
@@ -1327,6 +1377,10 @@ struct SparseDepthInterval {
     /// Sparse sample positions - only stores samples that are present
     /// Sorted by sample_id for binary search lookup
     samples: Vec<SamplePosition>,
+    /// Total pangenome bases: sum of all samples' union query lengths for this interval.
+    /// Accounts for multiple overlapping alignments from the same sample by computing
+    /// the union of their query-side projections (grouped by contig).
+    pangenome_bases: i64,
 }
 
 impl SparseDepthInterval {
@@ -1375,10 +1429,19 @@ fn split_intervals_by_window(intervals: Vec<SparseDepthInterval>, window_size: i
                 (sid, qid, new_qs, new_qe)
             }).collect();
 
+            // Proportionally split pangenome_bases
+            let chunk_frac = if interval_len > 0 {
+                (chunk_end - pos) as f64 / interval_len as f64
+            } else {
+                1.0
+            };
+            let chunk_pangenome_bases = (interval.pangenome_bases as f64 * chunk_frac).round() as i64;
+
             result.push(SparseDepthInterval {
                 start: pos,
                 end: chunk_end,
                 samples,
+                pangenome_bases: chunk_pangenome_bases,
             });
             pos = chunk_end;
         }
@@ -1415,6 +1478,7 @@ fn merge_sparse_intervals(intervals: Vec<SparseDepthInterval>, tolerance: f64) -
         if interval.start == current.end && within_tolerance {
             // Merge: extend end, union samples, update depth range
             current.end = interval.end;
+            current.pangenome_bases += interval.pangenome_bases;
             current_min_depth = new_min;
             current_max_depth = new_max;
 
@@ -2273,6 +2337,32 @@ fn process_anchor_region_transitive_cigar(
     }
 }
 
+/// Compute the total length of the union of a set of intervals.
+/// Intervals may overlap; overlapping regions are counted only once.
+fn interval_union_length(intervals: &mut Vec<(i64, i64)>) -> i64 {
+    if intervals.is_empty() {
+        return 0;
+    }
+    if intervals.len() == 1 {
+        return (intervals[0].1 - intervals[0].0).max(0);
+    }
+    intervals.sort_unstable_by_key(|&(s, _)| s);
+    let mut total = 0i64;
+    let mut merged_start = intervals[0].0;
+    let mut merged_end = intervals[0].1;
+    for &(s, e) in &intervals[1..] {
+        if s <= merged_end {
+            merged_end = merged_end.max(e);
+        } else {
+            total += merged_end - merged_start;
+            merged_start = s;
+            merged_end = e;
+        }
+    }
+    total += merged_end - merged_start;
+    total.max(0)
+}
+
 /// Sweep-line algorithm: given alignments, produce depth intervals with sample tracking.
 /// Callers must include the anchor sample as an alignment covering [region_start, region_end]
 /// so that depth naturally counts all samples (including the anchor itself).
@@ -2317,18 +2407,50 @@ fn sweep_line_depth(
                 let clipped_end = interval_end.min(region_end);
 
                 if clipped_start < clipped_end {
-                    // Build SPARSE sample positions
+                    // Build SPARSE sample positions + compute pangenome bases
                     let mut samples: Vec<SamplePosition> = Vec::new();
+                    let mut pangenome_bases: i64 = 0;
 
                     for sample_id in active_bitmap.active_samples() {
                         let alns = &active_alns[sample_id as usize];
-                        if let Some(&best_idx) = alns.iter().max_by_key(|&&idx| {
+
+                        // Compute query projections for ALL active alignments of this sample,
+                        // grouped by query_id (contig) to correctly compute union lengths.
+                        let mut query_intervals_by_contig: FxHashMap<u32, Vec<(i64, i64)>> = FxHashMap::default();
+                        let mut best_idx: Option<usize> = None;
+                        let mut best_overlap: i64 = -1;
+
+                        for &idx in alns {
                             let aln = &alignments[idx];
                             let overlap_start = clipped_start.max(aln.target_start);
                             let overlap_end = clipped_end.min(aln.target_end);
-                            overlap_end - overlap_start
-                        }) {
-                            let aln = &alignments[best_idx];
+                            let overlap = overlap_end - overlap_start;
+
+                            if overlap <= 0 {
+                                continue;
+                            }
+
+                            let (q_start, q_end) = map_target_to_query_linear(
+                                &[],
+                                aln.target_start, aln.target_end,
+                                aln.query_start, aln.query_end,
+                                clipped_start, clipped_end,
+                                aln.is_reverse,
+                            );
+                            query_intervals_by_contig
+                                .entry(aln.query_id)
+                                .or_default()
+                                .push((q_start, q_end));
+
+                            if overlap > best_overlap {
+                                best_overlap = overlap;
+                                best_idx = Some(idx);
+                            }
+                        }
+
+                        // Best alignment for TSV output (same as before)
+                        if let Some(idx) = best_idx {
+                            let aln = &alignments[idx];
                             let (q_start, q_end) = map_target_to_query_linear(
                                 &[],
                                 aln.target_start, aln.target_end,
@@ -2338,6 +2460,11 @@ fn sweep_line_depth(
                             );
                             samples.push((sample_id, aln.query_id, q_start, q_end));
                         }
+
+                        // Pangenome bases: union of query projections per contig
+                        for (_, intervals) in query_intervals_by_contig.iter_mut() {
+                            pangenome_bases += interval_union_length(intervals);
+                        }
                     }
 
                     if !samples.is_empty() {
@@ -2346,6 +2473,7 @@ fn sweep_line_depth(
                             start: clipped_start,
                             end: clipped_end,
                             samples,
+                            pangenome_bases,
                         });
                     }
                 }
@@ -2642,7 +2770,7 @@ pub fn compute_depth_global(
                     // Stats add-on: accumulate depth distribution and intervals
                     let depth = interval.depth();
                     if let Some(ref mut ls) = local_stats {
-                        ls.add_interval(seq_name, interval.start, interval.end, depth);
+                        ls.add_interval(seq_name, interval.start, interval.end, depth, interval.pangenome_bases);
                     }
                     if let Some(ref mut lc) = local_combined {
                         let sample_names: Vec<String> = interval.samples.iter()
@@ -2650,7 +2778,7 @@ pub fn compute_depth_global(
                                 sample_index.get_name(sid).map(|s| s.to_string())
                             })
                             .collect();
-                        lc.add_interval(seq_name, interval.start, interval.end, depth, sample_names);
+                        lc.add_interval(seq_name, interval.start, interval.end, depth, sample_names, interval.pangenome_bases);
                     }
                 } else {
                     // Normal mode: write TSV row to buf
@@ -2987,14 +3115,15 @@ pub fn compute_depth_global(
             }
 
             if stats_mode {
-                // Add depth=1 to stats accumulators
+                // Add depth=1 to stats accumulators (pangenome_bases = seq_len for single sample)
                 if let Some(ref acc) = stats_accumulator {
-                    acc.lock().unwrap().add_interval(seq_name, 0, seq_len, 1);
+                    acc.lock().unwrap().add_interval(seq_name, 0, seq_len, 1, seq_len);
                 }
                 if let Some(ref acc) = stats_combined_acc {
                     acc.lock().unwrap().add_interval(
                         seq_name, 0, seq_len, 1,
                         vec![sample_name.to_string()],
+                        seq_len,
                     );
                 }
             } else if let Some(ref w) = writer {

--- a/src/commands/depth.rs
+++ b/src/commands/depth.rs
@@ -1,14 +1,14 @@
 use crate::impg::{CigarOp, SortedRanges};
 use crate::impg_index::{ImpgIndex, RawAlignmentInterval};
-use indicatif::{ProgressBar, ProgressStyle};
 use crate::sequence_index::UnifiedSequenceIndex;
 use bitvec::prelude::*;
+use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, info};
+use parking_lot::Mutex;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::io::{self, BufWriter, Write};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
 
 /// Configuration for the depth command
 pub struct DepthConfig {
@@ -119,7 +119,14 @@ impl DepthStats {
     }
 
     /// Add an interval with a specific depth and pangenome bases
-    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize, pangenome_bases: i64) {
+    pub fn add_interval(
+        &mut self,
+        seq_name: &str,
+        start: i64,
+        end: i64,
+        depth: usize,
+        pangenome_bases: i64,
+    ) {
         let length = end - start;
         if length <= 0 {
             return;
@@ -182,8 +189,14 @@ impl DepthStats {
         }
         writeln!(writer)?;
         writeln!(writer, "Pangenome-wide depth distribution:")?;
-        writeln!(writer, "Total pangenome bases: {}", self.pangenome_total_bases)?;
-        let mut pg_dist: Vec<_> = self.pangenome_depth_distribution.iter()
+        writeln!(
+            writer,
+            "Total pangenome bases: {}",
+            self.pangenome_total_bases
+        )?;
+        let mut pg_dist: Vec<_> = self
+            .pangenome_depth_distribution
+            .iter()
             .map(|(&d, &c)| (d, c))
             .collect();
         pg_dist.sort_by_key(|&(d, _)| d);
@@ -266,7 +279,15 @@ impl DepthStatsWithSamples {
     }
 
     /// Add an interval with depth, sample list, and pangenome bases
-    pub fn add_interval(&mut self, seq_name: &str, start: i64, end: i64, depth: usize, samples: Vec<String>, pangenome_bases: i64) {
+    pub fn add_interval(
+        &mut self,
+        seq_name: &str,
+        start: i64,
+        end: i64,
+        depth: usize,
+        samples: Vec<String>,
+        pangenome_bases: i64,
+    ) {
         let length = end - start;
         if length <= 0 {
             return;
@@ -327,8 +348,14 @@ impl DepthStatsWithSamples {
         }
         writeln!(writer)?;
         writeln!(writer, "Pangenome-wide depth distribution:")?;
-        writeln!(writer, "Total pangenome bases: {}", self.pangenome_total_bases)?;
-        let mut pg_dist: Vec<_> = self.pangenome_depth_distribution.iter()
+        writeln!(
+            writer,
+            "Total pangenome bases: {}",
+            self.pangenome_total_bases
+        )?;
+        let mut pg_dist: Vec<_> = self
+            .pangenome_depth_distribution
+            .iter()
             .map(|(&d, &c)| (d, c))
             .collect();
         pg_dist.sort_by_key(|&(d, _)| d);
@@ -353,7 +380,8 @@ impl DepthStatsWithSamples {
 
         // Sort intervals by sequence name, then by start position
         self.intervals.sort_by(|a, b| {
-            a.seq_name.cmp(&b.seq_name)
+            a.seq_name
+                .cmp(&b.seq_name)
                 .then_with(|| a.start.cmp(&b.start))
                 .then_with(|| a.end.cmp(&b.end))
         });
@@ -376,7 +404,10 @@ impl DepthStatsWithSamples {
                 writeln!(
                     writer,
                     "{}\t{}\t{}\t{}",
-                    interval.seq_name, interval.end - interval.start, interval.depth, samples_str
+                    interval.seq_name,
+                    interval.end - interval.start,
+                    interval.depth,
+                    samples_str
                 )?;
             }
 
@@ -393,7 +424,10 @@ impl DepthStatsWithSamples {
                 writeln!(
                     writer,
                     "{}\t{}\t{}\t{}",
-                    interval.seq_name, interval.end - interval.start, interval.depth, samples_str
+                    interval.seq_name,
+                    interval.end - interval.start,
+                    interval.depth,
+                    samples_str
                 )?;
             }
 
@@ -425,7 +459,8 @@ impl DepthStatsWithSamples {
         let mut current_end = self.intervals[0].end;
         let mut current_min_depth = self.intervals[0].depth;
         let mut current_max_depth = self.intervals[0].depth;
-        let mut current_samples: FxHashSet<String> = self.intervals[0].samples.iter().cloned().collect();
+        let mut current_samples: FxHashSet<String> =
+            self.intervals[0].samples.iter().cloned().collect();
 
         for interval in self.intervals.iter().skip(1) {
             // Check if this interval can be merged with current group
@@ -449,7 +484,7 @@ impl DepthStatsWithSamples {
                     current_seq,
                     current_start,
                     current_end,
-                    current_max_depth,  // Use max depth for output
+                    current_max_depth, // Use max depth for output
                     samples_vec,
                 ));
 
@@ -480,12 +515,17 @@ impl DepthStatsWithSamples {
     /// Check if adding a new depth to an existing range would keep it within tolerance
     /// Returns true if (new_max - new_min) / new_max <= tolerance
     /// where new_min = min(current_min, new_depth) and new_max = max(current_max, new_depth)
-    fn within_tolerance_range(current_min: usize, current_max: usize, new_depth: usize, tolerance: f64) -> bool {
+    fn within_tolerance_range(
+        current_min: usize,
+        current_max: usize,
+        new_depth: usize,
+        tolerance: f64,
+    ) -> bool {
         let new_min = current_min.min(new_depth);
         let new_max = current_max.max(new_depth);
 
         if new_max == 0 {
-            return true;  // All zeros, can merge
+            return true; // All zeros, can merge
         }
 
         let diff = (new_max - new_min) as f64 / new_max as f64;
@@ -714,7 +754,7 @@ impl SequenceLengths {
 #[derive(Debug, Clone)]
 pub struct SampleIndex {
     name_to_id: FxHashMap<String, u16>,
-    id_to_name: Vec<String>,  // Use Vec for O(1) lookup
+    id_to_name: Vec<String>, // Use Vec for O(1) lookup
 }
 
 impl SampleIndex {
@@ -739,7 +779,10 @@ impl SampleIndex {
             id_to_name.push(sample);
         }
 
-        Self { name_to_id, id_to_name }
+        Self {
+            name_to_id,
+            id_to_name,
+        }
     }
 
     /// Get sample ID from name
@@ -810,7 +853,10 @@ impl CompactSequenceLengths {
             name_to_id.insert(sample.clone(), i as u16);
             id_to_name.push(sample);
         }
-        let sample_index = SampleIndex { name_to_id, id_to_name };
+        let sample_index = SampleIndex {
+            name_to_id,
+            id_to_name,
+        };
 
         // Second pass: build mappings
         let num_seqs = impg.seq_index().len();
@@ -854,13 +900,19 @@ impl CompactSequenceLengths {
     /// Get sample ID for a sequence
     #[inline]
     pub fn get_sample_id(&self, seq_id: u32) -> u16 {
-        self.seq_to_sample.get(seq_id as usize).copied().unwrap_or(0)
+        self.seq_to_sample
+            .get(seq_id as usize)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Get sequences for a sample
     #[inline]
     pub fn get_seqs_of_sample(&self, sample_id: u16) -> &[u32] {
-        self.sample_to_seqs.get(sample_id as usize).map(|v| v.as_slice()).unwrap_or(&[])
+        self.sample_to_seqs
+            .get(sample_id as usize)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Get sample index
@@ -1052,13 +1104,14 @@ impl IntervalSet {
 
         // Binary search: find the first interval whose end >= start (could overlap)
         // partition_point returns the first index where predicate is false
-        let first_overlap_idx = self.intervals.partition_point(|&(_, iv_end)| iv_end < start);
+        let first_overlap_idx = self
+            .intervals
+            .partition_point(|&(_, iv_end)| iv_end < start);
 
         // Find the last overlapping interval: first interval whose start > end
         // Only search from first_overlap_idx onward
         let last_overlap_end = first_overlap_idx
-            + self.intervals[first_overlap_idx..]
-                .partition_point(|&(iv_start, _)| iv_start <= end);
+            + self.intervals[first_overlap_idx..].partition_point(|&(iv_start, _)| iv_start <= end);
 
         if first_overlap_idx == last_overlap_end {
             // No overlapping intervals - just insert at correct position
@@ -1077,7 +1130,8 @@ impl IntervalSet {
 
             // Replace overlapping range with merged interval using drain + insert
             self.intervals.drain(first_overlap_idx..last_overlap_end);
-            self.intervals.insert(first_overlap_idx, (merged_start, merged_end));
+            self.intervals
+                .insert(first_overlap_idx, (merged_start, merged_end));
 
             // Update total length
             let added_length = merged_end - merged_start;
@@ -1142,7 +1196,9 @@ impl IntervalSet {
         }
 
         // Binary search: find the first interval whose end > sub_start (could overlap)
-        let first_overlap_idx = self.intervals.partition_point(|&(_, iv_end)| iv_end <= sub_start);
+        let first_overlap_idx = self
+            .intervals
+            .partition_point(|&(_, iv_end)| iv_end <= sub_start);
 
         // Find the last overlapping interval: first interval whose start >= sub_end
         let last_overlap_end = first_overlap_idx
@@ -1174,7 +1230,8 @@ impl IntervalSet {
         }
 
         // Replace affected range with replacement intervals
-        self.intervals.splice(first_overlap_idx..last_overlap_end, replacement);
+        self.intervals
+            .splice(first_overlap_idx..last_overlap_end, replacement);
         self.total_length -= removed_length;
     }
 
@@ -1348,10 +1405,14 @@ impl PartialOrd for CompactDepthEvent {
 /// Check if an alignment is a same-sample transitive alignment (intra-genome duplication).
 /// Returns true if the alignment should be filtered out.
 #[inline]
-fn is_self_alignment(query_sample_id: u16, anchor_sample_id: u16, query_id: u32, target_seq_id: u32) -> bool {
+fn is_self_alignment(
+    query_sample_id: u16,
+    anchor_sample_id: u16,
+    query_id: u32,
+    target_seq_id: u32,
+) -> bool {
     query_sample_id == anchor_sample_id && query_id != target_seq_id
 }
-
 
 // ============================================================================
 // Windowed depth computation - fixed window size, sample by sample
@@ -1395,14 +1456,23 @@ impl SparseDepthInterval {
         self.samples
             .binary_search_by_key(&sample_id, |s| s.0)
             .ok()
-            .map(|idx| (self.samples[idx].1, self.samples[idx].2, self.samples[idx].3))
+            .map(|idx| {
+                (
+                    self.samples[idx].1,
+                    self.samples[idx].2,
+                    self.samples[idx].3,
+                )
+            })
     }
 }
 
 /// Split intervals at fixed window boundaries.
 /// Each interval crossing a window edge is cut into pieces,
 /// with sample query coordinates proportionally adjusted.
-fn split_intervals_by_window(intervals: Vec<SparseDepthInterval>, window_size: i64) -> Vec<SparseDepthInterval> {
+fn split_intervals_by_window(
+    intervals: Vec<SparseDepthInterval>,
+    window_size: i64,
+) -> Vec<SparseDepthInterval> {
     let mut result: Vec<SparseDepthInterval> = Vec::new();
     for interval in intervals {
         let mut pos = interval.start;
@@ -1417,17 +1487,21 @@ fn split_intervals_by_window(intervals: Vec<SparseDepthInterval>, window_size: i
 
             let interval_len = interval.end - interval.start;
             // Proportionally adjust sample query coordinates for this chunk
-            let samples: Vec<SamplePosition> = interval.samples.iter().map(|&(sid, qid, qs, qe)| {
-                if interval_len <= 0 {
-                    return (sid, qid, qs, qe);
-                }
-                let q_len = qe - qs;
-                let frac_start = (pos - interval.start) as f64 / interval_len as f64;
-                let frac_end = (chunk_end - interval.start) as f64 / interval_len as f64;
-                let new_qs = qs + (frac_start * q_len as f64) as i64;
-                let new_qe = qs + (frac_end * q_len as f64) as i64;
-                (sid, qid, new_qs, new_qe)
-            }).collect();
+            let samples: Vec<SamplePosition> = interval
+                .samples
+                .iter()
+                .map(|&(sid, qid, qs, qe)| {
+                    if interval_len <= 0 {
+                        return (sid, qid, qs, qe);
+                    }
+                    let q_len = qe - qs;
+                    let frac_start = (pos - interval.start) as f64 / interval_len as f64;
+                    let frac_end = (chunk_end - interval.start) as f64 / interval_len as f64;
+                    let new_qs = qs + (frac_start * q_len as f64) as i64;
+                    let new_qe = qs + (frac_end * q_len as f64) as i64;
+                    (sid, qid, new_qs, new_qe)
+                })
+                .collect();
 
             // Proportionally split pangenome_bases
             let chunk_frac = if interval_len > 0 {
@@ -1435,7 +1509,8 @@ fn split_intervals_by_window(intervals: Vec<SparseDepthInterval>, window_size: i
             } else {
                 1.0
             };
-            let chunk_pangenome_bases = (interval.pangenome_bases as f64 * chunk_frac).round() as i64;
+            let chunk_pangenome_bases =
+                (interval.pangenome_bases as f64 * chunk_frac).round() as i64;
 
             result.push(SparseDepthInterval {
                 start: pos,
@@ -1451,7 +1526,10 @@ fn split_intervals_by_window(intervals: Vec<SparseDepthInterval>, window_size: i
 
 /// Merge adjacent intervals with similar depth
 /// tolerance: fraction (0.0-1.0), e.g., 0.05 = merge if depth diff <= 5%
-fn merge_sparse_intervals(intervals: Vec<SparseDepthInterval>, tolerance: f64) -> Vec<SparseDepthInterval> {
+fn merge_sparse_intervals(
+    intervals: Vec<SparseDepthInterval>,
+    tolerance: f64,
+) -> Vec<SparseDepthInterval> {
     if intervals.is_empty() || tolerance <= 0.0 {
         return intervals;
     }
@@ -1488,7 +1566,8 @@ fn merge_sparse_intervals(intervals: Vec<SparseDepthInterval>, tolerance: f64) -
                 sample_map.insert(sid, (qid, qs, qe));
             }
             for (sid, qid, qs, qe) in interval.samples {
-                sample_map.entry(sid)
+                sample_map
+                    .entry(sid)
                     .and_modify(|e| {
                         // Extend query range
                         e.1 = e.1.min(qs);
@@ -1496,7 +1575,8 @@ fn merge_sparse_intervals(intervals: Vec<SparseDepthInterval>, tolerance: f64) -
                     })
                     .or_insert((qid, qs, qe));
             }
-            current.samples = sample_map.into_iter()
+            current.samples = sample_map
+                .into_iter()
                 .map(|(sid, (qid, qs, qe))| (sid, qid, qs, qe))
                 .collect();
             current.samples.sort_by_key(|s| s.0);
@@ -1535,7 +1615,7 @@ impl ConcurrentProcessedTracker {
 
     /// Get unprocessed regions for a sequence within [start, end)
     fn get_unprocessed(&self, seq_id: u32, start: i64, end: i64) -> Vec<(i64, i64)> {
-        let lock = self.processed[seq_id as usize].lock().unwrap();
+        let lock = self.processed[seq_id as usize].lock();
         if lock.is_empty() {
             return vec![(start, end)];
         }
@@ -1558,7 +1638,7 @@ impl ConcurrentProcessedTracker {
 
     /// Mark a region as processed
     fn mark_processed(&self, seq_id: u32, start: i64, end: i64) {
-        let mut lock = self.processed[seq_id as usize].lock().unwrap();
+        let mut lock = self.processed[seq_id as usize].lock();
         lock.add(start, end);
     }
 
@@ -1595,7 +1675,11 @@ fn compute_alignment_degrees(
             let self_sample = compact_lengths.get_sample_id(seq_id);
             let mut samples = FxHashSet::default();
             for aln in &raw_alns {
-                if !seq_included.get(aln.query_id as usize).copied().unwrap_or(false) {
+                if !seq_included
+                    .get(aln.query_id as usize)
+                    .copied()
+                    .unwrap_or(false)
+                {
                     continue;
                 }
                 let sample_id = compact_lengths.get_sample_id(aln.query_id);
@@ -1642,7 +1726,10 @@ fn build_sequence_order(
             .then_with(|| b.1.cmp(&a.1)) // then by length descending
     });
 
-    seq_order.into_iter().map(|(seq_id, _, _, _)| seq_id).collect()
+    seq_order
+        .into_iter()
+        .map(|(seq_id, _, _, _)| seq_id)
+        .collect()
 }
 
 /// Result of processing a single anchor region
@@ -1709,7 +1796,9 @@ fn depth_transitive_bfs(
         }
     }
 
-    while let Some((current_target_id, current_start, current_end, current_depth)) = queue.pop_front() {
+    while let Some((current_target_id, current_start, current_end, current_depth)) =
+        queue.pop_front()
+    {
         if max_depth > 0 && current_depth >= max_depth {
             continue;
         }
@@ -1745,12 +1834,16 @@ fn depth_transitive_bfs(
             };
 
             let (clipped_query_start, clipped_query_end) = if aln.is_reverse {
-                let cqe = aln.query_end - ((clipped_target_start - aln_target_start) as f64 * ratio) as i32;
-                let cqs = aln.query_end - ((clipped_target_end - aln_target_start) as f64 * ratio) as i32;
+                let cqe = aln.query_end
+                    - ((clipped_target_start - aln_target_start) as f64 * ratio) as i32;
+                let cqs =
+                    aln.query_end - ((clipped_target_end - aln_target_start) as f64 * ratio) as i32;
                 (cqs.min(cqe), cqs.max(cqe))
             } else {
-                let cqs = aln.query_start + ((clipped_target_start - aln_target_start) as f64 * ratio) as i32;
-                let cqe = aln.query_start + ((clipped_target_end - aln_target_start) as f64 * ratio) as i32;
+                let cqs = aln.query_start
+                    + ((clipped_target_start - aln_target_start) as f64 * ratio) as i32;
+                let cqe = aln.query_start
+                    + ((clipped_target_end - aln_target_start) as f64 * ratio) as i32;
                 (cqs.min(cqe), cqs.max(cqe))
             };
 
@@ -1782,7 +1875,10 @@ fn depth_transitive_bfs(
             let mut should_add = true;
             if min_distance_between_ranges > 0 {
                 let (new_min, new_max) = (explore_start, explore_end);
-                let idx = match ranges.ranges.binary_search_by_key(&new_min, |&(start, _)| start) {
+                let idx = match ranges
+                    .ranges
+                    .binary_search_by_key(&new_min, |&(start, _)| start)
+                {
                     Ok(i) => i,
                     Err(i) => i,
                 };
@@ -1872,8 +1968,13 @@ fn process_anchor_region_transitive_raw(
 
     // Self alignment (anchor covers itself)
     alignments.push(CompactAlignmentInfo::new(
-        anchor_sample_id, anchor_seq_id,
-        region_start, region_end, region_start, region_end, false,
+        anchor_sample_id,
+        anchor_seq_id,
+        region_start,
+        region_end,
+        region_start,
+        region_end,
+        false,
     ));
 
     // Pass 1: Build anchor coverage map from hop 0 results (target on anchor)
@@ -1884,7 +1985,9 @@ fn process_anchor_region_transitive_raw(
             let q_end = hit.query_start.max(hit.query_end) as i64;
             let t_start = hit.target_start.min(hit.target_end) as i64;
             let t_end = hit.target_start.max(hit.target_end) as i64;
-            let entry = seq_anchor_coverage.entry(hit.query_id).or_insert((q_start, q_end, t_start, t_end));
+            let entry = seq_anchor_coverage
+                .entry(hit.query_id)
+                .or_insert((q_start, q_end, t_start, t_end));
             entry.0 = entry.0.min(q_start);
             entry.1 = entry.1.max(q_end);
             entry.2 = entry.2.min(t_start);
@@ -1895,7 +1998,12 @@ fn process_anchor_region_transitive_raw(
     // Pass 2: Process all hits for depth
     for hit in &hits {
         // Filter by sequence inclusion (min_seq_length)
-        if min_seq_length > 0 && !seq_included.get(hit.query_id as usize).copied().unwrap_or(false) {
+        if min_seq_length > 0
+            && !seq_included
+                .get(hit.query_id as usize)
+                .copied()
+                .unwrap_or(false)
+        {
             continue;
         }
 
@@ -1929,7 +2037,10 @@ fn process_anchor_region_transitive_raw(
                     let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
                     let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
                     let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
-                    (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                    (
+                        proj_s.min(proj_e).max(region_start),
+                        proj_s.max(proj_e).min(region_end),
+                    )
                 } else {
                     (region_start, region_end)
                 }
@@ -1938,20 +2049,23 @@ fn process_anchor_region_transitive_raw(
             }
         };
 
-        if a_start >= a_end { continue; }
+        if a_start >= a_end {
+            continue;
+        }
 
         alignments.push(CompactAlignmentInfo::new(
-            query_sample_id, hit.query_id,
-            query_start, query_end,
-            a_start, a_end,
+            query_sample_id,
+            hit.query_id,
+            query_start,
+            query_end,
+            a_start,
+            a_end,
             hit.is_reverse,
         ));
     }
 
     // Sweep-line to compute depth intervals
-    let seq_intervals = sweep_line_depth(
-        &alignments, num_samples, region_start, region_end,
-    );
+    let seq_intervals = sweep_line_depth(&alignments, num_samples, region_start, region_end);
 
     AnchorRegionResult {
         intervals: seq_intervals,
@@ -1987,15 +2101,29 @@ fn process_anchor_region(
     if is_transitive {
         if config.use_cigar_bfs {
             return process_anchor_region_transitive_cigar(
-                impg, config, compact_lengths, num_samples,
-                anchor_seq_id, anchor_sample_id, region_start, region_end,
-                seq_included, min_seq_length,
+                impg,
+                config,
+                compact_lengths,
+                num_samples,
+                anchor_seq_id,
+                anchor_sample_id,
+                region_start,
+                region_end,
+                seq_included,
+                min_seq_length,
             );
         } else {
             return process_anchor_region_transitive_raw(
-                impg, config, compact_lengths, num_samples,
-                anchor_seq_id, anchor_sample_id, region_start, region_end,
-                seq_included, min_seq_length,
+                impg,
+                config,
+                compact_lengths,
+                num_samples,
+                anchor_seq_id,
+                anchor_sample_id,
+                region_start,
+                region_end,
+                seq_included,
+                min_seq_length,
             );
         }
     }
@@ -2005,16 +2133,26 @@ fn process_anchor_region(
     discovered_regions.push((anchor_seq_id, region_start, region_end));
 
     let overlaps = impg.query(
-        anchor_seq_id, region_start as i32, region_end as i32,
-        false, None, None, false,
+        anchor_seq_id,
+        region_start as i32,
+        region_end as i32,
+        false,
+        None,
+        None,
+        false,
     );
 
     let mut alignments: Vec<CompactAlignmentInfo> = Vec::new();
 
     // Add self (anchor sample covers the range)
     alignments.push(CompactAlignmentInfo::new(
-        anchor_sample_id, anchor_seq_id,
-        region_start, region_end, region_start, region_end, false,
+        anchor_sample_id,
+        anchor_seq_id,
+        region_start,
+        region_end,
+        region_start,
+        region_end,
+        false,
     ));
 
     for overlap in &overlaps {
@@ -2024,7 +2162,12 @@ fn process_anchor_region(
         let query_id = query_interval.metadata;
 
         // Filter by sequence inclusion (min_seq_length)
-        if min_seq_length > 0 && !seq_included.get(query_id as usize).copied().unwrap_or(false) {
+        if min_seq_length > 0
+            && !seq_included
+                .get(query_id as usize)
+                .copied()
+                .unwrap_or(false)
+        {
             continue;
         }
 
@@ -2051,7 +2194,11 @@ fn process_anchor_region(
         // Proportionally adjust query coordinates for clipped target
         let target_len = target_end - target_start;
         let query_len = query_end - query_start;
-        let ratio = if target_len > 0 { query_len as f64 / target_len as f64 } else { 1.0 };
+        let ratio = if target_len > 0 {
+            query_len as f64 / target_len as f64
+        } else {
+            1.0
+        };
 
         let (cq_start, cq_end) = if is_reverse {
             let cqe = query_end - ((clipped_target_start - target_start) as f64 * ratio) as i64;
@@ -2064,9 +2211,12 @@ fn process_anchor_region(
         };
 
         alignments.push(CompactAlignmentInfo::new(
-            query_sample_id, query_id,
-            cq_start, cq_end,
-            clipped_target_start, clipped_target_end,
+            query_sample_id,
+            query_id,
+            cq_start,
+            cq_end,
+            clipped_target_start,
+            clipped_target_end,
             is_reverse,
         ));
 
@@ -2074,9 +2224,7 @@ fn process_anchor_region(
     }
 
     // Sweep-line to compute depth intervals
-    let seq_intervals = sweep_line_depth(
-        &alignments, num_samples, region_start, region_end,
-    );
+    let seq_intervals = sweep_line_depth(&alignments, num_samples, region_start, region_end);
 
     AnchorRegionResult {
         intervals: seq_intervals,
@@ -2105,8 +2253,13 @@ fn process_anchor_region_raw(
 
     // Self alignment (anchor covers itself)
     alignments.push(CompactAlignmentInfo::new(
-        anchor_sample_id, anchor_seq_id,
-        region_start, region_end, region_start, region_end, false,
+        anchor_sample_id,
+        anchor_seq_id,
+        region_start,
+        region_end,
+        region_start,
+        region_end,
+        false,
     ));
 
     // Binary search: only scan intervals where target_start < region_end
@@ -2124,7 +2277,12 @@ fn process_anchor_region_raw(
         let query_sample_id = compact_lengths.get_sample_id(aln.query_id);
 
         // Filter self-alignments (same sample, different sequence)
-        if is_self_alignment(query_sample_id, anchor_sample_id, aln.query_id, anchor_seq_id) {
+        if is_self_alignment(
+            query_sample_id,
+            anchor_sample_id,
+            aln.query_id,
+            anchor_seq_id,
+        ) {
             continue;
         }
 
@@ -2138,7 +2296,11 @@ fn process_anchor_region_raw(
         // Proportional query coordinate clipping (linear interpolation)
         let target_len = target_end - target_start;
         let query_len = query_end - query_start;
-        let ratio = if target_len > 0 { query_len as f64 / target_len as f64 } else { 1.0 };
+        let ratio = if target_len > 0 {
+            query_len as f64 / target_len as f64
+        } else {
+            1.0
+        };
 
         let (clipped_query_start, clipped_query_end) = if aln.is_reverse {
             let cqe = query_end - ((clipped_target_start - target_start) as f64 * ratio) as i64;
@@ -2151,10 +2313,12 @@ fn process_anchor_region_raw(
         };
 
         alignments.push(CompactAlignmentInfo::new(
-            query_sample_id, aln.query_id,
+            query_sample_id,
+            aln.query_id,
             clipped_query_start.min(clipped_query_end),
             clipped_query_start.max(clipped_query_end),
-            clipped_target_start, clipped_target_end,
+            clipped_target_start,
+            clipped_target_end,
             aln.is_reverse,
         ));
 
@@ -2163,9 +2327,7 @@ fn process_anchor_region_raw(
     }
 
     // Sweep-line to compute depth intervals
-    let seq_intervals = sweep_line_depth(
-        &alignments, num_samples, region_start, region_end,
-    );
+    let seq_intervals = sweep_line_depth(&alignments, num_samples, region_start, region_end);
 
     AnchorRegionResult {
         intervals: seq_intervals,
@@ -2202,17 +2364,35 @@ fn process_anchor_region_transitive_cigar(
     // Use the same CIGAR-precise BFS/DFS as the query command (--use-BFS path)
     let overlaps = if config.transitive_dfs {
         impg.query_transitive_dfs(
-            anchor_seq_id, region_start as i32, region_end as i32, None,
-            config.max_depth, config.min_transitive_len,
-            config.min_distance_between_ranges, None, false, None,
-            None, false, None,
+            anchor_seq_id,
+            region_start as i32,
+            region_end as i32,
+            None,
+            config.max_depth,
+            config.min_transitive_len,
+            config.min_distance_between_ranges,
+            None,
+            false,
+            None,
+            None,
+            false,
+            None,
         )
     } else {
         impg.query_transitive_bfs(
-            anchor_seq_id, region_start as i32, region_end as i32, None,
-            config.max_depth, config.min_transitive_len,
-            config.min_distance_between_ranges, None, false, None,
-            None, false, None,
+            anchor_seq_id,
+            region_start as i32,
+            region_end as i32,
+            None,
+            config.max_depth,
+            config.min_transitive_len,
+            config.min_distance_between_ranges,
+            None,
+            false,
+            None,
+            None,
+            false,
+            None,
         )
     };
 
@@ -2220,8 +2400,13 @@ fn process_anchor_region_transitive_cigar(
 
     // Self alignment (anchor covers itself)
     alignments.push(CompactAlignmentInfo::new(
-        anchor_sample_id, anchor_seq_id,
-        region_start, region_end, region_start, region_end, false,
+        anchor_sample_id,
+        anchor_seq_id,
+        region_start,
+        region_end,
+        region_start,
+        region_end,
+        false,
     ));
 
     // Pass 1: Build anchor coverage map from hop 0 results (target on anchor)
@@ -2235,7 +2420,9 @@ fn process_anchor_region_transitive_cigar(
             let q_end = query_interval.first.max(query_interval.last) as i64;
             let t_start = target_interval.first.min(target_interval.last) as i64;
             let t_end = target_interval.first.max(target_interval.last) as i64;
-            let entry = seq_anchor_coverage.entry(query_id).or_insert((q_start, q_end, t_start, t_end));
+            let entry = seq_anchor_coverage
+                .entry(query_id)
+                .or_insert((q_start, q_end, t_start, t_end));
             entry.0 = entry.0.min(q_start);
             entry.1 = entry.1.max(q_end);
             entry.2 = entry.2.min(t_start);
@@ -2251,7 +2438,12 @@ fn process_anchor_region_transitive_cigar(
         let query_id = query_interval.metadata;
 
         // Filter by sequence inclusion (min_seq_length)
-        if min_seq_length > 0 && !seq_included.get(query_id as usize).copied().unwrap_or(false) {
+        if min_seq_length > 0
+            && !seq_included
+                .get(query_id as usize)
+                .copied()
+                .unwrap_or(false)
+        {
             continue;
         }
 
@@ -2286,7 +2478,10 @@ fn process_anchor_region_transitive_cigar(
                     let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
                     let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
                     let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
-                    (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                    (
+                        proj_s.min(proj_e).max(region_start),
+                        proj_s.max(proj_e).min(region_end),
+                    )
                 } else {
                     (region_start, region_end)
                 }
@@ -2295,12 +2490,17 @@ fn process_anchor_region_transitive_cigar(
             }
         };
 
-        if a_start >= a_end { continue; }
+        if a_start >= a_end {
+            continue;
+        }
 
         alignments.push(CompactAlignmentInfo::new(
-            query_sample_id, query_id,
-            query_start, query_end,
-            a_start, a_end,
+            query_sample_id,
+            query_id,
+            query_start,
+            query_end,
+            a_start,
+            a_end,
             is_reverse,
         ));
     }
@@ -2310,24 +2510,31 @@ fn process_anchor_region_transitive_cigar(
     // gaps at chunk boundaries due to indels. Raw extents ensure the full alignment
     // coverage is marked as processed, preventing Phase 2 from re-processing these
     // regions and producing duplicate output (e.g., CHM13 appearing in Phase 2 rows).
-    let raw_hop0 = impg.query_raw_overlapping(
-        anchor_seq_id, region_start as i32, region_end as i32,
-    );
+    let raw_hop0 =
+        impg.query_raw_overlapping(anchor_seq_id, region_start as i32, region_end as i32);
     for aln in &raw_hop0 {
-        if min_seq_length > 0 && !seq_included.get(aln.query_id as usize).copied().unwrap_or(false) {
+        if min_seq_length > 0
+            && !seq_included
+                .get(aln.query_id as usize)
+                .copied()
+                .unwrap_or(false)
+        {
             continue;
         }
         let query_sample_id = compact_lengths.get_sample_id(aln.query_id);
-        if is_self_alignment(query_sample_id, anchor_sample_id, aln.query_id, anchor_seq_id) {
+        if is_self_alignment(
+            query_sample_id,
+            anchor_sample_id,
+            aln.query_id,
+            anchor_seq_id,
+        ) {
             continue;
         }
         discovered_regions.push((aln.query_id, aln.query_start as i64, aln.query_end as i64));
     }
 
     // Sweep-line to compute depth intervals
-    let seq_intervals = sweep_line_depth(
-        &alignments, num_samples, region_start, region_end,
-    );
+    let seq_intervals = sweep_line_depth(&alignments, num_samples, region_start, region_end);
 
     AnchorRegionResult {
         intervals: seq_intervals,
@@ -2416,7 +2623,8 @@ fn sweep_line_depth(
 
                         // Compute query projections for ALL active alignments of this sample,
                         // grouped by query_id (contig) to correctly compute union lengths.
-                        let mut query_intervals_by_contig: FxHashMap<u32, Vec<(i64, i64)>> = FxHashMap::default();
+                        let mut query_intervals_by_contig: FxHashMap<u32, Vec<(i64, i64)>> =
+                            FxHashMap::default();
                         let mut best_idx: Option<usize> = None;
                         let mut best_overlap: i64 = -1;
 
@@ -2432,9 +2640,12 @@ fn sweep_line_depth(
 
                             let (q_start, q_end) = map_target_to_query_linear(
                                 &[],
-                                aln.target_start, aln.target_end,
-                                aln.query_start, aln.query_end,
-                                clipped_start, clipped_end,
+                                aln.target_start,
+                                aln.target_end,
+                                aln.query_start,
+                                aln.query_end,
+                                clipped_start,
+                                clipped_end,
                                 aln.is_reverse,
                             );
                             query_intervals_by_contig
@@ -2453,9 +2664,12 @@ fn sweep_line_depth(
                             let aln = &alignments[idx];
                             let (q_start, q_end) = map_target_to_query_linear(
                                 &[],
-                                aln.target_start, aln.target_end,
-                                aln.query_start, aln.query_end,
-                                clipped_start, clipped_end,
+                                aln.target_start,
+                                aln.target_end,
+                                aln.query_start,
+                                aln.query_end,
+                                clipped_start,
+                                clipped_end,
                                 aln.is_reverse,
                             );
                             samples.push((sample_id, aln.query_id, q_start, q_end));
@@ -2554,10 +2768,7 @@ pub fn compute_depth_global(
     let num_samples = sample_index.len();
     let num_sequences = impg.seq_index().len();
 
-    debug!(
-        "Found {} samples, {} sequences",
-        num_samples, num_sequences
-    );
+    debug!("Found {} samples, {} sequences", num_samples, num_sequences);
 
     // Build sequence inclusion filter (for --min-seq-length)
     let seq_included: Vec<bool> = (0..num_sequences as u32)
@@ -2577,13 +2788,22 @@ pub fn compute_depth_global(
         let id = sample_index.get_id(ref_name).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
-                format!("Reference sample '{}' not found in alignment index", ref_name),
+                format!(
+                    "Reference sample '{}' not found in alignment index",
+                    ref_name
+                ),
             )
         })?;
         if ref_only {
-            info!("Ref-only mode: '{}' (output filtered to this sample's anchored regions)", ref_name);
+            info!(
+                "Ref-only mode: '{}' (output filtered to this sample's anchored regions)",
+                ref_name
+            );
         } else {
-            info!("Ref-anchored mode: '{}' (Phase 1 anchor, coordinate system priority)", ref_name);
+            info!(
+                "Ref-anchored mode: '{}' (Phase 1 anchor, coordinate system priority)",
+                ref_name
+            );
         }
         Some(id)
     } else {
@@ -2599,7 +2819,11 @@ pub fn compute_depth_global(
     // Load FAI sequences if provided
     let fai_seq_lengths: Option<SequenceLengths> = if let Some(fai_path) = fai_list {
         let fai = SequenceLengths::from_fai_list(fai_path, separator)?;
-        debug!("FAI: {} samples, {} sequences", fai.sample_to_seqs.len(), fai.lengths.len());
+        debug!(
+            "FAI: {} samples, {} sequences",
+            fai.sample_to_seqs.len(),
+            fai.lengths.len()
+        );
         Some(fai)
     } else {
         None
@@ -2624,8 +2848,17 @@ pub fn compute_depth_global(
     );
 
     // Build sequence processing order (degree descending, length descending, ref sample first)
-    let sequence_order = build_sequence_order(impg, &compact_lengths, ref_sample_id, &seq_included, &degrees);
-    debug!("Sequence processing order: {} sequences", sequence_order.len());
+    let sequence_order = build_sequence_order(
+        impg,
+        &compact_lengths,
+        ref_sample_id,
+        &seq_included,
+        &degrees,
+    );
+    debug!(
+        "Sequence processing order: {} sequences",
+        sequence_order.len()
+    );
 
     // Prepare output: TSV writer for normal mode, stats accumulators for --stats add-on
     let writer: Option<Mutex<BufWriter<Box<dyn Write + Send>>>> = if !stats_mode {
@@ -2695,9 +2928,9 @@ pub fn compute_depth_global(
     // Partition sequences into Phase 1 (hubs) and Phase 2 (rest)
     let (phase1_seqs, phase2_seqs): (Vec<u32>, Vec<u32>) = if let Some(ref_id) = ref_sample_id {
         // --ref specified: ref sequences go to Phase 1
-        sequence_order.iter().partition(|&&seq_id| {
-            compact_lengths.get_sample_id(seq_id) == ref_id
-        })
+        sequence_order
+            .iter()
+            .partition(|&&seq_id| compact_lengths.get_sample_id(seq_id) == ref_id)
     } else {
         // No --ref: auto-detect hubs by alignment degree
         let hub_threshold = (max_degree + 1) / 2; // ceiling of max_degree/2
@@ -2708,7 +2941,8 @@ pub fn compute_depth_global(
             if !p1.is_empty() {
                 info!(
                     "Auto-detected {} hub sequences (degree >= {}) for Phase 1",
-                    p1.len(), hub_threshold
+                    p1.len(),
+                    hub_threshold
                 );
             }
             (p1, p2)
@@ -2726,7 +2960,8 @@ pub fn compute_depth_global(
     // In stats mode: accumulates depth distribution + intervals into stats accumulators.
     // In normal mode: formats TSV rows into buf for the caller to write.
     let write_results = |region_results: Vec<AnchorRegionResult>,
-                         buf: &mut Vec<u8>| -> io::Result<()> {
+                         buf: &mut Vec<u8>|
+     -> io::Result<()> {
         // Thread-local accumulators (merged into global at end of batch)
         let mut local_stats: Option<DepthStats> = if stats_accumulator.is_some() {
             Some(DepthStats::new())
@@ -2740,7 +2975,10 @@ pub fn compute_depth_global(
         };
 
         for result in region_results {
-            let seq_name = impg.seq_index().get_name(result.anchor_seq_id).unwrap_or("?");
+            let seq_name = impg
+                .seq_index()
+                .get_name(result.anchor_seq_id)
+                .unwrap_or("?");
             let anchor_sample_id = result.anchor_sample_id;
 
             let should_output = if ref_only {
@@ -2770,22 +3008,42 @@ pub fn compute_depth_global(
                     // Stats add-on: accumulate depth distribution and intervals
                     let depth = interval.depth();
                     if let Some(ref mut ls) = local_stats {
-                        ls.add_interval(seq_name, interval.start, interval.end, depth, interval.pangenome_bases);
+                        ls.add_interval(
+                            seq_name,
+                            interval.start,
+                            interval.end,
+                            depth,
+                            interval.pangenome_bases,
+                        );
                     }
                     if let Some(ref mut lc) = local_combined {
-                        let sample_names: Vec<String> = interval.samples.iter()
+                        let sample_names: Vec<String> = interval
+                            .samples
+                            .iter()
                             .filter_map(|&(sid, _, _, _)| {
                                 sample_index.get_name(sid).map(|s| s.to_string())
                             })
                             .collect();
-                        lc.add_interval(seq_name, interval.start, interval.end, depth, sample_names, interval.pangenome_bases);
+                        lc.add_interval(
+                            seq_name,
+                            interval.start,
+                            interval.end,
+                            depth,
+                            sample_names,
+                            interval.pangenome_bases,
+                        );
                     }
                 } else {
                     // Normal mode: write TSV row to buf
                     let rid = row_counter.fetch_add(1, Ordering::Relaxed) + 1;
 
-                    write!(buf, "{}\t{}\t{}",
-                           rid, interval.end - interval.start, interval.depth())?;
+                    write!(
+                        buf,
+                        "{}\t{}\t{}",
+                        rid,
+                        interval.end - interval.start,
+                        interval.depth()
+                    )?;
 
                     for sid in 0..num_samples as u16 {
                         if sid == anchor_sample_id {
@@ -2807,12 +3065,12 @@ pub fn compute_depth_global(
         // Merge thread-local stats into global accumulators (one lock per batch)
         if let Some(ls) = local_stats {
             if let Some(ref acc) = stats_accumulator {
-                acc.lock().unwrap().merge(&ls);
+                acc.lock().merge(&ls);
             }
         }
         if let Some(lc) = local_combined {
             if let Some(ref acc) = stats_combined_acc {
-                acc.lock().unwrap().merge(lc);
+                acc.lock().merge(lc);
             }
         }
 
@@ -2826,23 +3084,28 @@ pub fn compute_depth_global(
         if is_transitive {
             // Transitive mode: chunk-level parallelism for full thread utilization.
             // Split hub sequences into 5MB chunks → ~1200 tasks for 128 threads.
-            let phase1_chunks: Vec<(u32, u16, i64, i64)> = phase1_seqs.iter().flat_map(|&seq_id| {
-                let seq_len = compact_lengths.get_length(seq_id);
-                let sample_id = compact_lengths.get_sample_id(seq_id);
-                let mut chunks = Vec::new();
-                let mut pos = 0i64;
-                while pos < seq_len {
-                    let chunk_end = (pos + TRANSITIVE_CHUNK_SIZE).min(seq_len);
-                    chunks.push((seq_id, sample_id, pos, chunk_end));
-                    pos = chunk_end;
-                }
-                chunks
-            }).collect();
+            let phase1_chunks: Vec<(u32, u16, i64, i64)> = phase1_seqs
+                .iter()
+                .flat_map(|&seq_id| {
+                    let seq_len = compact_lengths.get_length(seq_id);
+                    let sample_id = compact_lengths.get_sample_id(seq_id);
+                    let mut chunks = Vec::new();
+                    let mut pos = 0i64;
+                    while pos < seq_len {
+                        let chunk_end = (pos + TRANSITIVE_CHUNK_SIZE).min(seq_len);
+                        chunks.push((seq_id, sample_id, pos, chunk_end));
+                        pos = chunk_end;
+                    }
+                    chunks
+                })
+                .collect();
 
             let num_chunks = phase1_chunks.len();
             info!(
                 "Phase 1: {} hub sequences -> {} chunks ({}MB each), chunk-level parallelism",
-                phase1_seqs.len(), num_chunks, TRANSITIVE_CHUNK_SIZE / 1_000_000
+                phase1_seqs.len(),
+                num_chunks,
+                TRANSITIVE_CHUNK_SIZE / 1_000_000
             );
 
             let pb_phase1 = ProgressBar::new(num_chunks as u64);
@@ -2855,32 +3118,39 @@ pub fn compute_depth_global(
 
             let phase1_count = AtomicUsize::new(0);
 
-            phase1_chunks.par_iter().try_for_each(|&(seq_id, sample_id, chunk_start, chunk_end)| -> io::Result<()> {
-                let result = process_anchor_region(
-                    impg,
-                    config,
-                    &compact_lengths, num_samples,
-                    seq_id, sample_id, chunk_start, chunk_end,
-                    &seq_included, min_seq_length,
-                );
+            phase1_chunks.par_iter().try_for_each(
+                |&(seq_id, sample_id, chunk_start, chunk_end)| -> io::Result<()> {
+                    let result = process_anchor_region(
+                        impg,
+                        config,
+                        &compact_lengths,
+                        num_samples,
+                        seq_id,
+                        sample_id,
+                        chunk_start,
+                        chunk_end,
+                        &seq_included,
+                        min_seq_length,
+                    );
 
-                tracker.mark_processed_batch(&result.discovered_regions);
+                    tracker.mark_processed_batch(&result.discovered_regions);
 
-                let mut buf: Vec<u8> = Vec::new();
-                write_results(vec![result], &mut buf)?;
-                if !buf.is_empty() {
-                    if let Some(ref w) = writer {
-                        w.lock().unwrap().write_all(&buf)?;
+                    let mut buf: Vec<u8> = Vec::new();
+                    write_results(vec![result], &mut buf)?;
+                    if !buf.is_empty() {
+                        if let Some(ref w) = writer {
+                            w.lock().write_all(&buf)?;
+                        }
                     }
-                }
 
-                impg.clear_sub_index_cache();
+                    impg.clear_sub_index_cache();
 
-                let count = phase1_count.fetch_add(1, Ordering::Relaxed) + 1;
-                pb_phase1.set_position(count as u64);
+                    let count = phase1_count.fetch_add(1, Ordering::Relaxed) + 1;
+                    pb_phase1.set_position(count as u64);
 
-                Ok(())
-            })?;
+                    Ok(())
+                },
+            )?;
 
             pb_phase1.finish_and_clear();
         } else {
@@ -2901,44 +3171,54 @@ pub fn compute_depth_global(
 
             let phase1_count = AtomicUsize::new(0);
 
-            phase1_seqs.par_iter().try_for_each(|&seq_id| -> io::Result<()> {
-                let seq_len = compact_lengths.get_length(seq_id);
-                if seq_len <= 0 {
+            phase1_seqs
+                .par_iter()
+                .try_for_each(|&seq_id| -> io::Result<()> {
+                    let seq_len = compact_lengths.get_length(seq_id);
+                    if seq_len <= 0 {
+                        let count = phase1_count.fetch_add(1, Ordering::Relaxed) + 1;
+                        pb_phase1.set_position(count as u64);
+                        return Ok(());
+                    }
+
+                    let sample_id = compact_lengths.get_sample_id(seq_id);
+
+                    let mut raw_alns = impg.query_raw_intervals(seq_id);
+                    if min_seq_length > 0 {
+                        raw_alns.retain(|aln| {
+                            seq_included
+                                .get(aln.query_id as usize)
+                                .copied()
+                                .unwrap_or(false)
+                        });
+                        raw_alns.shrink_to_fit();
+                    }
+                    raw_alns.sort_unstable_by_key(|aln| aln.target_start);
+
+                    let result = process_anchor_region_raw(
+                        &raw_alns,
+                        &compact_lengths,
+                        num_samples,
+                        seq_id,
+                        sample_id,
+                        0,
+                        seq_len,
+                    );
+                    tracker.mark_processed_batch(&result.discovered_regions);
+
+                    let mut buf: Vec<u8> = Vec::new();
+                    write_results(vec![result], &mut buf)?;
+                    if !buf.is_empty() {
+                        if let Some(ref w) = writer {
+                            w.lock().write_all(&buf)?;
+                        }
+                    }
+
                     let count = phase1_count.fetch_add(1, Ordering::Relaxed) + 1;
                     pb_phase1.set_position(count as u64);
-                    return Ok(());
-                }
 
-                let sample_id = compact_lengths.get_sample_id(seq_id);
-
-                let mut raw_alns = impg.query_raw_intervals(seq_id);
-                if min_seq_length > 0 {
-                    raw_alns.retain(|aln| {
-                        seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
-                    });
-                    raw_alns.shrink_to_fit();
-                }
-                raw_alns.sort_unstable_by_key(|aln| aln.target_start);
-
-                let result = process_anchor_region_raw(
-                    &raw_alns, &compact_lengths, num_samples,
-                    seq_id, sample_id, 0, seq_len,
-                );
-                tracker.mark_processed_batch(&result.discovered_regions);
-
-                let mut buf: Vec<u8> = Vec::new();
-                write_results(vec![result], &mut buf)?;
-                if !buf.is_empty() {
-                    if let Some(ref w) = writer {
-                        w.lock().unwrap().write_all(&buf)?;
-                    }
-                }
-
-                let count = phase1_count.fetch_add(1, Ordering::Relaxed) + 1;
-                pb_phase1.set_position(count as u64);
-
-                Ok(())
-            })?;
+                    Ok(())
+                })?;
 
             pb_phase1.finish_and_clear();
         }
@@ -2959,7 +3239,11 @@ pub fn compute_depth_global(
     // =========================================================================
     // Phase 2: Process remaining sequences (sequence-level parallelism)
     // =========================================================================
-    let phase2_label = if phase1_seqs.is_empty() { "" } else { "Phase 2: " };
+    let phase2_label = if phase1_seqs.is_empty() {
+        ""
+    } else {
+        "Phase 2: "
+    };
     let pb_depth = ProgressBar::new(total_sequences as u64);
     pb_depth.set_style(
         ProgressStyle::default_bar()
@@ -2972,118 +3256,148 @@ pub fn compute_depth_global(
     );
     pb_depth.set_position(processed_count.load(Ordering::Relaxed) as u64);
 
-    phase2_seqs.par_iter().try_for_each(|&seq_id| -> io::Result<()> {
-        let seq_len = compact_lengths.get_length(seq_id);
-        if seq_len <= 0 {
-            let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
-            pb_depth.set_position(count as u64);
-            return Ok(());
-        }
-
-        let unprocessed = tracker.get_unprocessed(seq_id, 0, seq_len);
-        if unprocessed.is_empty() {
-            let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
-            pb_depth.set_position(count as u64);
-            return Ok(());
-        }
-
-        let sample_id = compact_lengths.get_sample_id(seq_id);
-
-        // Non-transitive: load raw intervals once per sequence (not per gap)
-        let raw_alns_cached = if !is_transitive {
-            let mut raw_alns = impg.query_raw_intervals(seq_id);
-            if min_seq_length > 0 {
-                raw_alns.retain(|aln| {
-                    seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
-                });
-                raw_alns.shrink_to_fit();
+    phase2_seqs
+        .par_iter()
+        .try_for_each(|&seq_id| -> io::Result<()> {
+            let seq_len = compact_lengths.get_length(seq_id);
+            if seq_len <= 0 {
+                let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
+                pb_depth.set_position(count as u64);
+                return Ok(());
             }
-            raw_alns.sort_unstable_by_key(|aln| aln.target_start);
-            Some(raw_alns)
-        } else {
-            None
-        };
 
-        for (region_start, region_end) in unprocessed {
-            let region_results = if is_transitive {
-                let gap_len = region_end - region_start;
+            let unprocessed = tracker.get_unprocessed(seq_id, 0, seq_len);
+            if unprocessed.is_empty() {
+                let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
+                pb_depth.set_position(count as u64);
+                return Ok(());
+            }
 
-                // Fast path: gaps smaller than min_transitive_len can't trigger
-                // transitive hops, so BFS setup (visited_ranges allocation for all
-                // sequences, sub-index loading) is wasted. Use raw intervals instead.
-                if gap_len < config.min_transitive_len as i64 {
-                    let mut raw_alns = impg.query_raw_overlapping(
-                        seq_id, region_start as i32, region_end as i32,
-                    );
-                    if min_seq_length > 0 {
-                        raw_alns.retain(|aln| {
-                            seq_included.get(aln.query_id as usize).copied().unwrap_or(false)
-                        });
-                    }
-                    raw_alns.sort_unstable_by_key(|aln| aln.target_start);
-                    let result = process_anchor_region_raw(
-                        &raw_alns, &compact_lengths, num_samples,
-                        seq_id, sample_id, region_start, region_end,
-                    );
-                    tracker.mark_processed_batch(&result.discovered_regions);
-                    vec![result]
-                } else if gap_len > TRANSITIVE_CHUNK_SIZE {
-                    let mut results = Vec::new();
-                    let mut pos = region_start;
-                    while pos < region_end {
-                        let chunk_end = (pos + TRANSITIVE_CHUNK_SIZE).min(region_end);
+            let sample_id = compact_lengths.get_sample_id(seq_id);
+
+            // Non-transitive: load raw intervals once per sequence (not per gap)
+            let raw_alns_cached = if !is_transitive {
+                let mut raw_alns = impg.query_raw_intervals(seq_id);
+                if min_seq_length > 0 {
+                    raw_alns.retain(|aln| {
+                        seq_included
+                            .get(aln.query_id as usize)
+                            .copied()
+                            .unwrap_or(false)
+                    });
+                    raw_alns.shrink_to_fit();
+                }
+                raw_alns.sort_unstable_by_key(|aln| aln.target_start);
+                Some(raw_alns)
+            } else {
+                None
+            };
+
+            for (region_start, region_end) in unprocessed {
+                let region_results = if is_transitive {
+                    let gap_len = region_end - region_start;
+
+                    // Fast path: gaps smaller than min_transitive_len can't trigger
+                    // transitive hops, so BFS setup (visited_ranges allocation for all
+                    // sequences, sub-index loading) is wasted. Use raw intervals instead.
+                    if gap_len < config.min_transitive_len as i64 {
+                        let mut raw_alns = impg.query_raw_overlapping(
+                            seq_id,
+                            region_start as i32,
+                            region_end as i32,
+                        );
+                        if min_seq_length > 0 {
+                            raw_alns.retain(|aln| {
+                                seq_included
+                                    .get(aln.query_id as usize)
+                                    .copied()
+                                    .unwrap_or(false)
+                            });
+                        }
+                        raw_alns.sort_unstable_by_key(|aln| aln.target_start);
+                        let result = process_anchor_region_raw(
+                            &raw_alns,
+                            &compact_lengths,
+                            num_samples,
+                            seq_id,
+                            sample_id,
+                            region_start,
+                            region_end,
+                        );
+                        tracker.mark_processed_batch(&result.discovered_regions);
+                        vec![result]
+                    } else if gap_len > TRANSITIVE_CHUNK_SIZE {
+                        let mut results = Vec::new();
+                        let mut pos = region_start;
+                        while pos < region_end {
+                            let chunk_end = (pos + TRANSITIVE_CHUNK_SIZE).min(region_end);
+                            let result = process_anchor_region(
+                                impg,
+                                config,
+                                &compact_lengths,
+                                num_samples,
+                                seq_id,
+                                sample_id,
+                                pos,
+                                chunk_end,
+                                &seq_included,
+                                min_seq_length,
+                            );
+                            tracker.mark_processed_batch(&result.discovered_regions);
+                            results.push(result);
+                            pos = chunk_end;
+                        }
+                        results
+                    } else {
                         let result = process_anchor_region(
                             impg,
                             config,
-                            &compact_lengths, num_samples,
-                            seq_id, sample_id, pos, chunk_end,
-                            &seq_included, min_seq_length,
+                            &compact_lengths,
+                            num_samples,
+                            seq_id,
+                            sample_id,
+                            region_start,
+                            region_end,
+                            &seq_included,
+                            min_seq_length,
                         );
                         tracker.mark_processed_batch(&result.discovered_regions);
-                        results.push(result);
-                        pos = chunk_end;
+                        vec![result]
                     }
-                    results
                 } else {
-                    let result = process_anchor_region(
-                        impg,
-                        config,
-                        &compact_lengths, num_samples,
-                        seq_id, sample_id, region_start, region_end,
-                        &seq_included, min_seq_length,
+                    let result = process_anchor_region_raw(
+                        raw_alns_cached.as_ref().unwrap(),
+                        &compact_lengths,
+                        num_samples,
+                        seq_id,
+                        sample_id,
+                        region_start,
+                        region_end,
                     );
                     tracker.mark_processed_batch(&result.discovered_regions);
                     vec![result]
-                }
-            } else {
-                let result = process_anchor_region_raw(
-                    raw_alns_cached.as_ref().unwrap(), &compact_lengths, num_samples,
-                    seq_id, sample_id, region_start, region_end,
-                );
-                tracker.mark_processed_batch(&result.discovered_regions);
-                vec![result]
-            };
+                };
 
-            // Format output into thread-local buffer, then write atomically
-            let mut buf: Vec<u8> = Vec::new();
-            write_results(region_results, &mut buf)?;
-            if !buf.is_empty() {
-                if let Some(ref w) = writer {
-                    w.lock().unwrap().write_all(&buf)?;
+                // Format output into thread-local buffer, then write atomically
+                let mut buf: Vec<u8> = Vec::new();
+                write_results(region_results, &mut buf)?;
+                if !buf.is_empty() {
+                    if let Some(ref w) = writer {
+                        w.lock().write_all(&buf)?;
+                    }
                 }
             }
-        }
 
-        // Phase 2: do NOT clear sub-index cache after each sequence.
-        // Unlike Phase 1 (which processes large hub regions and can accumulate many trees),
-        // Phase 2 sequences are mostly small/partially-processed. Keeping sub-indices loaded
-        // across sequences avoids repeated disk deserialization — the total memory is bounded
-        // by num_alignment_files × sub_index_size regardless of how many sequences we process.
-        let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
-        pb_depth.set_position(count as u64);
+            // Phase 2: do NOT clear sub-index cache after each sequence.
+            // Unlike Phase 1 (which processes large hub regions and can accumulate many trees),
+            // Phase 2 sequences are mostly small/partially-processed. Keeping sub-indices loaded
+            // across sequences avoids repeated disk deserialization — the total memory is bounded
+            // by num_alignment_files × sub_index_size regardless of how many sequences we process.
+            let count = processed_count.fetch_add(1, Ordering::Relaxed) + 1;
+            pb_depth.set_position(count as u64);
 
-        Ok(())
-    })?;
+            Ok(())
+        })?;
 
     // Clear sub-index cache once after all Phase 2 processing
     if is_transitive {
@@ -3117,18 +3431,21 @@ pub fn compute_depth_global(
             if stats_mode {
                 // Add depth=1 to stats accumulators (pangenome_bases = seq_len for single sample)
                 if let Some(ref acc) = stats_accumulator {
-                    acc.lock().unwrap().add_interval(seq_name, 0, seq_len, 1, seq_len);
+                    acc.lock().add_interval(seq_name, 0, seq_len, 1, seq_len);
                 }
                 if let Some(ref acc) = stats_combined_acc {
-                    acc.lock().unwrap().add_interval(
-                        seq_name, 0, seq_len, 1,
+                    acc.lock().add_interval(
+                        seq_name,
+                        0,
+                        seq_len,
+                        1,
                         vec![sample_name.to_string()],
                         seq_len,
                     );
                 }
             } else if let Some(ref w) = writer {
                 let rid = row_counter.fetch_add(1, Ordering::Relaxed) + 1;
-                let mut w = w.lock().unwrap();
+                let mut w = w.lock();
 
                 // Output as depth=1 for entire sequence
                 write!(w, "{}\t{}\t1", rid, seq_len)?;
@@ -3150,7 +3467,7 @@ pub fn compute_depth_global(
         let prefix = output_prefix.unwrap_or("depth_stats");
 
         if let Some(acc) = stats_accumulator {
-            let stats = acc.into_inner().unwrap();
+            let stats = acc.into_inner();
 
             // Write summary
             let summary_path = format!("{}.summary.txt", prefix);
@@ -3173,7 +3490,7 @@ pub fn compute_depth_global(
         }
 
         if let Some(acc) = stats_combined_acc {
-            let mut stats = acc.into_inner().unwrap();
+            let mut stats = acc.into_inner();
 
             // Write summary
             let summary_path = format!("{}.summary.txt", prefix);
@@ -3198,7 +3515,7 @@ pub fn compute_depth_global(
     } else {
         // Normal mode: flush TSV writer
         if let Some(w) = writer {
-            let mut w = w.into_inner().unwrap();
+            let mut w = w.into_inner();
             w.flush()?;
         }
 
@@ -3290,11 +3607,8 @@ fn compute_sweep_line_depth_multi(
         if let Some(prev) = prev_pos {
             if event.position > prev {
                 // Create window from prev to event.position
-                let mut result = RegionDepthResult::new(
-                    anchor_seq.to_string(),
-                    prev,
-                    event.position,
-                );
+                let mut result =
+                    RegionDepthResult::new(anchor_seq.to_string(), prev, event.position);
 
                 // Collect all active samples and their alignments
                 for (sample, aln_indices) in &active_alignments {
@@ -3457,17 +3771,35 @@ pub fn query_region_depth(
         // CIGAR-precise BFS (--use-BFS): identical to query command's BFS
         let overlaps = if config.transitive_dfs {
             impg.query_transitive_dfs(
-                target_id, target_start, target_end, None,
-                config.max_depth, config.min_transitive_len,
-                config.min_distance_between_ranges, None, false, None,
-                sequence_index, false, None,
+                target_id,
+                target_start,
+                target_end,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                false,
+                None,
             )
         } else {
             impg.query_transitive_bfs(
-                target_id, target_start, target_end, None,
-                config.max_depth, config.min_transitive_len,
-                config.min_distance_between_ranges, None, false, None,
-                sequence_index, false, None,
+                target_id,
+                target_start,
+                target_end,
+                None,
+                config.max_depth,
+                config.min_transitive_len,
+                config.min_distance_between_ranges,
+                None,
+                false,
+                None,
+                sequence_index,
+                false,
+                None,
             )
         };
 
@@ -3485,7 +3817,9 @@ pub fn query_region_depth(
                 let q_end = query_interval.first.max(query_interval.last) as i64;
                 let t_start = target_interval.first.min(target_interval.last) as i64;
                 let t_end = target_interval.first.max(target_interval.last) as i64;
-                let entry = seq_anchor_coverage.entry(query_id).or_insert((q_start, q_end, t_start, t_end));
+                let entry = seq_anchor_coverage
+                    .entry(query_id)
+                    .or_insert((q_start, q_end, t_start, t_end));
                 entry.0 = entry.0.min(q_start);
                 entry.1 = entry.1.max(q_end);
                 entry.2 = entry.2.min(t_start);
@@ -3536,7 +3870,10 @@ pub fn query_region_depth(
                         let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
                         let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
                         let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
-                        (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                        (
+                            proj_s.min(proj_e).max(region_start),
+                            proj_s.max(proj_e).min(region_end),
+                        )
                     } else {
                         (region_start, region_end)
                     }
@@ -3545,7 +3882,9 @@ pub fn query_region_depth(
                 }
             };
 
-            if a_start >= a_end { continue; }
+            if a_start >= a_end {
+                continue;
+            }
 
             alignments.push(AlignmentInfoMulti {
                 sample,
@@ -3581,7 +3920,9 @@ pub fn query_region_depth(
                 let q_end = hit.query_start.max(hit.query_end) as i64;
                 let t_start = hit.target_start.min(hit.target_end) as i64;
                 let t_end = hit.target_start.max(hit.target_end) as i64;
-                let entry = seq_anchor_coverage.entry(hit.query_id).or_insert((q_start, q_end, t_start, t_end));
+                let entry = seq_anchor_coverage
+                    .entry(hit.query_id)
+                    .or_insert((q_start, q_end, t_start, t_end));
                 entry.0 = entry.0.min(q_start);
                 entry.1 = entry.1.max(q_end);
                 entry.2 = entry.2.min(t_start);
@@ -3627,7 +3968,10 @@ pub fn query_region_depth(
                         let frac_e = (t_end - seq_start) as f64 / seq_len as f64;
                         let proj_s = anc_start + (frac_s * anc_len as f64) as i64;
                         let proj_e = anc_start + (frac_e * anc_len as f64) as i64;
-                        (proj_s.min(proj_e).max(region_start), proj_s.max(proj_e).min(region_end))
+                        (
+                            proj_s.min(proj_e).max(region_start),
+                            proj_s.max(proj_e).min(region_end),
+                        )
                     } else {
                         (region_start, region_end)
                     }
@@ -3636,7 +3980,9 @@ pub fn query_region_depth(
                 }
             };
 
-            if a_start >= a_end { continue; }
+            if a_start >= a_end {
+                continue;
+            }
 
             alignments.push(AlignmentInfoMulti {
                 sample,
@@ -3651,8 +3997,13 @@ pub fn query_region_depth(
     } else if config.use_cigar_bfs {
         // Non-transitive with --use-BFS: CIGAR-precise query
         let overlaps = impg.query(
-            target_id, target_start, target_end,
-            false, None, sequence_index, false,
+            target_id,
+            target_start,
+            target_end,
+            false,
+            None,
+            sequence_index,
+            false,
         );
 
         for overlap in &overlaps {
@@ -3720,15 +4071,23 @@ pub fn query_region_depth(
             // Proportional query coordinate clipping (linear interpolation)
             let target_len = aln_target_end - aln_target_start;
             let query_len = aln_query_end - aln_query_start;
-            let ratio = if target_len > 0 { query_len as f64 / target_len as f64 } else { 1.0 };
+            let ratio = if target_len > 0 {
+                query_len as f64 / target_len as f64
+            } else {
+                1.0
+            };
 
             let (clipped_query_start, clipped_query_end) = if aln.is_reverse {
-                let cqe = aln_query_end - ((clipped_target_start - aln_target_start) as f64 * ratio) as i64;
-                let cqs = aln_query_end - ((clipped_target_end - aln_target_start) as f64 * ratio) as i64;
+                let cqe = aln_query_end
+                    - ((clipped_target_start - aln_target_start) as f64 * ratio) as i64;
+                let cqs =
+                    aln_query_end - ((clipped_target_end - aln_target_start) as f64 * ratio) as i64;
                 (cqs, cqe)
             } else {
-                let cqs = aln_query_start + ((clipped_target_start - aln_target_start) as f64 * ratio) as i64;
-                let cqe = aln_query_start + ((clipped_target_end - aln_target_start) as f64 * ratio) as i64;
+                let cqs = aln_query_start
+                    + ((clipped_target_start - aln_target_start) as f64 * ratio) as i64;
+                let cqe = aln_query_start
+                    + ((clipped_target_end - aln_target_start) as f64 * ratio) as i64;
                 (cqs, cqe)
             };
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod align;
+pub mod depth;
 pub mod graph;
 pub mod lace;
 pub mod partition;

--- a/src/impg_index.rs
+++ b/src/impg_index.rs
@@ -14,6 +14,18 @@ use coitrees::BasicCOITree;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
+/// Raw alignment interval without CIGAR projection, for fast depth computation.
+/// Contains only the coordinate metadata stored in the interval tree nodes.
+#[derive(Debug, Clone)]
+pub struct RawAlignmentInterval {
+    pub target_start: i32,
+    pub target_end: i32,
+    pub query_id: u32,
+    pub query_start: i32,
+    pub query_end: i32,
+    pub is_reverse: bool,
+}
+
 /// Trait for IMPG index operations.
 ///
 /// Both `Impg` (single-file) and `MultiImpg` (multi-file) implement this trait,
@@ -127,10 +139,30 @@ pub trait ImpgIndex: Send + Sync {
     /// Clear tree cache to free memory.
     fn clear_tree_cache(&self);
 
+    /// Clear sub-index cache (MultiImpg only) to free memory.
+    /// For single Impg, this is a no-op.
+    /// Useful for depth computation with many alignment files to bound peak memory.
+    fn clear_sub_index_cache(&self);
+
+    /// Enable or disable tree caching.
+    /// When disabled, trees loaded from disk are not stored in the cache,
+    /// bounding peak memory for transitive queries.
+    fn set_tree_cache_enabled(&self, enabled: bool);
+
     /// Check if this index was built with bidirectional mode.
     /// Bidirectional indices contain both A→B and B→A entries for each alignment,
     /// eliminating the need for a separate reverse index in depth calculations.
     fn is_bidirectional(&self) -> bool;
+
+    /// Iterate all alignment intervals for a target sequence, returning raw coordinates
+    /// without CIGAR projection. Much faster than query() for bulk operations like depth.
+    /// For MultiImpg, this merges results from all sub-indices that contain the target.
+    fn query_raw_intervals(&self, target_id: u32) -> Vec<RawAlignmentInterval>;
+
+    /// Query only alignment intervals that overlap a specific range [start, end) on a target sequence.
+    /// Returns raw coordinates without CIGAR projection, using coitrees range query for O(n+k) performance.
+    /// Much more efficient than query_raw_intervals() when only a subset of intervals is needed (e.g., BFS).
+    fn query_raw_overlapping(&self, target_id: u32, start: i32, end: i32) -> Vec<RawAlignmentInterval>;
 }
 
 /// Enum wrapper that can hold either a single `Impg` or a `MultiImpg`.
@@ -431,10 +463,38 @@ impl ImpgIndex for ImpgWrapper {
         }
     }
 
+    fn clear_sub_index_cache(&self) {
+        match self {
+            ImpgWrapper::Single(impg) => impg.clear_sub_index_cache(),
+            ImpgWrapper::Multi(multi) => multi.clear_sub_index_cache(),
+        }
+    }
+
+    fn set_tree_cache_enabled(&self, enabled: bool) {
+        match self {
+            ImpgWrapper::Single(impg) => impg.set_tree_cache_enabled(enabled),
+            ImpgWrapper::Multi(multi) => multi.set_tree_cache_enabled(enabled),
+        }
+    }
+
     fn is_bidirectional(&self) -> bool {
         match self {
             ImpgWrapper::Single(impg) => impg.is_bidirectional(),
             ImpgWrapper::Multi(multi) => multi.is_bidirectional(),
+        }
+    }
+
+    fn query_raw_intervals(&self, target_id: u32) -> Vec<RawAlignmentInterval> {
+        match self {
+            ImpgWrapper::Single(impg) => impg.query_raw_intervals(target_id),
+            ImpgWrapper::Multi(multi) => multi.query_raw_intervals(target_id),
+        }
+    }
+
+    fn query_raw_overlapping(&self, target_id: u32, start: i32, end: i32) -> Vec<RawAlignmentInterval> {
+        match self {
+            ImpgWrapper::Single(impg) => impg.query_raw_overlapping(target_id, start, end),
+            ImpgWrapper::Multi(multi) => multi.query_raw_overlapping(target_id, start, end),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1051,10 +1051,12 @@ enum Args {
         #[clap(long, action)]
         merge_adjacent: bool,
 
-        /// Use approximate mode for faster queries with 1aln files
+        /// Use CIGAR-precise BFS for transitive depth (slower but base-level precision).
+        /// Default uses raw-interval BFS with linear interpolation, which is faster
+        /// and sufficient for region-level conservation depth.
         #[arg(help_heading = "Performance")]
-        #[clap(long, action)]
-        approximate: bool,
+        #[clap(long = "use-BFS", action)]
+        use_bfs: bool,
 
         /// Separator for PanSN format (default: #)
         #[arg(help_heading = "Output options")]
@@ -2209,7 +2211,7 @@ fn run() -> io::Result<()> {
             ref_only,
             min_seq_length,
             merge_adjacent,
-            approximate,
+            use_bfs,
             separator,
             output_prefix,
             window_size,
@@ -2224,14 +2226,6 @@ fn run() -> io::Result<()> {
             initialize_threads_and_log(&common);
 
             let alignment_files = resolve_alignment_files(&alignment)?;
-
-            // Validate approximate mode
-            if approximate {
-                validate_approximate_mode_min_length(
-                    transitive_opts.min_transitive_len,
-                    transitive || transitive_opts.transitive_dfs,
-                )?;
-            }
 
             let impg = initialize_index(
                 &common,
@@ -2254,46 +2248,8 @@ fn run() -> io::Result<()> {
                 min_transitive_len: transitive_opts.effective_min_transitive_len(),
                 min_distance_between_ranges: transitive_opts.min_distance_between_ranges,
                 merge_adjacent,
-                approximate_mode: approximate,
+                use_cigar_bfs: use_bfs,
             };
-
-            // Statistics add-on: produces summary and per-depth BED files
-            if stats {
-                let prefix = output_prefix.as_deref().unwrap_or("depth_stats");
-                if ref_sample.is_some() {
-                    info!("Running depth with --stats add-on (ref-anchored), output prefix: {}", prefix);
-                } else {
-                    info!("Running depth with --stats add-on, output prefix: {}", prefix);
-                }
-
-                if combined_output {
-                    info!("Combined output mode: will generate single file with sample lists");
-                    if merge_tolerance > 0.0 {
-                        info!("Merge tolerance: {:.1}%", merge_tolerance * 100.0);
-                    }
-                    depth::compute_depth_stats_with_samples(
-                        &impg,
-                        &config,
-                        &separator,
-                        prefix,
-                        sample_filter.as_ref(),
-                        fai_list.as_deref(),
-                        ref_sample.as_deref(),
-                        merge_tolerance,
-                    )?;
-                } else {
-                    depth::compute_depth_stats(
-                        &impg,
-                        &config,
-                        &separator,
-                        prefix,
-                        sample_filter.as_ref(),
-                        fai_list.as_deref(),
-                        ref_sample.as_deref(),
-                    )?;
-                }
-                return Ok(());
-            }
 
             // Region query mode: depth for specific genomic regions
             if target_range.is_some() || target_bed.is_some() {
@@ -2364,9 +2320,17 @@ fn run() -> io::Result<()> {
             }
 
             // Default / ref-anchored / ref-only depth computation
+            // --stats is an add-on: same hub-first pipeline, different output format
             // Without --ref: auto hub detection via degree pre-scan
             // With --ref: ref sample's sequences are Phase 1 anchors
             // With --ref --ref-only: output filtered to ref sample's anchored regions only
+            if stats {
+                let prefix = output_prefix.as_deref().unwrap_or("depth_stats");
+                info!("Stats add-on enabled, output prefix: {}", prefix);
+                if combined_output {
+                    info!("Combined output mode: will generate single file with sample lists");
+                }
+            }
             if let Some(ws) = window_size {
                 info!("Window size: {} bp", ws);
             }
@@ -2387,6 +2351,8 @@ fn run() -> io::Result<()> {
                 ref_sample.as_deref(),
                 ref_only,
                 min_seq_length as i64,
+                stats,
+                combined_output,
             )?;
         }
     }


### PR DESCRIPTION
The depth command iterates through all sequences as references, calculates coverage depth (unique sample count) for each position using a sweep-line algorithm, and outputs a TSV table with window_id, depth, and sample columns.

Key features:
- Two-phase processing: parallel overlap queries + sequential deduplication
- Union approach for A-B/B-A alignment asymmetry (merges all intervals per sample)
- Groups by PanSN sample name (sample#haplotype#chr -> sample)
- Supports transitive queries, custom reference ordering, and adjacent window merging
- Each position is output only once via ProcessedRegions tracking
