### PR TITLE
Persist syng syncmer parameters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1161,7 +1161,7 @@ impl RefineOpts {
 /// prefix (base name before `.1khash` / `.1gbwt`) if one is found.
 ///
 /// Accepts:
-///   - Explicit file path ending in `.1khash`, `.1gbwt`, or `.syng.spos` → strip suffix
+///   - Explicit file path ending in `.1khash`, `.1gbwt`, `.syng.spos`, or `.syng.meta` → strip suffix
 ///   - Bare prefix with sibling `.1khash` on disk → return prefix as-is
 fn detect_syng_prefix(path: &str) -> Option<String> {
     if let Some(stem) = path.strip_suffix(".1khash") {
@@ -1171,6 +1171,9 @@ fn detect_syng_prefix(path: &str) -> Option<String> {
         return Some(stem.to_string());
     }
     if let Some(stem) = path.strip_suffix(".syng.spos") {
+        return Some(stem.to_string());
+    }
+    if let Some(stem) = path.strip_suffix(".syng.meta") {
         return Some(stem.to_string());
     }
     if std::path::Path::new(&format!("{path}.1khash")).exists() {
@@ -1693,7 +1696,7 @@ enum Args {
 
     /// Map sequences to a syng index using exact shared syncmers
     Map {
-        /// Syng index prefix or .1khash/.1gbwt path
+        /// Syng index prefix or .1khash/.1gbwt/.syng.spos/.syng.meta path
         #[clap(short = 'a', long, value_parser)]
         index: String,
 
@@ -1738,7 +1741,7 @@ enum Args {
         fasta: Option<String>,
 
         // --- Output ---
-        /// Output file prefix (produces .1khash, .1gbwt, .syng.names, .syng.spos)
+        /// Output file prefix (produces .1khash, .1gbwt, .syng.names, .syng.spos, .syng.meta)
         #[clap(short = 'o', long, value_parser)]
         output: String,
 
@@ -3952,8 +3955,9 @@ fn run() -> io::Result<()> {
             info!("Saving index to prefix: {}", output);
             index.save(&output)?;
             info!(
-                "Index saved in {}: {}.1khash, {}.1gbwt, {}.syng.names, {}.syng.spos",
+                "Index saved in {}: {}.1khash, {}.1gbwt, {}.syng.names, {}.syng.spos, {}.syng.meta",
                 format_duration(save_start.elapsed()),
+                output,
                 output,
                 output,
                 output,

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -434,7 +434,7 @@ fn sampled_position_hash(
 }
 
 /// Parameters controlling syncmer extraction.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SyncmerParams {
     /// Inner k-mer length (default 8).
     pub k: u32,
@@ -464,6 +464,139 @@ impl SyncmerParams {
             seed: self.seed as i32,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SyngMetadata {
+    params: SyncmerParams,
+}
+
+impl SyngMetadata {
+    const VERSION: u32 = 1;
+
+    fn new(params: SyncmerParams) -> Self {
+        Self { params }
+    }
+
+    fn save(&self, path: &str) -> io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        writeln!(writer, "# impg syng metadata")?;
+        writeln!(writer, "version\t{}", Self::VERSION)?;
+        writeln!(writer, "syncmer_k\t{}", self.params.k)?;
+        writeln!(writer, "syncmer_w\t{}", self.params.w)?;
+        writeln!(writer, "syncmer_seed\t{}", self.params.seed)?;
+        writeln!(writer, "syncmer_length\t{}", self.params.k + self.params.w)?;
+        writeln!(writer, "smer_length\t{}", self.params.k)?;
+        writer.flush()
+    }
+
+    fn load(path: &str) -> io::Result<Self> {
+        let file = std::fs::File::open(path).map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "syng metadata not found: {} (rebuild the syng index with this impg)",
+                        path
+                    ),
+                )
+            } else {
+                e
+            }
+        })?;
+        let reader = BufReader::new(file);
+
+        let mut version = None;
+        let mut syncmer_k = None;
+        let mut syncmer_w = None;
+        let mut syncmer_seed = None;
+
+        for (line_no, line) in reader.lines().enumerate() {
+            let line = line?;
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let mut parts = line.split('\t');
+            let key = parts.next().unwrap_or_default();
+            let value = parts.next().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid syng metadata line {}: {}", line_no + 1, line),
+                )
+            })?;
+            if parts.next().is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid syng metadata line {}: {}", line_no + 1, line),
+                ));
+            }
+
+            match key {
+                "version" => version = Some(parse_metadata_u32(key, value, line_no + 1)?),
+                "syncmer_k" => syncmer_k = Some(parse_metadata_u32(key, value, line_no + 1)?),
+                "syncmer_w" => syncmer_w = Some(parse_metadata_u32(key, value, line_no + 1)?),
+                "syncmer_seed" => syncmer_seed = Some(parse_metadata_u32(key, value, line_no + 1)?),
+                "syncmer_length" | "smer_length" => {}
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("unknown syng metadata key '{}' on line {}", key, line_no + 1),
+                    ));
+                }
+            }
+        }
+
+        let version = version.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "syng metadata missing version")
+        })?;
+        if version != Self::VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported syng metadata version {}", version),
+            ));
+        }
+
+        let params = SyncmerParams {
+            k: syncmer_k.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "syng metadata missing syncmer_k")
+            })?,
+            w: syncmer_w.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "syng metadata missing syncmer_w")
+            })?,
+            seed: syncmer_seed.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "syng metadata missing syncmer_seed")
+            })?,
+        };
+
+        if params.k == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "syng metadata syncmer_k must be greater than 0",
+            ));
+        }
+        if params.k.checked_add(params.w).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "syng metadata syncmer length overflowed u32",
+            ));
+        }
+
+        Ok(Self { params })
+    }
+}
+
+fn parse_metadata_u32(key: &str, value: &str, line_no: usize) -> io::Result<u32> {
+    value.parse::<u32>().map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "invalid syng metadata value for '{}' on line {}: {}",
+                key, line_no, e
+            ),
+        )
+    })
 }
 
 /// Information needed to walk a genome's forward path through the GBWT.
@@ -972,11 +1105,12 @@ impl SyngIndex {
 
     /// Save the index to disk.
     ///
-    /// Produces four files at the given prefix:
+    /// Produces five files at the given prefix:
     /// - `{prefix}.1khash` — syncmer hash (syng-compatible)
     /// - `{prefix}.1gbwt` — GBWT graph (syng-compatible)
     /// - `{prefix}.syng.names` — sequence name mapping
     /// - `{prefix}.syng.spos` — sampled path-position index
+    /// - `{prefix}.syng.meta` — syncmer extraction parameters
     pub fn save(&mut self, prefix: &str) -> io::Result<()> {
         let _ = self.finalize_online_sampled_positions()?;
         let schema_text = syng_ffi::syng_schema_text();
@@ -1049,17 +1183,24 @@ impl SyngIndex {
         })?;
         sampled_positions.save(&format!("{}.syng.spos", prefix))?;
 
+        // Write .syng.meta last so a complete index records the syncmer
+        // parameters that future query/map calls must use.
+        SyngMetadata::new(self.params).save(&format!("{}.syng.meta", prefix))?;
+
         Ok(())
     }
 
     /// Load an index from disk.
     ///
-    /// Reads four files at the given prefix:
+    /// Reads five files at the given prefix:
     /// - `{prefix}.1khash`
     /// - `{prefix}.1gbwt`
     /// - `{prefix}.syng.names`
     /// - `{prefix}.syng.spos`
-    pub fn load(prefix: &str, params: SyncmerParams) -> io::Result<Self> {
+    /// - `{prefix}.syng.meta`
+    pub fn load(prefix: &str, _params: SyncmerParams) -> io::Result<Self> {
+        let metadata = SyngMetadata::load(&format!("{}.syng.meta", prefix))?;
+        let params = metadata.params;
         let schema_text = syng_ffi::syng_schema_text();
 
         // Read .1gbwt
@@ -1157,7 +1298,17 @@ impl SyngIndex {
         // Read required .syng.spos sampled-position sidecar.
         let sampled_positions_path = format!("{}.syng.spos", prefix);
         let sampled_positions = if Path::new(&sampled_positions_path).exists() {
-            Some(SampledPositions::load(&sampled_positions_path)?)
+            match SampledPositions::load(&sampled_positions_path) {
+                Ok(sp) => Some(sp),
+                Err(e) => {
+                    unsafe {
+                        syng_ffi::syngBWTdestroy(gbwt);
+                        syng_ffi::kmerHashDestroy(kmer_hash);
+                        syng_ffi::impg_seqhashDestroy(seqhash);
+                    }
+                    return Err(e);
+                }
+            }
         } else {
             unsafe {
                 syng_ffi::syngBWTdestroy(gbwt);
@@ -2029,9 +2180,14 @@ mod tests {
             std::path::Path::new(&format!("{}.syng.names", prefix_str)).exists(),
             ".syng.names file should exist"
         );
+        assert!(
+            std::path::Path::new(&format!("{}.syng.meta", prefix_str)).exists(),
+            ".syng.meta file should exist"
+        );
 
         // Load
         let loaded = SyngIndex::load(prefix_str, params).unwrap();
+        assert_eq!(loaded.params, params);
 
         // Verify name map is intact
         assert_eq!(
@@ -2049,6 +2205,44 @@ mod tests {
         assert!(!loaded.gbwt.is_null());
         assert!(!loaded.kmer_hash.is_null());
         assert!(!loaded.seqhash.is_null());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_save_load_uses_saved_syncmer_params() {
+        let _guard = lock_syng();
+        let seq = make_test_sequence(5000, 11);
+        let params = SyncmerParams {
+            k: 6,
+            w: 31,
+            seed: 42,
+        };
+        let mut index = SyngIndex::build(params, vec![("seq".to_string(), seq)].into_iter());
+
+        let dir = std::env::temp_dir().join("impg_test_syng_saved_params");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prefix = dir.join("idx");
+        let prefix_str = prefix.to_str().unwrap();
+
+        index.save(prefix_str).unwrap();
+
+        let meta = std::fs::read_to_string(format!("{}.syng.meta", prefix_str)).unwrap();
+        assert!(meta.contains("syncmer_k\t6"));
+        assert!(meta.contains("syncmer_w\t31"));
+        assert!(meta.contains("syncmer_seed\t42"));
+
+        let loaded = SyngIndex::load(prefix_str, SyncmerParams::default()).unwrap();
+        assert_eq!(
+            loaded.params, params,
+            "load must use syncmer params stored in .syng.meta, not caller defaults"
+        );
+        let matches = loaded.matched_syncmers_in_sequence(&make_test_sequence(5000, 11));
+        assert!(
+            !matches.is_empty(),
+            "loaded index should query with the saved non-default params"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -2613,6 +2807,10 @@ mod tests {
         assert!(
             std::path::Path::new(&format!("{}.syng.spos", output_prefix_str)).exists(),
             ".syng.spos should be built by default"
+        );
+        assert!(
+            std::path::Path::new(&format!("{}.syng.meta", output_prefix_str)).exists(),
+            ".syng.meta should be built by default"
         );
 
         // Load and verify content

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -148,11 +148,13 @@ fn test_syng_agc_build_produces_non_empty_index() {
     let khash_path = format!("{}.1khash", out_prefix.to_str().unwrap());
     let names_path = format!("{}.syng.names", out_prefix.to_str().unwrap());
     let spos_path = format!("{}.syng.spos", out_prefix.to_str().unwrap());
+    let meta_path = format!("{}.syng.meta", out_prefix.to_str().unwrap());
 
     assert!(std::path::Path::new(&gbwt_path).exists(), ".1gbwt missing");
     assert!(std::path::Path::new(&khash_path).exists(), ".1khash missing");
     assert!(std::path::Path::new(&names_path).exists(), ".syng.names missing");
     assert!(std::path::Path::new(&spos_path).exists(), ".syng.spos missing");
+    assert!(std::path::Path::new(&meta_path).exists(), ".syng.meta missing");
 
     // Key assertion: the GBWT must contain actual vertex data, not just a
     // schema header. The yeast235 bug slipped through because nothing
@@ -523,6 +525,10 @@ fn test_syng_map_cli_sampled_positions_paf() {
     assert!(
         std::path::Path::new(&format!("{}.syng.spos", idx_prefix.to_str().unwrap())).exists(),
         "default sampled-position sidecar should be written"
+    );
+    assert!(
+        std::path::Path::new(&format!("{}.syng.meta", idx_prefix.to_str().unwrap())).exists(),
+        "syncmer metadata should be written"
     );
     assert!(
         !std::path::Path::new(&format!("{}.syng.locate", idx_prefix.to_str().unwrap())).exists(),


### PR DESCRIPTION
## Summary
- write a required `.syng.meta` file with syncmer extraction parameters
- make `SyngIndex::load` use stored params instead of caller defaults
- allow `.syng.meta` paths anywhere syng prefixes are accepted

## Tests
- `cargo test --release --lib syng::tests -- --nocapture`
- `cargo test --release --test test_syng_integration -- --nocapture`
- `cargo install --path . --force`

## Local smoke
- `impg map` 1M HG002 R1 reads to 3-sample syng in GAF mode: 58.01s wall, max RSS 9,704,044 KB
- `impg map` 100k HG002 R1 reads to 3-sample syng in PAF mode: 2:07.77 wall, max RSS 9,742,896 KB
