### PR TITLE
Add parallel syng dictionary construction

### DIFF
--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -1,0 +1,114 @@
+# Syng Parallel Construction Design
+
+## Goal
+
+Build a syng index from many genomes without being limited by one serial
+`kmerHashAdd` / `syngBWTpathAdd` stream for the whole input. The construction
+must produce a normal syng index:
+
+- `{prefix}.1khash`
+- `{prefix}.1gbwt`
+- `{prefix}.syng.names`
+- `{prefix}.syng.spos`
+- `{prefix}.syng.meta`
+
+The output does not need to assign the same numeric syncmer node ids as the
+legacy one-pass build. It must assign ids consistently across all files and
+produce equivalent query/map behavior.
+
+## Mathematical Model
+
+For each genome path `p`, syncmer extraction produces an ordered stream:
+
+```text
+S_p = [(x_1, strand_1, pos_1), ..., (x_n, strand_n, pos_n)]
+```
+
+where `x_i` is the canonical full syncmer sequence, `strand_i` records whether
+the occurrence matched the canonical orientation or reverse complement, and
+`pos_i` is the bp coordinate on `p`.
+
+The global syncmer dictionary is:
+
+```text
+K = union_p { x_i : (x_i, strand_i, pos_i) in S_p }
+```
+
+Construction chooses one deterministic bijection:
+
+```text
+phi: K -> {1, 2, ..., |K|}
+```
+
+Every path is then encoded as signed global node ids:
+
+```text
+P_p = [(strand_i * phi(x_i), pos_i)]
+```
+
+The GBWT and sampled-position sidecar are functions of the ordered collection
+of `P_p` streams. A parallel build is correct if all shards use the same `phi`
+and the final path order is the chosen global path order.
+
+## Production Algorithm
+
+The clean end-state is a two-pass parallel dictionary plus per-node reduce:
+
+1. Enumerate all input paths and assign stable global path ids.
+2. In parallel, extract canonical syncmers and build shard-local unique sets.
+3. Sort/deduplicate the union and assign global ids.
+4. In parallel, stream inputs again and map syncmers through the global
+   dictionary.
+5. For each shard, emit per-node occurrence records and sampled-position
+   records using global node ids and global path coordinates.
+6. Reduce per-node occurrence records into the final GBWT node structures.
+7. Sort/group sampled-position records and write `.syng.spos`.
+
+Step 6 is the only part not exposed by the current syng C API. The existing
+API has one mutable `syngBWTpathAdd` stream, but no `syngBWTmerge` or builder
+from per-node occurrence lists. That API should be added only after the
+dictionary split is tested.
+
+## Implemented First Step
+
+The first implementation stage is intentionally conservative:
+
+1. Build the global syncmer dictionary in parallel.
+2. Construct a syng `KmerHash` from that frozen dictionary.
+3. Replay paths through the existing serial GBWT writer, using dictionary
+   lookup instead of adding new syncmers.
+
+This validates the global-id model and allows tests to compare the new two-pass
+path against the legacy one-pass path. It also removes hash-table growth and
+syncmer insertion from the serial GBWT phase. The final GBWT insertion remains
+serial until a true per-node reduce API is added.
+
+This path is exposed as `impg syng --parallel-dictionary` for both FASTA and
+AGC inputs.
+
+## Correctness Requirements
+
+- Syncmer parameters are read from `.syng.meta` and written with every build.
+- Packed canonical syncmers use the same canonical orientation as syng's
+  `kmerHashAdd`.
+- The frozen dictionary rejects duplicate packed syncmers.
+- Replay fails if any extracted syncmer is absent from the frozen dictionary.
+- `.syng.spos` sampling uses global path ids and positions, so it remains
+  merge-compatible.
+
+## Next Step: True GBWT Reduce
+
+A full parallel GBWT builder needs a new internal representation:
+
+```text
+node_id -> ordered incoming/outgoing occurrence lists
+```
+
+For a fixed global path partition order, shard-local occurrence lists for the
+same node can be concatenated in that partition order and converted to the same
+simple-node / rskip representation currently produced incrementally by
+`syngBWTpathAdd`.
+
+That reduce API should live below `SyngIndex`, ideally in C next to
+`syngbwt3.c`, because it needs to construct `NodeSide` / `Rskip` structures
+directly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod agc_index;
 pub mod syng_ffi;
 pub mod syng;
+pub mod syng_parallel;
 pub mod alignment_record;
 pub mod commands;
 pub mod faidx;

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,127 @@ fn resolve_syng_syncmer_params(
     })
 }
 
+#[derive(Debug, Clone)]
+struct SyngAgcRecord {
+    sample: String,
+    contig: String,
+    name: String,
+    length: usize,
+}
+
+fn syng_sequence_name(sample: &str, contig: &str) -> String {
+    if contig.contains('#') {
+        contig.to_string()
+    } else {
+        format!("{}@{}", contig, sample)
+    }
+}
+
+fn ragc_numeric_to_ascii(seq: &[u8]) -> Vec<u8> {
+    seq.iter()
+        .map(|&b| match b {
+            0 => b'A',
+            1 => b'C',
+            2 => b'G',
+            3 => b'T',
+            _ => b'N',
+        })
+        .collect()
+}
+
+fn read_syng_fasta_sequences(fasta_path: &str) -> io::Result<Vec<(String, Vec<u8>)>> {
+    let file = File::open(fasta_path)?;
+    let (reader, _format) = niffler::get_reader(Box::new(file)).map_err(|e| {
+        io::Error::other(format!(
+            "Failed to open reader for '{}': {}",
+            fasta_path, e
+        ))
+    })?;
+    let reader = BufReader::new(reader);
+
+    let mut sequences = Vec::new();
+    let mut current_name = String::new();
+    let mut current_seq = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with('>') {
+            if !current_name.is_empty() && !current_seq.is_empty() {
+                sequences.push((
+                    std::mem::take(&mut current_name),
+                    std::mem::take(&mut current_seq),
+                ));
+            }
+            current_name = line
+                .strip_prefix('>')
+                .unwrap_or("")
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            current_seq.clear();
+        } else {
+            current_seq.extend(line.trim().as_bytes());
+        }
+    }
+    if !current_name.is_empty() && !current_seq.is_empty() {
+        sequences.push((current_name, current_seq));
+    }
+
+    Ok(sequences)
+}
+
+fn collect_syng_agc_records(agc_path: &str) -> io::Result<Vec<SyngAgcRecord>> {
+    let config = ragc_core::DecompressorConfig { verbosity: 0 };
+    let mut decompressor = ragc_core::Decompressor::open(agc_path, config).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Failed to open AGC file '{}': {}", agc_path, e),
+        )
+    })?;
+
+    let samples = decompressor.list_samples();
+    let mut records = Vec::new();
+    for sample in samples {
+        let contigs = decompressor
+            .list_contigs_names_only(&sample)
+            .unwrap_or_default();
+        for contig in contigs {
+            let length = decompressor.get_contig_length(&sample, &contig).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to get length for contig '{}@{}': {}", contig, sample, e),
+                )
+            })?;
+            records.push(SyngAgcRecord {
+                name: syng_sequence_name(&sample, &contig),
+                sample: sample.clone(),
+                contig,
+                length,
+            });
+        }
+    }
+    Ok(records)
+}
+
+fn read_syng_agc_record(
+    decompressor: &mut ragc_core::Decompressor,
+    record: &SyngAgcRecord,
+) -> io::Result<Vec<u8>> {
+    let contig_data = decompressor
+        .get_contig_range(&record.sample, &record.contig, 0, record.length)
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Failed to decompress contig '{}@{}': {}",
+                    record.contig, record.sample, e
+                ),
+            )
+        })?;
+    Ok(ragc_numeric_to_ascii(&contig_data))
+}
+
 fn format_duration(duration: Duration) -> String {
     if duration.as_secs() >= 60 {
         let mins = duration.as_secs() / 60;
@@ -1754,6 +1875,11 @@ enum Args {
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SEED)]
         position_sample_seed: u64,
+
+        /// Build a deterministic global syncmer dictionary in a parallel prepass, then replay paths through it.
+        #[arg(help_heading = "Construction")]
+        #[clap(long, action)]
+        parallel_dictionary: bool,
 
         // --- Syncmer parameters ---
         /// Inner k-mer length for syncmer extraction
@@ -3643,6 +3769,7 @@ fn run() -> io::Result<()> {
             syncmer_seed,
             position_sample_shift,
             position_sample_seed,
+            parallel_dictionary,
             common,
         } => {
             initialize_threads_and_log(&common);
@@ -3690,6 +3817,122 @@ fn run() -> io::Result<()> {
             let total_start = Instant::now();
 
             let mut index = if let Some(agc_path) = agc {
+                if parallel_dictionary {
+                    let input_start = Instant::now();
+                    info!(
+                        "Reading AGC sequence catalog for parallel dictionary build: {} at +{}",
+                        agc_path,
+                        format_duration(total_start.elapsed())
+                    );
+                    let records = collect_syng_agc_records(&agc_path)?;
+                    let total_bp: u64 = records.iter().map(|record| record.length as u64).sum();
+                    info!(
+                        "Found {} AGC sequences ({} bp) for dictionary prepass",
+                        records.len(),
+                        total_bp
+                    );
+
+                    let dictionary_start = Instant::now();
+                    let agc_path_for_threads = agc_path.clone();
+                    let packed_syncmers = records
+                        .par_iter()
+                        .map_init(
+                            move || {
+                                let config = ragc_core::DecompressorConfig { verbosity: 0 };
+                                ragc_core::Decompressor::open(&agc_path_for_threads, config)
+                                    .map_err(|e| {
+                                        io::Error::new(
+                                            io::ErrorKind::InvalidData,
+                                            format!(
+                                                "Failed to open AGC file '{}': {}",
+                                                agc_path_for_threads, e
+                                            ),
+                                        )
+                                    })
+                            },
+                            |decompressor, record| {
+                                let decompressor = match decompressor {
+                                    Ok(decompressor) => decompressor,
+                                    Err(e) => {
+                                        return Err(io::Error::new(e.kind(), e.to_string()));
+                                    }
+                                };
+                                let seq = read_syng_agc_record(decompressor, record)?;
+                                impg::syng_parallel::extract_packed_syncmers(params, &seq)
+                            },
+                        )
+                        .try_reduce(Vec::new, |mut acc, mut part| {
+                            acc.append(&mut part);
+                            Ok(acc)
+                        })?;
+                    let raw_syncmers = packed_syncmers.len();
+                    let dictionary =
+                        impg::syng_parallel::sort_dedup_packed_syncmers(packed_syncmers);
+                    info!(
+                        "Built packed syncmer dictionary in {}: {} raw syncmers, {} unique syncmer nodes at +{}",
+                        format_duration(dictionary_start.elapsed()),
+                        raw_syncmers,
+                        dictionary.len(),
+                        format_duration(total_start.elapsed())
+                    );
+
+                    let preload_start = Instant::now();
+                    let mut index = impg::syng::SyngIndex::new_with_packed_syncmer_dictionary(
+                        params,
+                        &dictionary,
+                    )?;
+                    configure_position_sampling(&mut index)?;
+                    info!(
+                        "Preloaded {} syncmer nodes into KmerHash in {}",
+                        dictionary.len(),
+                        format_duration(preload_start.elapsed())
+                    );
+
+                    let config = ragc_core::DecompressorConfig { verbosity: 0 };
+                    let mut decompressor =
+                        ragc_core::Decompressor::open(&agc_path, config).map_err(|e| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("Failed to open AGC file '{}': {}", agc_path, e),
+                            )
+                        })?;
+                    let mut sequence_count = 0usize;
+                    let mut indexed_bp = 0u64;
+                    let mut total_syncmers = 0usize;
+                    for (record_idx, record) in records.iter().enumerate() {
+                        let contig_start = Instant::now();
+                        let seq = read_syng_agc_record(&mut decompressor, record)?;
+                        info!("  Processing {} ({} bp)", record.name, seq.len());
+                        let stats = index
+                            .add_sequence_with_existing_syncmers(record.name.clone(), seq)?;
+                        sequence_count += 1;
+                        indexed_bp += stats.sequence_len as u64;
+                        total_syncmers += stats.syncmers;
+                        info!(
+                            "  Indexed contig {}/{} {}: {} bp, {} syncmers, indexed={}, elapsed {}, total {} sequences / {} bp / {} syncmers at +{}",
+                            record_idx + 1,
+                            records.len(),
+                            record.name,
+                            stats.sequence_len,
+                            stats.syncmers,
+                            stats.indexed,
+                            format_duration(contig_start.elapsed()),
+                            sequence_count,
+                            indexed_bp,
+                            total_syncmers,
+                            format_duration(total_start.elapsed())
+                        );
+                    }
+
+                    info!(
+                        "Built syng paths from {} sequences ({} bp, {} syncmers) in {}",
+                        sequence_count,
+                        indexed_bp,
+                        total_syncmers,
+                        format_duration(input_start.elapsed())
+                    );
+                    index
+                } else {
                 // Stream sequences from AGC
                 let input_start = Instant::now();
                 info!(
@@ -3829,7 +4072,81 @@ fn run() -> io::Result<()> {
                     format_duration(input_start.elapsed())
                 );
                 index
+                }
             } else if let Some(fasta_path) = fasta {
+                if parallel_dictionary {
+                    let input_start = Instant::now();
+                    info!(
+                        "Reading sequences from FASTA for parallel dictionary build: {} at +{}",
+                        fasta_path,
+                        format_duration(total_start.elapsed())
+                    );
+                    let sequences = read_syng_fasta_sequences(&fasta_path)?;
+                    let total_sequences = sequences.len();
+                    let total_bp: u64 =
+                        sequences.iter().map(|(_, seq)| seq.len() as u64).sum();
+                    info!(
+                        "Read {} FASTA sequences ({} bp) for dictionary prepass",
+                        sequences.len(),
+                        total_bp
+                    );
+
+                    let dictionary_start = Instant::now();
+                    let dictionary =
+                        impg::syng_parallel::build_packed_syncmer_dictionary(params, &sequences)?;
+                    info!(
+                        "Built packed syncmer dictionary in {}: {} unique syncmer nodes at +{}",
+                        format_duration(dictionary_start.elapsed()),
+                        dictionary.len(),
+                        format_duration(total_start.elapsed())
+                    );
+
+                    let preload_start = Instant::now();
+                    let mut index = impg::syng::SyngIndex::new_with_packed_syncmer_dictionary(
+                        params,
+                        &dictionary,
+                    )?;
+                    configure_position_sampling(&mut index)?;
+                    info!(
+                        "Preloaded {} syncmer nodes into KmerHash in {}",
+                        dictionary.len(),
+                        format_duration(preload_start.elapsed())
+                    );
+
+                    let mut sequence_count = 0usize;
+                    let mut total_syncmers = 0usize;
+                    for (seq_idx, (name, seq)) in sequences.into_iter().enumerate() {
+                        let seq_start = Instant::now();
+                        let seq_len = seq.len();
+                        info!("  Processing {} ({} bp)", name, seq_len);
+                        let stats = index.add_sequence_with_existing_syncmers(name.clone(), seq)?;
+                        sequence_count += 1;
+                        total_syncmers += stats.syncmers;
+                        info!(
+                            "  Indexed sequence {}/{} {}: {} bp, {} syncmers, indexed={}, elapsed {}, total {} sequences / {} bp / {} syncmers at +{}",
+                            seq_idx + 1,
+                            total_sequences,
+                            name,
+                            stats.sequence_len,
+                            stats.syncmers,
+                            stats.indexed,
+                            format_duration(seq_start.elapsed()),
+                            sequence_count,
+                            total_bp,
+                            total_syncmers,
+                            format_duration(total_start.elapsed())
+                        );
+                    }
+
+                    info!(
+                        "Built syng paths from {} sequences ({} bp, {} syncmers) in {}",
+                        sequence_count,
+                        total_bp,
+                        total_syncmers,
+                        format_duration(input_start.elapsed())
+                    );
+                    index
+                } else {
                 // Read sequences from FASTA
                 let input_start = Instant::now();
                 info!(
@@ -3933,6 +4250,7 @@ fn run() -> io::Result<()> {
                     format_duration(input_start.elapsed())
                 );
                 index
+                }
             } else {
                 unreachable!()
             };

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -444,6 +444,16 @@ pub struct SyncmerParams {
     pub seed: u32,
 }
 
+/// Packed canonical full-syncmer sequence used for prebuilt KmerHash dictionaries.
+///
+/// This is the same 2-bit little-endian packing used by syng's `seqPack()`,
+/// stored as `kmerHash` expects it: `(syncmer_len + 31) / 32` u64 words.
+pub type PackedSyncmer = Vec<u64>;
+
+pub fn packed_syncmer_word_len(params: SyncmerParams) -> usize {
+    ((params.w + params.k + 31) / 32) as usize
+}
+
 impl Default for SyncmerParams {
     fn default() -> Self {
         Self {
@@ -856,6 +866,12 @@ pub struct SyngAddSequenceStats {
     pub indexed: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SyncmerLookupMode {
+    AddMissing,
+    RequireExisting,
+}
+
 // SAFETY: The C structures are only accessed through &self or &mut self,
 // and the C library's read-only query functions are thread-safe.
 unsafe impl Send for SyngIndex {}
@@ -892,6 +908,66 @@ impl SyngIndex {
                 .expect("default sampled-position parameters are valid"),
             ),
         }
+    }
+
+    /// Create an index and preload its syncmer dictionary.
+    ///
+    /// Paths can then be replayed with [`Self::add_sequence_with_existing_syncmers`].
+    /// The supplied dictionary must already be canonicalized, deduplicated, and
+    /// in the intended global ID order.
+    pub fn new_with_packed_syncmer_dictionary(
+        params: SyncmerParams,
+        packed_syncmers: &[PackedSyncmer],
+    ) -> io::Result<Self> {
+        let mut index = Self::new(params);
+        index.add_packed_syncmer_dictionary(packed_syncmers)?;
+        Ok(index)
+    }
+
+    /// Preload packed canonical syncmers into the C KmerHash in order.
+    pub fn add_packed_syncmer_dictionary(
+        &mut self,
+        packed_syncmers: &[PackedSyncmer],
+    ) -> io::Result<()> {
+        let expected_words = packed_syncmer_word_len(self.params);
+        for (i, packed) in packed_syncmers.iter().enumerate() {
+            if packed.len() != expected_words {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "packed syncmer {} has {} words, expected {}",
+                        i,
+                        packed.len(),
+                        expected_words
+                    ),
+                ));
+            }
+            let mut index: i64 = 0;
+            let added = unsafe {
+                syng_ffi::kmerHashAddPacked(
+                    self.kmer_hash,
+                    packed.as_ptr() as *mut syng_ffi::U64,
+                    &mut index,
+                )
+            };
+            if !added {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("duplicate packed syncmer at dictionary offset {}", i),
+                ));
+            }
+            let expected_index = i as i64 + 1;
+            if index != expected_index {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "packed syncmer dictionary assigned id {}, expected {}",
+                        index, expected_index
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// True if a sampled path-position sidecar has been built or loaded.
@@ -972,6 +1048,29 @@ impl SyngIndex {
     /// large callers can stream inputs without buffering all decompressed
     /// sequences before GBWT construction.
     pub fn add_sequence(&mut self, name: String, seq: Vec<u8>) -> SyngAddSequenceStats {
+        self.add_sequence_internal(name, seq, SyncmerLookupMode::AddMissing)
+            .expect("adding new syncmers to KmerHash should not fail")
+    }
+
+    /// Add one sequence using a preloaded dictionary.
+    ///
+    /// Returns an error if any extracted syncmer is absent from the current
+    /// KmerHash. This is used by two-pass/parallel construction to replay paths
+    /// through a frozen global syncmer ID assignment.
+    pub fn add_sequence_with_existing_syncmers(
+        &mut self,
+        name: String,
+        seq: Vec<u8>,
+    ) -> io::Result<SyngAddSequenceStats> {
+        self.add_sequence_internal(name, seq, SyncmerLookupMode::RequireExisting)
+    }
+
+    fn add_sequence_internal(
+        &mut self,
+        name: String,
+        seq: Vec<u8>,
+        lookup_mode: SyncmerLookupMode,
+    ) -> io::Result<SyngAddSequenceStats> {
         self.sampled_positions = None;
 
         let syncmer_len = (self.params.w + self.params.k) as usize;
@@ -982,11 +1081,11 @@ impl SyngIndex {
             if let Some(builder) = self.sampled_position_builder.as_mut() {
                 builder.record_path(path_num as usize, seq_len as u64, &[]);
             }
-            return SyngAddSequenceStats {
+            return Ok(SyngAddSequenceStats {
                 sequence_len: seq_len,
                 syncmers: 0,
                 indexed: false,
-            };
+            });
         }
 
         // Convert sequence to numeric encoding (0=a, 1=c, 2=g, 3=t) for the C
@@ -1019,13 +1118,30 @@ impl SyngIndex {
                 &mut pos,
                 std::ptr::null_mut(),
             ) {
-                // Add the syncmer to the KmerHash (or find existing)
                 let mut kmer_index: i64 = 0;
-                syng_ffi::kmerHashAdd(
-                    self.kmer_hash,
-                    seq_buf.as_mut_ptr().add(pos as usize) as *mut i8,
-                    &mut kmer_index,
-                );
+                let syncmer_ptr = seq_buf.as_mut_ptr().add(pos as usize) as *mut i8;
+                match lookup_mode {
+                    SyncmerLookupMode::AddMissing => {
+                        syng_ffi::kmerHashAdd(self.kmer_hash, syncmer_ptr, &mut kmer_index);
+                    }
+                    SyncmerLookupMode::RequireExisting => {
+                        let found = syng_ffi::kmerHashFind(
+                            self.kmer_hash,
+                            syncmer_ptr,
+                            &mut kmer_index,
+                        );
+                        if !found {
+                            syng_ffi::impg_seqhashIteratorDestroy(sit);
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "syncmer at {}:{} is absent from the preloaded dictionary",
+                                    name, pos
+                                ),
+                            ));
+                        }
+                    }
+                }
                 syncmers.push((kmer_index, pos));
             }
 
@@ -1037,11 +1153,11 @@ impl SyngIndex {
             if let Some(builder) = self.sampled_position_builder.as_mut() {
                 builder.record_path(path_num as usize, seq_len as u64, &[]);
             }
-            return SyngAddSequenceStats {
+            return Ok(SyngAddSequenceStats {
                 sequence_len: seq_len,
                 syncmers: 0,
                 indexed: false,
-            };
+            });
         }
 
         // Build forward GBWT path and capture start info
@@ -1096,11 +1212,11 @@ impl SyngIndex {
             builder.record_path(path_num as usize, seq_len as u64, &syncmers);
         }
 
-        SyngAddSequenceStats {
+        Ok(SyngAddSequenceStats {
             sequence_len: seq_len,
             syncmers: syncmers.len(),
             indexed: true,
-        }
+        })
     }
 
     /// Save the index to disk.
@@ -2103,6 +2219,49 @@ mod tests {
             seq.push(bases[((state >> 16) % 4) as usize]);
         }
         seq
+    }
+
+    #[test]
+    fn test_preloaded_dictionary_replay_supports_query() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let shared = make_test_sequence(800, 42);
+        let mut seq_a = shared.clone();
+        seq_a.extend_from_slice(&make_test_sequence(300, 1));
+        let mut seq_b = shared;
+        seq_b.extend_from_slice(&make_test_sequence(300, 2));
+        let sequences = vec![
+            ("seqA".to_string(), seq_a.clone()),
+            ("seqB".to_string(), seq_b),
+            ("seqC".to_string(), make_test_sequence(1100, 99)),
+        ];
+
+        let dictionary =
+            crate::syng_parallel::build_packed_syncmer_dictionary(params, &sequences).unwrap();
+        assert!(!dictionary.is_empty());
+
+        let mut index =
+            SyngIndex::new_with_packed_syncmer_dictionary(params, &dictionary).unwrap();
+        index
+            .enable_online_sampled_positions(0, DEFAULT_POSITION_SAMPLE_SEED)
+            .unwrap();
+        for (name, seq) in sequences {
+            let stats = index
+                .add_sequence_with_existing_syncmers(name, seq)
+                .unwrap();
+            assert!(stats.indexed);
+            assert!(stats.syncmers > 0);
+        }
+        index.finalize_online_sampled_positions().unwrap();
+
+        let matches = index.matched_syncmers_in_sequence(&seq_a);
+        assert!(!matches.is_empty());
+
+        let intervals = index.query_region("seqA", 0, 500, 0).unwrap();
+        assert!(
+            intervals.iter().any(|interval| interval.genome == "seqB"),
+            "shared-prefix sequence should be discoverable through preloaded dictionary"
+        );
     }
 
     #[test]

--- a/src/syng_parallel.rs
+++ b/src/syng_parallel.rs
@@ -1,0 +1,197 @@
+//! Parallel construction helpers for syng indices.
+//!
+//! The first implemented stage builds a deterministic global syncmer
+//! dictionary in parallel. Existing serial GBWT path construction can then
+//! replay sequences through that frozen dictionary.
+
+use rayon::prelude::*;
+use std::io;
+
+use crate::syng::{packed_syncmer_word_len, PackedSyncmer, SyncmerParams};
+use crate::syng_ffi;
+
+fn base_code(base: u8) -> u8 {
+    match base {
+        b'a' | b'A' | 0 => 0,
+        b'c' | b'C' | 1 => 1,
+        b'g' | b'G' | 2 => 2,
+        b't' | b'T' | 3 => 3,
+        _ => 0,
+    }
+}
+
+fn complement_code(code: u8) -> u8 {
+    3 - code
+}
+
+fn forward_is_canonical(syncmer: &[u8]) -> bool {
+    if syncmer.is_empty() {
+        return true;
+    }
+    let mut left = 0usize;
+    let mut right = syncmer.len() - 1;
+    while left <= right {
+        let fwd = base_code(syncmer[left]);
+        let rev = complement_code(base_code(syncmer[right]));
+        if fwd != rev {
+            return fwd < rev;
+        }
+        if left == right {
+            break;
+        }
+        left += 1;
+        right -= 1;
+    }
+    true
+}
+
+/// Convert a sequence to syng's numeric DNA encoding.
+pub fn numeric_sequence(seq: &[u8]) -> Vec<u8> {
+    seq.iter().map(|&b| base_code(b)).collect()
+}
+
+/// Pack a full syncmer in the canonical orientation expected by KmerHash.
+pub fn pack_canonical_syncmer(syncmer: &[u8]) -> PackedSyncmer {
+    let word_len = (syncmer.len() + 31) / 32;
+    let mut bytes = vec![0u8; word_len * 8];
+    let use_forward = forward_is_canonical(syncmer);
+
+    for i in 0..syncmer.len() {
+        let code = if use_forward {
+            base_code(syncmer[i])
+        } else {
+            complement_code(base_code(syncmer[syncmer.len() - 1 - i]))
+        };
+        bytes[i / 4] |= code << (2 * (i % 4));
+    }
+
+    bytes
+        .chunks_exact(8)
+        .map(|chunk| {
+            let mut word = [0u8; 8];
+            word.copy_from_slice(chunk);
+            u64::from_le_bytes(word)
+        })
+        .collect()
+}
+
+/// Extract packed canonical full-syncmers from a sequence.
+pub fn extract_packed_syncmers(
+    params: SyncmerParams,
+    seq: &[u8],
+) -> io::Result<Vec<PackedSyncmer>> {
+    let syncmer_len = (params.w + params.k) as usize;
+    if seq.len() < syncmer_len {
+        return Ok(Vec::new());
+    }
+
+    let mut seq_buf = numeric_sequence(seq);
+    seq_buf.push(0);
+
+    let mut out = Vec::new();
+    unsafe {
+        let seqhash = syng_ffi::impg_seqhashCreateSafe(
+            params.k as i32,
+            params.w as i32,
+            params.seed as i32,
+        );
+        if seqhash.is_null() {
+            return Err(io::Error::other("seqhashCreate returned null"));
+        }
+
+        let sit = syng_ffi::syncmerIterator(
+            seqhash,
+            seq_buf.as_mut_ptr() as *mut i8,
+            seq.len() as i32,
+        );
+        if sit.is_null() {
+            syng_ffi::impg_seqhashDestroy(seqhash);
+            return Err(io::Error::other("syncmerIterator returned null"));
+        }
+
+        let mut pos: i32 = 0;
+        while syng_ffi::syncmerNext(
+            sit,
+            std::ptr::null_mut(),
+            &mut pos,
+            std::ptr::null_mut(),
+        ) {
+            let start = pos as usize;
+            if start + syncmer_len > seq.len() {
+                syng_ffi::impg_seqhashIteratorDestroy(sit);
+                syng_ffi::impg_seqhashDestroy(seqhash);
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "syncmer iterator returned out-of-range position {} for sequence length {}",
+                        start,
+                        seq.len()
+                    ),
+                ));
+            }
+            out.push(pack_canonical_syncmer(
+                &seq_buf[start..start + syncmer_len],
+            ));
+        }
+
+        syng_ffi::impg_seqhashIteratorDestroy(sit);
+        syng_ffi::impg_seqhashDestroy(seqhash);
+    }
+
+    Ok(out)
+}
+
+pub fn sort_dedup_packed_syncmers(mut syncmers: Vec<PackedSyncmer>) -> Vec<PackedSyncmer> {
+    syncmers.sort_unstable();
+    syncmers.dedup();
+    syncmers
+}
+
+/// Build a deterministic global packed-syncmer dictionary in parallel.
+pub fn build_packed_syncmer_dictionary(
+    params: SyncmerParams,
+    sequences: &[(String, Vec<u8>)],
+) -> io::Result<Vec<PackedSyncmer>> {
+    let expected_words = packed_syncmer_word_len(params);
+    let syncmers = sequences
+        .par_iter()
+        .map(|(_, seq)| extract_packed_syncmers(params, seq))
+        .try_reduce(Vec::new, |mut acc, mut part| {
+            acc.append(&mut part);
+            Ok(acc)
+        })?;
+
+    let dictionary = sort_dedup_packed_syncmers(syncmers);
+    if let Some((i, packed)) = dictionary
+        .iter()
+        .enumerate()
+        .find(|(_, packed)| packed.len() != expected_words)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "dictionary entry {} has {} words, expected {}",
+                i,
+                packed.len(),
+                expected_words
+            ),
+        ));
+    }
+    Ok(dictionary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_packing_is_orientation_invariant() {
+        let seq = b"ACGTACGTACGTA";
+        let rc = b"TACGTACGTACGT";
+        assert_eq!(
+            pack_canonical_syncmer(seq),
+            pack_canonical_syncmer(rc),
+            "forward and reverse-complement syncmers should share packed canonical form"
+        );
+    }
+}

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -264,6 +264,66 @@ fn test_syng_agc_roundtrip_query() {
 }
 
 #[test]
+fn test_syng_agc_parallel_dictionary_roundtrip_query() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_agc_parallel_dictionary");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let agc_path = dir.join("test.agc");
+    create_test_agc(agc_path.to_str().unwrap());
+
+    let out_prefix = dir.join("idx");
+    let out_prefix_str = out_prefix.to_str().unwrap();
+
+    let build_output = Command::new(&bin)
+        .args([
+            "syng",
+            "--agc",
+            agc_path.to_str().unwrap(),
+            "--parallel-dictionary",
+            "-o",
+            out_prefix_str,
+            "--position-sample-shift",
+            "0",
+        ])
+        .output()
+        .expect("Failed to run impg syng --agc --parallel-dictionary");
+    assert!(
+        build_output.status.success(),
+        "impg syng --agc --parallel-dictionary failed. stderr: {}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let index = impg::syng::SyngIndex::load(
+        out_prefix_str,
+        impg::syng::SyncmerParams::default(),
+    )
+    .expect("Failed to load AGC parallel-dictionary syng index");
+    let query_name = index
+        .name_map
+        .path_to_name
+        .iter()
+        .find(|n| n.contains("sampleA"))
+        .expect("sampleA contig should be in name map")
+        .clone();
+    let intervals = index
+        .query_region(&query_name, 0, 500, 0)
+        .expect("query_region failed");
+    assert!(
+        intervals.iter().any(|iv| iv.genome.contains("sampleB")),
+        "parallel dictionary build should preserve shared-backbone query behavior"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_syng_fasta_build_produces_non_empty_index() {
     // Same non-empty-GBWT assertion but via the FASTA input path, to catch
     // regressions in either build path symmetrically.
@@ -323,6 +383,67 @@ fn test_syng_fasta_build_produces_non_empty_index() {
     assert!(
         gbwt_size > 2000,
         ".1gbwt is only {} bytes from FASTA build",
+        gbwt_size
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_syng_fasta_parallel_dictionary_build_produces_non_empty_index() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_fasta_parallel_dictionary");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let fasta_path = dir.join("test.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        let backbone = numeric_to_ascii(&make_sequence_numeric(800, 42));
+        let tail_a = numeric_to_ascii(&make_sequence_numeric(400, 1));
+        let tail_b = numeric_to_ascii(&make_sequence_numeric(400, 2));
+
+        writeln!(f, ">sampleA#chr1").unwrap();
+        f.write_all(&backbone).unwrap();
+        f.write_all(&tail_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#chr1").unwrap();
+        f.write_all(&backbone).unwrap();
+        f.write_all(&tail_b).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let out_prefix = dir.join("idx");
+    let out = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "--parallel-dictionary",
+            "-o",
+            out_prefix.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to run impg syng -f --parallel-dictionary");
+    assert!(
+        out.status.success(),
+        "impg syng -f --parallel-dictionary failed. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let gbwt_size =
+        std::fs::metadata(format!("{}.1gbwt", out_prefix.to_str().unwrap()))
+            .unwrap()
+            .len();
+    assert!(
+        gbwt_size > 2000,
+        ".1gbwt is only {} bytes from parallel FASTA build",
         gbwt_size
     );
 


### PR DESCRIPTION
## Summary
- document the global-ID model for parallel syng construction
- add packed canonical syncmer dictionary extraction/deduplication
- add `impg syng --parallel-dictionary` for FASTA and AGC, replaying paths through a frozen KmerHash
- test frozen replay through unit coverage plus FASTA/AGC CLI smoke tests

## Tests
- `cargo check --release`
- `cargo test --release --lib syng -- --nocapture`
- `cargo test --release --test test_syng_integration -- --nocapture`
- `cargo test --release --test test_syng_integration test_syng_agc_parallel_dictionary_roundtrip_query -- --nocapture`