### PR TITLE
Fix seqwish dep: point to rust-2 (includes label prop revert)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,7 +2405,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 [[package]]
 name = "seqwish"
 version = "0.1.3"
-source = "git+https://github.com/pangenome/seqwish?branch=transclosure-optimize#3a6baad097ca678a654f684fbc10d476b92b6ccb"
+source = "git+https://github.com/pangenome/seqwish?branch=rust-2#b65a7e0a8b6d1a2fb9e2f69e43efc7b57d87bf28"
 dependencies = [
  "bitvec",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ gzp = "1.0.1"
 
 # Dependencies for graph building (sweepga + seqwish integration)
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "29d21238765abb1016d7d75c19666127faa962cb", default-features = false }
-seqwish = { git = "https://github.com/pangenome/seqwish", branch = "transclosure-optimize" }
+seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "b5fdb1d" }


### PR DESCRIPTION
The seqwish dependency was pointing to `transclosure-optimize` branch which has a race condition causing crashes on larger inputs (USP14 region). Update to `rust-2` which has the fix (PR pangenome/seqwish#137 reverted label propagation to DisjointSetsAsm).

Smoke test: MHC C4 region produces correct output (2727 nodes, 52047bp).