### PR TITLE
Update sweepga, default to fastga, fix frequency multiplier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "gfasort"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/gfasort?rev=e23f45e#e23f45e94e2746f2817eb17925f53e0319b1b085"
+source = "git+https://github.com/pangenome/gfasort?rev=b5fdb1d#b5fdb1d2222cfd295288465aba007ef88603b665"
 dependencies = [
  "clap",
  "rand 0.9.2",
@@ -2405,7 +2405,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 [[package]]
 name = "seqwish"
 version = "0.1.3"
-source = "git+https://github.com/pangenome/seqwish?branch=rust-2#5c80b1c833e08fc40b86d2e17a2f2c2807d8b4e0"
+source = "git+https://github.com/pangenome/seqwish?branch=transclosure-optimize#3a6baad097ca678a654f684fbc10d476b92b6ccb"
 dependencies = [
  "bitvec",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "fastga-rs"
 version = "0.1.2"
-source = "git+https://github.com/pangenome/fastga-rs?rev=01eb1ff#01eb1ffe5df54b45123fee40cf69a8beb04fd1fc"
+source = "git+https://github.com/pangenome/fastga-rs?rev=e5037d5#e5037d5ef818f0ed1eef68e5678324a3b6f9111a"
 dependencies = [
  "anyhow",
  "cc",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=38a6affbc8516a24eb219d731d3056f25a1da8ef#38a6affbc8516a24eb219d731d3056f25a1da8ef"
+source = "git+https://github.com/pangenome/sweepga?rev=29d21238765abb1016d7d75c19666127faa962cb#29d21238765abb1016d7d75c19666127faa962cb"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ zstd = { version = "0.13.3", features = ["zstdmt"] }
 gzp = "1.0.1"
 
 # Dependencies for graph building (sweepga + seqwish integration)
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "38a6affbc8516a24eb219d731d3056f25a1da8ef", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "29d21238765abb1016d7d75c19666127faa962cb", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 
 # Dependencies for graph sorting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,10 @@ gzp = "1.0.1"
 
 # Dependencies for graph building (sweepga + seqwish integration)
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "29d21238765abb1016d7d75c19666127faa962cb", default-features = false }
-seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
+seqwish = { git = "https://github.com/pangenome/seqwish", branch = "transclosure-optimize" }
 
 # Dependencies for graph sorting
-gfasort = { git = "https://github.com/pangenome/gfasort", rev = "e23f45e" }
+gfasort = { git = "https://github.com/pangenome/gfasort", rev = "b5fdb1d" }
 
 [dev-dependencies]
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5,7 +5,7 @@ use spoa_rs::{AlignmentEngine, AlignmentType as SpoaAlignmentType, Graph as Spoa
 use std::io::{self, BufWriter, Write};
 
 // Gfasort imports for graph sorting
-use gfasort::gfa_parser::load_gfa;
+use gfasort::gfa_parser::{load_gfa, load_gfa_from_str};
 use gfasort::ygs::{unchop_only, ygs_sort, YgsParams};
 
 #[derive(Clone)]
@@ -713,14 +713,7 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 /// Compact consecutive nodes (unchop) without sorting.
 /// Reduces 1-bp SPOA nodes into longer segments early, shrinking the graph for downstream steps.
 pub(crate) fn unchop_gfa(gfa_content: &str) -> io::Result<String> {
-    let temp_gfa = tempfile::Builder::new()
-        .suffix(".gfa")
-        .tempfile()
-        .map_err(|e| io::Error::other(format!("unchop: failed to create temp file: {}", e)))?;
-    std::fs::write(temp_gfa.path(), gfa_content)
-        .map_err(|e| io::Error::other(format!("unchop: failed to write temp file: {}", e)))?;
-
-    let mut graph = load_gfa(temp_gfa.path())
+    let mut graph = load_gfa_from_str(gfa_content)
         .map_err(|e| io::Error::other(format!("unchop: failed to load GFA: {}", e)))?;
 
     if graph.nodes.iter().filter(|n| n.is_some()).count() <= 1 {
@@ -751,17 +744,8 @@ pub fn normalize_and_sort(gfa: String, num_threads: usize) -> io::Result<String>
 }
 
 pub fn sort_gfa(gfa_content: &str, num_threads: usize) -> io::Result<String> {
-    // Write GFA to temp file (gfasort's load_gfa requires a file path)
-    let temp_gfa = tempfile::Builder::new()
-        .suffix(".gfa")
-        .tempfile()
-        .map_err(|e| io::Error::other(format!("Failed to create temp GFA file: {}", e)))?;
-
-    std::fs::write(temp_gfa.path(), gfa_content)
-        .map_err(|e| io::Error::other(format!("Failed to write temp GFA: {}", e)))?;
-
-    // Load GFA into gfasort's graph structure
-    let mut graph = load_gfa(temp_gfa.path())
+    // Load GFA directly from string (no temp file round-trip)
+    let mut graph = load_gfa_from_str(gfa_content)
         .map_err(|e| io::Error::other(format!("Failed to load GFA for sorting: {}", e)))?;
 
     // Skip sorting for trivial graphs (0 or 1 node)

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ struct CommonOpts {
 struct AlnOpts {
     // --- Aligner backend ---
     /// Aligner
-    #[clap(long, value_parser = ["fastga", "wfmash"], default_value = "wfmash")]
+    #[clap(long, value_parser = ["fastga", "wfmash"], default_value = "fastga")]
     aligner: String,
 
     // --- General alignment options ---
@@ -174,11 +174,11 @@ struct AlnOpts {
     min_map_length: u64,
 
     // --- fastga-specific options ---
-    /// [fastga] K-mer frequency multiplier (frequency = num_sequences * multiplier)
+    /// [fastga] K-mer frequency multiplier (frequency = num_genomes * multiplier)
     #[clap(
         long = "fastga-frequency-multiplier",
         value_parser,
-        default_value_t = 10
+        default_value_t = 1
     )]
     fastga_frequency_multiplier: usize,
 


### PR DESCRIPTION
## Summary
- Update sweepga from 38a6aff to 29d2123 (includes default fastga aligner, runtime resource logging, batch-bytes fix, fastga-rs update)
- Switch default `--aligner` from wfmash to fastga to match sweepga's new default
- Change default `--fastga-frequency-multiplier` from 10 to 1, so frequency = num_genomes (matching sweepga standalone behavior)

The 10x multiplier caused `-f4660` instead of `-f466` for a 466-genome query, making FastGA alignment unnecessarily slow for local pangenome construction.

## Test plan
- [x] Tested `impg query -o gfa` on C4/MHC region (GRCh38#0#chr6:31972057-32055418) with HPRCv2 — FastGA now correctly uses `-f466`
- [x] Verified standalone `sweepga` produces matching frequency