### PR TITLE
Add parallel syng GBWT reduce construction

### DIFF
--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -98,17 +98,24 @@ AGC inputs.
 
 ## Next Step: True GBWT Reduce
 
-A full parallel GBWT builder needs a new internal representation:
+The next implementation layer uses a new internal representation:
 
 ```text
 node_id -> ordered incoming/outgoing occurrence lists
 ```
 
-For a fixed global path partition order, shard-local occurrence lists for the
-same node can be concatenated in that partition order and converted to the same
-simple-node / rskip representation currently produced incrementally by
-`syngBWTpathAdd`.
+For a fixed global path order, every directed edge occurrence receives a
+deterministic rank within that edge. Each node can then be reduced
+independently:
 
-That reduce API should live below `SyngIndex`, ideally in C next to
-`syngbwt3.c`, because it needs to construct `NodeSide` / `Rskip` structures
-directly.
+- directory counts come from incoming edge ranks on that side;
+- BWT run lists are ordered by the opposite side's incoming edge ranks;
+- the run symbols are edge ids on the side being built.
+
+This is exposed as `impg syng --parallel-reduce`. Rust extracts ranked path
+occurrences and reduces each node independently; a C helper in `syngbwt3.c`
+installs the resulting edge directories and run lists directly into syng's
+`NodeSide` / `Rskip` representation. The implementation is currently in-memory:
+the next scaling step is to spill shard occurrence records and externally sort
+by `(node_id, side)` and `(directed_edge, occurrence_order)` for HPRC-scale
+construction without retaining all path occurrences at once.

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,6 +221,44 @@ fn read_syng_agc_record(
     Ok(ragc_numeric_to_ascii(&contig_data))
 }
 
+fn extract_syng_agc_sequence_paths(
+    agc_path: &str,
+    records: &[SyngAgcRecord],
+    params: impg::syng::SyncmerParams,
+    dictionary: &[impg::syng::PackedSyncmer],
+) -> io::Result<Vec<impg::syng_parallel::SequenceSyncmerPath>> {
+    records
+        .par_iter()
+        .map_init(
+            || {
+                let config = ragc_core::DecompressorConfig { verbosity: 0 };
+                ragc_core::Decompressor::open(agc_path, config).map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Failed to open AGC file '{}': {}", agc_path, e),
+                    )
+                })
+            },
+            |decompressor, record| {
+                let decompressor = match decompressor {
+                    Ok(decompressor) => decompressor,
+                    Err(e) => return Err(io::Error::new(e.kind(), e.to_string())),
+                };
+                let seq = read_syng_agc_record(decompressor, record)?;
+                Ok(impg::syng_parallel::SequenceSyncmerPath {
+                    name: record.name.clone(),
+                    sequence_len: seq.len() as u64,
+                    syncmers: impg::syng_parallel::extract_syncmer_path_with_dictionary(
+                        params,
+                        &seq,
+                        dictionary,
+                    )?,
+                })
+            },
+        )
+        .collect()
+}
+
 fn format_duration(duration: Duration) -> String {
     if duration.as_secs() >= 60 {
         let mins = duration.as_secs() / 60;
@@ -1880,6 +1918,11 @@ enum Args {
         #[arg(help_heading = "Construction")]
         #[clap(long, action)]
         parallel_dictionary: bool,
+
+        /// Build a deterministic global dictionary and reduce GBWT nodes from ranked path occurrences.
+        #[arg(help_heading = "Construction")]
+        #[clap(long, action)]
+        parallel_reduce: bool,
 
         // --- Syncmer parameters ---
         /// Inner k-mer length for syncmer extraction
@@ -3770,6 +3813,7 @@ fn run() -> io::Result<()> {
             position_sample_shift,
             position_sample_seed,
             parallel_dictionary,
+            parallel_reduce,
             common,
         } => {
             initialize_threads_and_log(&common);
@@ -3817,7 +3861,108 @@ fn run() -> io::Result<()> {
             let total_start = Instant::now();
 
             let mut index = if let Some(agc_path) = agc {
-                if parallel_dictionary {
+                if parallel_reduce {
+                    let input_start = Instant::now();
+                    info!(
+                        "Reading AGC sequence catalog for parallel GBWT reduce build: {} at +{}",
+                        agc_path,
+                        format_duration(total_start.elapsed())
+                    );
+                    let records = collect_syng_agc_records(&agc_path)?;
+                    let total_bp: u64 = records.iter().map(|record| record.length as u64).sum();
+                    info!(
+                        "Found {} AGC sequences ({} bp) for parallel reduce prepasses",
+                        records.len(),
+                        total_bp
+                    );
+
+                    let dictionary_start = Instant::now();
+                    let agc_path_for_threads = agc_path.clone();
+                    let packed_syncmers = records
+                        .par_iter()
+                        .map_init(
+                            move || {
+                                let config = ragc_core::DecompressorConfig { verbosity: 0 };
+                                ragc_core::Decompressor::open(&agc_path_for_threads, config)
+                                    .map_err(|e| {
+                                        io::Error::new(
+                                            io::ErrorKind::InvalidData,
+                                            format!(
+                                                "Failed to open AGC file '{}': {}",
+                                                agc_path_for_threads, e
+                                            ),
+                                        )
+                                    })
+                            },
+                            |decompressor, record| {
+                                let decompressor = match decompressor {
+                                    Ok(decompressor) => decompressor,
+                                    Err(e) => {
+                                        return Err(io::Error::new(e.kind(), e.to_string()));
+                                    }
+                                };
+                                let seq = read_syng_agc_record(decompressor, record)?;
+                                impg::syng_parallel::extract_packed_syncmers(params, &seq)
+                            },
+                        )
+                        .try_reduce(Vec::new, |mut acc, mut part| {
+                            acc.append(&mut part);
+                            Ok(acc)
+                        })?;
+                    let raw_syncmers = packed_syncmers.len();
+                    let dictionary =
+                        impg::syng_parallel::sort_dedup_packed_syncmers(packed_syncmers);
+                    info!(
+                        "Built packed syncmer dictionary in {}: {} raw syncmers, {} unique syncmer nodes at +{}",
+                        format_duration(dictionary_start.elapsed()),
+                        raw_syncmers,
+                        dictionary.len(),
+                        format_duration(total_start.elapsed())
+                    );
+
+                    let path_start = Instant::now();
+                    let sequence_paths =
+                        extract_syng_agc_sequence_paths(&agc_path, &records, params, &dictionary)?;
+                    let extracted_syncmers: usize = sequence_paths
+                        .iter()
+                        .map(|path| path.syncmers.len())
+                        .sum();
+                    info!(
+                        "Extracted {} sequence syncmer paths ({} syncmers) in {} at +{}",
+                        sequence_paths.len(),
+                        extracted_syncmers,
+                        format_duration(path_start.elapsed()),
+                        format_duration(total_start.elapsed())
+                    );
+
+                    let reduce_start = Instant::now();
+                    let (index, stats) =
+                        impg::syng_parallel::build_index_with_parallel_gbwt_reduce(
+                            params,
+                            dictionary,
+                            sequence_paths,
+                            position_sample_shift,
+                            position_sample_seed,
+                        )?;
+                    info!(
+                        "Reduced GBWT nodes in {}: {} sequences, {} indexed, {} GBWT paths, {} path occurrences, {} reduced nodes, {} dictionary nodes at +{}",
+                        format_duration(reduce_start.elapsed()),
+                        stats.sequences,
+                        stats.indexed_sequences,
+                        stats.gbwt_paths,
+                        stats.syncmer_occurrences,
+                        stats.reduced_nodes,
+                        stats.dictionary_nodes,
+                        format_duration(total_start.elapsed())
+                    );
+                    info!(
+                        "Built syng paths from {} sequences ({} bp) in {}",
+                        records.len(),
+                        total_bp,
+                        format_duration(input_start.elapsed())
+                    );
+                    index
+                } else if parallel_dictionary {
                     let input_start = Instant::now();
                     info!(
                         "Reading AGC sequence catalog for parallel dictionary build: {} at +{}",
@@ -4074,7 +4219,79 @@ fn run() -> io::Result<()> {
                 index
                 }
             } else if let Some(fasta_path) = fasta {
-                if parallel_dictionary {
+                if parallel_reduce {
+                    let input_start = Instant::now();
+                    info!(
+                        "Reading sequences from FASTA for parallel GBWT reduce build: {} at +{}",
+                        fasta_path,
+                        format_duration(total_start.elapsed())
+                    );
+                    let sequences = read_syng_fasta_sequences(&fasta_path)?;
+                    let total_bp: u64 =
+                        sequences.iter().map(|(_, seq)| seq.len() as u64).sum();
+                    info!(
+                        "Read {} FASTA sequences ({} bp) for parallel reduce prepasses",
+                        sequences.len(),
+                        total_bp
+                    );
+
+                    let dictionary_start = Instant::now();
+                    let dictionary =
+                        impg::syng_parallel::build_packed_syncmer_dictionary(params, &sequences)?;
+                    info!(
+                        "Built packed syncmer dictionary in {}: {} unique syncmer nodes at +{}",
+                        format_duration(dictionary_start.elapsed()),
+                        dictionary.len(),
+                        format_duration(total_start.elapsed())
+                    );
+
+                    let path_start = Instant::now();
+                    let sequence_paths =
+                        impg::syng_parallel::extract_sequence_syncmer_paths(
+                            params,
+                            &sequences,
+                            &dictionary,
+                        )?;
+                    let extracted_syncmers: usize = sequence_paths
+                        .iter()
+                        .map(|path| path.syncmers.len())
+                        .sum();
+                    info!(
+                        "Extracted {} sequence syncmer paths ({} syncmers) in {} at +{}",
+                        sequence_paths.len(),
+                        extracted_syncmers,
+                        format_duration(path_start.elapsed()),
+                        format_duration(total_start.elapsed())
+                    );
+
+                    let reduce_start = Instant::now();
+                    let (index, stats) =
+                        impg::syng_parallel::build_index_with_parallel_gbwt_reduce(
+                            params,
+                            dictionary,
+                            sequence_paths,
+                            position_sample_shift,
+                            position_sample_seed,
+                        )?;
+                    info!(
+                        "Reduced GBWT nodes in {}: {} sequences, {} indexed, {} GBWT paths, {} path occurrences, {} reduced nodes, {} dictionary nodes at +{}",
+                        format_duration(reduce_start.elapsed()),
+                        stats.sequences,
+                        stats.indexed_sequences,
+                        stats.gbwt_paths,
+                        stats.syncmer_occurrences,
+                        stats.reduced_nodes,
+                        stats.dictionary_nodes,
+                        format_duration(total_start.elapsed())
+                    );
+                    info!(
+                        "Built syng paths from {} sequences ({} bp) in {}",
+                        sequences.len(),
+                        total_bp,
+                        format_duration(input_start.elapsed())
+                    );
+                    index
+                } else if parallel_dictionary {
                     let input_start = Instant::now();
                     info!(
                         "Reading sequences from FASTA for parallel dictionary build: {} at +{}",

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -970,6 +970,32 @@ impl SyngIndex {
         Ok(())
     }
 
+    /// Create an index from a prebuilt GBWT and preloaded packed dictionary.
+    ///
+    /// The returned index owns `gbwt` and will destroy it on drop.
+    pub fn from_prebuilt_gbwt(
+        params: SyncmerParams,
+        packed_syncmers: &[PackedSyncmer],
+        gbwt: *mut syng_ffi::SyngBWT,
+        name_map: SyngNameMap,
+    ) -> io::Result<Self> {
+        if gbwt.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "prebuilt SyngBWT pointer is null",
+            ));
+        }
+        let mut index = Self::new_with_packed_syncmer_dictionary(params, packed_syncmers)?;
+        unsafe {
+            syng_ffi::syngBWTdestroy(index.gbwt);
+        }
+        index.gbwt = gbwt;
+        index.name_map = name_map;
+        index.sampled_positions = None;
+        index.sampled_position_builder = None;
+        Ok(index)
+    }
+
     /// True if a sampled path-position sidecar has been built or loaded.
     pub fn has_sampled_positions(&self) -> bool {
         self.sampled_positions.is_some()
@@ -1012,6 +1038,23 @@ impl SyngIndex {
         let (sampled_positions, stats) = builder.finish(&self.name_map.path_to_length)?;
         self.sampled_positions = Some(sampled_positions);
         Ok(Some(stats))
+    }
+
+    /// Build sampled positions from already-extracted forward syncmer paths.
+    pub fn set_sampled_positions_from_paths<'a>(
+        &mut self,
+        sample_shift: u32,
+        seed: u64,
+        paths: impl IntoIterator<Item = (usize, u64, &'a [(i64, i32)])>,
+    ) -> io::Result<SampledPositionBuildStats> {
+        let mut builder = SampledPositionBuilder::new(sample_shift, seed, 0, 0)?;
+        for (path_idx, path_len, syncmers) in paths {
+            builder.record_path(path_idx, path_len, syncmers);
+        }
+        let (sampled_positions, stats) = builder.finish(&self.name_map.path_to_length)?;
+        self.sampled_positions = Some(sampled_positions);
+        self.sampled_position_builder = None;
+        Ok(stats)
     }
 
     /// Build an index progressively from an iterator of (name, sequence) pairs.
@@ -2262,6 +2305,50 @@ mod tests {
             intervals.iter().any(|interval| interval.genome == "seqB"),
             "shared-prefix sequence should be discoverable through preloaded dictionary"
         );
+    }
+
+    #[test]
+    fn test_parallel_gbwt_reduce_supports_query() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let shared = make_test_sequence(900, 42);
+        let mut seq_a = shared.clone();
+        seq_a.extend_from_slice(&make_test_sequence(300, 1));
+        let mut seq_b = shared;
+        seq_b.extend_from_slice(&make_test_sequence(300, 2));
+        let sequences = vec![
+            ("seqA".to_string(), seq_a.clone()),
+            ("seqB".to_string(), seq_b),
+            ("seqC".to_string(), make_test_sequence(1200, 99)),
+        ];
+
+        let dictionary =
+            crate::syng_parallel::build_packed_syncmer_dictionary(params, &sequences).unwrap();
+        let sequence_paths =
+            crate::syng_parallel::extract_sequence_syncmer_paths(params, &sequences, &dictionary)
+                .unwrap();
+        let (index, stats) = crate::syng_parallel::build_index_with_parallel_gbwt_reduce(
+            params,
+            dictionary,
+            sequence_paths,
+            0,
+            DEFAULT_POSITION_SAMPLE_SEED,
+        )
+        .unwrap();
+
+        assert_eq!(stats.sequences, 3);
+        assert_eq!(stats.indexed_sequences, 3);
+        assert_eq!(stats.gbwt_paths, 6);
+        assert!(stats.reduced_nodes > 0);
+
+        let intervals = index.query_region("seqA", 0, 600, 0).unwrap();
+        assert!(
+            intervals.iter().any(|interval| interval.genome == "seqB"),
+            "parallel GBWT reduce should preserve shared-prefix query behavior"
+        );
+
+        let matches = index.matched_syncmers_in_sequence(&seq_a);
+        assert!(!matches.is_empty());
     }
 
     #[test]

--- a/src/syng_ffi.rs
+++ b/src/syng_ffi.rs
@@ -124,6 +124,14 @@ pub struct KmerHash {
     pub seq_pack: *mut SeqPack,
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ImpgSyngEdge {
+    pub sync: I32,
+    pub offset: U32,
+    pub count: U32,
+}
+
 /// Syncmer parameters (syncmerset.h: SyncmerParams).
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -191,6 +199,23 @@ extern "C" {
         path: *mut I64,
         offset: *mut I64,
     ) -> bool;
+
+    pub fn impg_syngBWTsetNode(
+        sb: *mut SyngBWT,
+        node_id: I32,
+        in_edges: *const ImpgSyngEdge,
+        n_in_edge: I32,
+        in_run_sym: *const I64,
+        in_run_len: *const I64,
+        n_in_run: I64,
+        out_edges: *const ImpgSyngEdge,
+        n_out_edge: I32,
+        out_run_sym: *const I64,
+        out_run_len: *const I64,
+        n_out_run: I64,
+    );
+    pub fn impg_syngBWTstartCountAdd(sb: *mut SyngBWT, start_node: I32, count: U32);
+    pub fn impg_syngBWTlocBuild(sb: *mut SyngBWT);
 
     // --- KmerHash (kmerhash.h) ---
 

--- a/src/syng_parallel.rs
+++ b/src/syng_parallel.rs
@@ -5,9 +5,13 @@
 //! replay sequences through that frozen dictionary.
 
 use rayon::prelude::*;
+use std::collections::BTreeMap;
 use std::io;
 
-use crate::syng::{packed_syncmer_word_len, PackedSyncmer, SyncmerParams};
+use crate::syng::{
+    packed_syncmer_word_len, GbwtPathStart, PackedSyncmer, SyngIndex, SyngNameMap,
+    SyncmerParams,
+};
 use crate::syng_ffi;
 
 fn base_code(base: u8) -> u8 {
@@ -51,7 +55,7 @@ pub fn numeric_sequence(seq: &[u8]) -> Vec<u8> {
 }
 
 /// Pack a full syncmer in the canonical orientation expected by KmerHash.
-pub fn pack_canonical_syncmer(syncmer: &[u8]) -> PackedSyncmer {
+pub fn pack_canonical_syncmer_with_orientation(syncmer: &[u8]) -> (PackedSyncmer, bool) {
     let word_len = (syncmer.len() + 31) / 32;
     let mut bytes = vec![0u8; word_len * 8];
     let use_forward = forward_is_canonical(syncmer);
@@ -65,14 +69,20 @@ pub fn pack_canonical_syncmer(syncmer: &[u8]) -> PackedSyncmer {
         bytes[i / 4] |= code << (2 * (i % 4));
     }
 
-    bytes
+    let packed = bytes
         .chunks_exact(8)
         .map(|chunk| {
             let mut word = [0u8; 8];
             word.copy_from_slice(chunk);
             u64::from_le_bytes(word)
         })
-        .collect()
+        .collect::<Vec<_>>();
+    (packed, use_forward)
+}
+
+/// Pack a full syncmer in the canonical orientation expected by KmerHash.
+pub fn pack_canonical_syncmer(syncmer: &[u8]) -> PackedSyncmer {
+    pack_canonical_syncmer_with_orientation(syncmer).0
 }
 
 /// Extract packed canonical full-syncmers from a sequence.
@@ -178,6 +188,610 @@ pub fn build_packed_syncmer_dictionary(
         ));
     }
     Ok(dictionary)
+}
+
+#[derive(Debug, Clone)]
+pub struct SequenceSyncmerPath {
+    pub name: String,
+    pub sequence_len: u64,
+    pub syncmers: Vec<(i32, u64)>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ParallelGbwtBuildStats {
+    pub sequences: usize,
+    pub indexed_sequences: usize,
+    pub gbwt_paths: usize,
+    pub syncmer_occurrences: usize,
+    pub reduced_nodes: usize,
+    pub dictionary_nodes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct EdgeKey {
+    sync: i32,
+    offset: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct DirectedEdge {
+    from: i32,
+    to: i32,
+    offset: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Side {
+    In,
+    Out,
+}
+
+#[derive(Debug, Clone)]
+struct ReducedGbwtPath {
+    source_path_idx: Option<usize>,
+    nodes: Vec<i32>,
+    positions: Vec<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct NodeOccurrence {
+    abs_node: u32,
+    path_order: usize,
+    node_idx: usize,
+    incoming_edge: DirectedEdge,
+    incoming_rank: u32,
+    incoming_side: Side,
+    incoming_key: EdgeKey,
+    sequence_side: Side,
+    value_key: EdgeKey,
+}
+
+#[derive(Debug, Clone)]
+struct SequenceItem {
+    position_key: EdgeKey,
+    position_rank: u32,
+    value_key: EdgeKey,
+}
+
+struct NodeReduced {
+    node_id: u32,
+    in_edges: Vec<syng_ffi::ImpgSyngEdge>,
+    in_run_sym: Vec<i64>,
+    in_run_len: Vec<i64>,
+    out_edges: Vec<syng_ffi::ImpgSyngEdge>,
+    out_run_sym: Vec<i64>,
+    out_run_len: Vec<i64>,
+}
+
+pub fn extract_syncmer_path_with_dictionary(
+    params: SyncmerParams,
+    seq: &[u8],
+    dictionary: &[PackedSyncmer],
+) -> io::Result<Vec<(i32, u64)>> {
+    let syncmer_len = (params.w + params.k) as usize;
+    if seq.len() < syncmer_len {
+        return Ok(Vec::new());
+    }
+
+    let mut seq_buf = numeric_sequence(seq);
+    seq_buf.push(0);
+
+    let mut out = Vec::new();
+    unsafe {
+        let seqhash = syng_ffi::impg_seqhashCreateSafe(
+            params.k as i32,
+            params.w as i32,
+            params.seed as i32,
+        );
+        if seqhash.is_null() {
+            return Err(io::Error::other("seqhashCreate returned null"));
+        }
+
+        let sit = syng_ffi::syncmerIterator(
+            seqhash,
+            seq_buf.as_mut_ptr() as *mut i8,
+            seq.len() as i32,
+        );
+        if sit.is_null() {
+            syng_ffi::impg_seqhashDestroy(seqhash);
+            return Err(io::Error::other("syncmerIterator returned null"));
+        }
+
+        let mut pos: i32 = 0;
+        while syng_ffi::syncmerNext(
+            sit,
+            std::ptr::null_mut(),
+            &mut pos,
+            std::ptr::null_mut(),
+        ) {
+            let start = pos as usize;
+            if start + syncmer_len > seq.len() {
+                syng_ffi::impg_seqhashIteratorDestroy(sit);
+                syng_ffi::impg_seqhashDestroy(seqhash);
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "syncmer iterator returned out-of-range position {} for sequence length {}",
+                        start,
+                        seq.len()
+                    ),
+                ));
+            }
+            let (packed, is_forward) =
+                pack_canonical_syncmer_with_orientation(&seq_buf[start..start + syncmer_len]);
+            let dict_idx = dictionary.binary_search(&packed).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("syncmer at position {} is absent from the packed dictionary", start),
+                )
+            })?;
+            let node_id = i32::try_from(dict_idx + 1).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "syncmer dictionary exceeds i32 node id range",
+                )
+            })?;
+            let signed_node = if is_forward { node_id } else { -node_id };
+            out.push((signed_node, start as u64));
+        }
+
+        syng_ffi::impg_seqhashIteratorDestroy(sit);
+        syng_ffi::impg_seqhashDestroy(seqhash);
+    }
+
+    Ok(out)
+}
+
+pub fn extract_sequence_syncmer_paths(
+    params: SyncmerParams,
+    sequences: &[(String, Vec<u8>)],
+    dictionary: &[PackedSyncmer],
+) -> io::Result<Vec<SequenceSyncmerPath>> {
+    sequences
+        .par_iter()
+        .map(|(name, seq)| {
+            Ok(SequenceSyncmerPath {
+                name: name.clone(),
+                sequence_len: seq.len() as u64,
+                syncmers: extract_syncmer_path_with_dictionary(params, seq, dictionary)?,
+            })
+        })
+        .collect()
+}
+
+pub fn build_index_with_parallel_gbwt_reduce(
+    params: SyncmerParams,
+    dictionary: Vec<PackedSyncmer>,
+    sequence_paths: Vec<SequenceSyncmerPath>,
+    position_sample_shift: u32,
+    position_sample_seed: u64,
+) -> io::Result<(SyngIndex, ParallelGbwtBuildStats)> {
+    let mut name_map = SyngNameMap::new();
+    let mut gbwt_paths = Vec::new();
+    let mut sampled_paths: Vec<Vec<(i64, i32)>> = Vec::with_capacity(sequence_paths.len());
+
+    for path in &sequence_paths {
+        let path_idx = name_map.add(path.name.clone(), path.sequence_len) as usize;
+        let sampled = path
+            .syncmers
+            .iter()
+            .map(|&(node, pos)| {
+                let pos_i32 = i32::try_from(pos).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("syncmer position {} exceeds i32 range", pos),
+                    )
+                })?;
+                Ok((node as i64, pos_i32))
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+        sampled_paths.push(sampled);
+
+        if path.syncmers.is_empty() {
+            let _ = path_idx;
+            continue;
+        }
+
+        let nodes: Vec<i32> = path.syncmers.iter().map(|&(node, _)| node).collect();
+        let positions: Vec<u64> = path.syncmers.iter().map(|&(_, pos)| pos).collect();
+        gbwt_paths.push(ReducedGbwtPath {
+            source_path_idx: Some(path_idx),
+            nodes: nodes.clone(),
+            positions: positions.clone(),
+        });
+
+        let rc_nodes: Vec<i32> = nodes.iter().rev().map(|node| -*node).collect();
+        let mut rc_positions = Vec::with_capacity(positions.len());
+        let mut rc_pos = 0u64;
+        rc_positions.push(rc_pos);
+        for i in (1..positions.len()).rev() {
+            rc_pos = rc_pos
+                .checked_add(positions[i] - positions[i - 1])
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "reverse path syncmer coordinate overflow",
+                    )
+                })?;
+            rc_positions.push(rc_pos);
+        }
+        gbwt_paths.push(ReducedGbwtPath {
+            source_path_idx: None,
+            nodes: rc_nodes,
+            positions: rc_positions,
+        });
+    }
+
+    let mut occurrences = collect_node_occurrences(&gbwt_paths)?;
+    assign_incoming_ranks(&mut occurrences)?;
+    install_path_starts(&gbwt_paths, &occurrences, &mut name_map)?;
+
+    let reduced_nodes = reduce_nodes(&occurrences)?;
+    let gbwt = unsafe {
+        syng_ffi::syngBWTcreate(
+            (params.w + params.k) as i32,
+            i64::try_from(dictionary.len() + 1).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "dictionary length exceeds i64 range")
+            })?,
+        )
+    };
+    if gbwt.is_null() {
+        return Err(io::Error::other("syngBWTcreate returned null"));
+    }
+
+    let start_counts = start_counts_by_node(&gbwt_paths);
+    unsafe {
+        for (start_node, count) in start_counts {
+            syng_ffi::impg_syngBWTstartCountAdd(gbwt, start_node, count);
+        }
+        for node in &reduced_nodes {
+            syng_ffi::impg_syngBWTsetNode(
+                gbwt,
+                node.node_id as i32,
+                node.in_edges.as_ptr(),
+                node.in_edges.len() as i32,
+                node.in_run_sym.as_ptr(),
+                node.in_run_len.as_ptr(),
+                node.in_run_sym.len() as i64,
+                node.out_edges.as_ptr(),
+                node.out_edges.len() as i32,
+                node.out_run_sym.as_ptr(),
+                node.out_run_len.as_ptr(),
+                node.out_run_sym.len() as i64,
+            );
+        }
+        syng_ffi::impg_syngBWTlocBuild(gbwt);
+    }
+
+    let mut index = SyngIndex::from_prebuilt_gbwt(params, &dictionary, gbwt, name_map)?;
+    index.set_sampled_positions_from_paths(
+        position_sample_shift,
+        position_sample_seed,
+        sampled_paths
+            .iter()
+            .enumerate()
+            .map(|(path_idx, syncmers)| {
+                (path_idx, sequence_paths[path_idx].sequence_len, syncmers.as_slice())
+            }),
+    )?;
+
+    let stats = ParallelGbwtBuildStats {
+        sequences: sequence_paths.len(),
+        indexed_sequences: sequence_paths
+            .iter()
+            .filter(|path| !path.syncmers.is_empty())
+            .count(),
+        gbwt_paths: gbwt_paths.len(),
+        syncmer_occurrences: occurrences.len(),
+        reduced_nodes: reduced_nodes.len(),
+        dictionary_nodes: dictionary.len(),
+    };
+    Ok((index, stats))
+}
+
+fn collect_node_occurrences(paths: &[ReducedGbwtPath]) -> io::Result<Vec<NodeOccurrence>> {
+    let mut occurrences = Vec::new();
+    for (path_order, path) in paths.iter().enumerate() {
+        for node_idx in 0..path.nodes.len() {
+            let current = path.nodes[node_idx];
+            let abs_node = current.unsigned_abs();
+            let (prev, in_offset) = if node_idx == 0 {
+                (0, 0)
+            } else {
+                let delta = path.positions[node_idx]
+                    .checked_sub(path.positions[node_idx - 1])
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "syncmer positions are not monotonic in GBWT path",
+                        )
+                    })?;
+                (path.nodes[node_idx - 1], checked_offset(delta)?)
+            };
+            let (next, out_offset) = if node_idx + 1 == path.nodes.len() {
+                (0, 0)
+            } else {
+                let delta = path.positions[node_idx + 1]
+                    .checked_sub(path.positions[node_idx])
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "syncmer positions are not monotonic in GBWT path",
+                        )
+                    })?;
+                (path.nodes[node_idx + 1], checked_offset(delta)?)
+            };
+
+            let (incoming_side, incoming_key, sequence_side, value_key) = if current >= 0 {
+                (
+                    Side::In,
+                    EdgeKey {
+                        sync: prev,
+                        offset: in_offset,
+                    },
+                    Side::Out,
+                    EdgeKey {
+                        sync: next,
+                        offset: out_offset,
+                    },
+                )
+            } else {
+                (
+                    Side::Out,
+                    EdgeKey {
+                        sync: -prev,
+                        offset: in_offset,
+                    },
+                    Side::In,
+                    EdgeKey {
+                        sync: -next,
+                        offset: out_offset,
+                    },
+                )
+            };
+
+            occurrences.push(NodeOccurrence {
+                abs_node,
+                path_order,
+                node_idx,
+                incoming_edge: DirectedEdge {
+                    from: prev,
+                    to: current,
+                    offset: in_offset,
+                },
+                incoming_rank: 0,
+                incoming_side,
+                incoming_key,
+                sequence_side,
+                value_key,
+            });
+        }
+    }
+    Ok(occurrences)
+}
+
+fn checked_offset(delta: u64) -> io::Result<u32> {
+    u32::try_from(delta).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("syncmer offset {} exceeds u32 range", delta),
+        )
+    })
+}
+
+fn assign_incoming_ranks(occurrences: &mut [NodeOccurrence]) -> io::Result<()> {
+    let mut order: Vec<(DirectedEdge, usize, usize, usize)> = occurrences
+        .iter()
+        .enumerate()
+        .map(|(idx, occ)| (occ.incoming_edge, occ.path_order, occ.node_idx, idx))
+        .collect();
+    order.sort_unstable();
+
+    let mut current_edge: Option<DirectedEdge> = None;
+    let mut rank = 0u32;
+    for (edge, _, _, idx) in order {
+        if current_edge != Some(edge) {
+            current_edge = Some(edge);
+            rank = 0;
+        }
+        occurrences[idx].incoming_rank = rank;
+        rank = rank.checked_add(1).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directed edge occurrence rank exceeds u32 range",
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn install_path_starts(
+    paths: &[ReducedGbwtPath],
+    occurrences: &[NodeOccurrence],
+    name_map: &mut SyngNameMap,
+) -> io::Result<()> {
+    for occ in occurrences.iter().filter(|occ| occ.node_idx == 0) {
+        if let Some(path_idx) = paths[occ.path_order].source_path_idx {
+            let path = &paths[occ.path_order];
+            name_map.set_path_start(
+                path_idx as u32,
+                GbwtPathStart {
+                    start_node: path.nodes[0],
+                    start_count: occ.incoming_rank,
+                    num_syncmers: path.nodes.len() as u32,
+                    first_syncmer_pos: path.positions[0],
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn start_counts_by_node(paths: &[ReducedGbwtPath]) -> Vec<(i32, u32)> {
+    let mut counts = BTreeMap::<i32, u32>::new();
+    for path in paths {
+        if let Some(&start) = path.nodes.first() {
+            *counts.entry(start).or_default() += 1;
+        }
+    }
+    counts.into_iter().collect()
+}
+
+fn reduce_nodes(occurrences: &[NodeOccurrence]) -> io::Result<Vec<NodeReduced>> {
+    let mut order: Vec<usize> = (0..occurrences.len()).collect();
+    order.sort_unstable_by_key(|&idx| occurrences[idx].abs_node);
+
+    let mut groups = Vec::new();
+    let mut start = 0usize;
+    while start < order.len() {
+        let node_id = occurrences[order[start]].abs_node;
+        let mut end = start + 1;
+        while end < order.len() && occurrences[order[end]].abs_node == node_id {
+            end += 1;
+        }
+        groups.push((node_id, start, end));
+        start = end;
+    }
+
+    groups
+        .par_iter()
+        .map(|&(node_id, start, end)| reduce_one_node(node_id, &order[start..end], occurrences))
+        .collect()
+}
+
+fn reduce_one_node(
+    node_id: u32,
+    indices: &[usize],
+    occurrences: &[NodeOccurrence],
+) -> io::Result<NodeReduced> {
+    let mut in_counts = BTreeMap::<EdgeKey, u32>::new();
+    let mut out_counts = BTreeMap::<EdgeKey, u32>::new();
+    let mut in_items = Vec::new();
+    let mut out_items = Vec::new();
+
+    for &idx in indices {
+        let occ = &occurrences[idx];
+        match occ.incoming_side {
+            Side::In => *in_counts.entry(occ.incoming_key).or_default() += 1,
+            Side::Out => *out_counts.entry(occ.incoming_key).or_default() += 1,
+        }
+
+        let item = SequenceItem {
+            position_key: occ.incoming_key,
+            position_rank: occ.incoming_rank,
+            value_key: occ.value_key,
+        };
+        match occ.sequence_side {
+            Side::In => in_items.push(item),
+            Side::Out => out_items.push(item),
+        }
+    }
+
+    let (in_edges, in_run_sym, in_run_len) =
+        build_side(&in_counts, &out_counts, &in_items)?;
+    let (out_edges, out_run_sym, out_run_len) =
+        build_side(&out_counts, &in_counts, &out_items)?;
+
+    Ok(NodeReduced {
+        node_id,
+        in_edges,
+        in_run_sym,
+        in_run_len,
+        out_edges,
+        out_run_sym,
+        out_run_len,
+    })
+}
+
+fn build_side(
+    side_counts: &BTreeMap<EdgeKey, u32>,
+    order_counts: &BTreeMap<EdgeKey, u32>,
+    items: &[SequenceItem],
+) -> io::Result<(Vec<syng_ffi::ImpgSyngEdge>, Vec<i64>, Vec<i64>)> {
+    let edges: Vec<syng_ffi::ImpgSyngEdge> = side_counts
+        .iter()
+        .map(|(&key, &count)| syng_ffi::ImpgSyngEdge {
+            sync: key.sync,
+            offset: key.offset,
+            count,
+        })
+        .collect();
+    if edges.is_empty() {
+        return Ok((edges, Vec::new(), Vec::new()));
+    }
+
+    let mut value_to_index = BTreeMap::new();
+    for (idx, &key) in side_counts.keys().enumerate() {
+        value_to_index.insert(key, idx as i64);
+    }
+
+    let mut order_prefix = BTreeMap::new();
+    let mut total_len = 0usize;
+    for (&key, &count) in order_counts {
+        order_prefix.insert(key, total_len);
+        total_len = total_len
+            .checked_add(count as usize)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "side length overflow"))?;
+    }
+
+    if total_len != items.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "side sequence length mismatch: order counts imply {}, got {} items",
+                total_len,
+                items.len()
+            ),
+        ));
+    }
+
+    let mut sequence = vec![None; total_len];
+    for item in items {
+        let prefix = *order_prefix.get(&item.position_key).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("missing order edge {:?}", item.position_key),
+            )
+        })?;
+        let pos = prefix + item.position_rank as usize;
+        let slot = sequence.get_mut(pos).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("side sequence position {} is out of range {}", pos, total_len),
+            )
+        })?;
+        if slot.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("duplicate side sequence position {}", pos),
+            ));
+        }
+        *slot = Some(item.value_key);
+    }
+
+    let mut run_sym = Vec::new();
+    let mut run_len = Vec::new();
+    let mut last_sym = None;
+    for value in sequence {
+        let value = value.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "unfilled side sequence position")
+        })?;
+        let sym = *value_to_index.get(&value).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("sequence edge {:?} is absent from side directory", value),
+            )
+        })?;
+        if last_sym == Some(sym) {
+            *run_len.last_mut().expect("run length exists") += 1;
+        } else {
+            run_sym.push(sym);
+            run_len.push(1);
+            last_sym = Some(sym);
+        }
+    }
+
+    Ok((edges, run_sym, run_len))
 }
 
 #[cfg(test)]

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -324,6 +324,66 @@ fn test_syng_agc_parallel_dictionary_roundtrip_query() {
 }
 
 #[test]
+fn test_syng_agc_parallel_reduce_roundtrip_query() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_agc_parallel_reduce");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let agc_path = dir.join("test.agc");
+    create_test_agc(agc_path.to_str().unwrap());
+
+    let out_prefix = dir.join("idx");
+    let out_prefix_str = out_prefix.to_str().unwrap();
+
+    let build_output = Command::new(&bin)
+        .args([
+            "syng",
+            "--agc",
+            agc_path.to_str().unwrap(),
+            "--parallel-reduce",
+            "-o",
+            out_prefix_str,
+            "--position-sample-shift",
+            "0",
+        ])
+        .output()
+        .expect("Failed to run impg syng --agc --parallel-reduce");
+    assert!(
+        build_output.status.success(),
+        "impg syng --agc --parallel-reduce failed. stderr: {}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let index = impg::syng::SyngIndex::load(
+        out_prefix_str,
+        impg::syng::SyncmerParams::default(),
+    )
+    .expect("Failed to load AGC parallel-reduce syng index");
+    let query_name = index
+        .name_map
+        .path_to_name
+        .iter()
+        .find(|n| n.contains("sampleA"))
+        .expect("sampleA contig should be in name map")
+        .clone();
+    let intervals = index
+        .query_region(&query_name, 0, 500, 0)
+        .expect("query_region failed");
+    assert!(
+        intervals.iter().any(|iv| iv.genome.contains("sampleB")),
+        "parallel reduce build should preserve shared-backbone query behavior"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_syng_fasta_build_produces_non_empty_index() {
     // Same non-empty-GBWT assertion but via the FASTA input path, to catch
     // regressions in either build path symmetrically.
@@ -444,6 +504,67 @@ fn test_syng_fasta_parallel_dictionary_build_produces_non_empty_index() {
     assert!(
         gbwt_size > 2000,
         ".1gbwt is only {} bytes from parallel FASTA build",
+        gbwt_size
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_syng_fasta_parallel_reduce_build_produces_non_empty_index() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_fasta_parallel_reduce");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let fasta_path = dir.join("test.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        let backbone = numeric_to_ascii(&make_sequence_numeric(800, 42));
+        let tail_a = numeric_to_ascii(&make_sequence_numeric(400, 1));
+        let tail_b = numeric_to_ascii(&make_sequence_numeric(400, 2));
+
+        writeln!(f, ">sampleA#chr1").unwrap();
+        f.write_all(&backbone).unwrap();
+        f.write_all(&tail_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#chr1").unwrap();
+        f.write_all(&backbone).unwrap();
+        f.write_all(&tail_b).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let out_prefix = dir.join("idx");
+    let out = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "--parallel-reduce",
+            "-o",
+            out_prefix.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to run impg syng -f --parallel-reduce");
+    assert!(
+        out.status.success(),
+        "impg syng -f --parallel-reduce failed. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let gbwt_size =
+        std::fs::metadata(format!("{}.1gbwt", out_prefix.to_str().unwrap()))
+            .unwrap()
+            .len();
+    assert!(
+        gbwt_size > 2000,
+        ".1gbwt is only {} bytes from parallel reduce FASTA build",
         gbwt_size
     );
 


### PR DESCRIPTION
## Summary
- add `impg syng --parallel-reduce` for FASTA and AGC builds
- extract syncmer paths against the global packed dictionary in parallel
- assign deterministic directed-edge occurrence ranks and reduce GBWT nodes from per-node edge/run arrays
- use new syng C hooks for direct NodeSide/Rskip installation
- build sampled positions from extracted forward paths without serial path replay

## Related
- pangenome/syng#1 merged the direct GBWT builder hooks used by this submodule bump

## Tests
- `cargo check --release`
- `cargo test --release --lib syng -- --nocapture`
- `cargo test --release --test test_syng_integration -- --nocapture`
- `cargo test --release test_parallel_gbwt_reduce_supports_query -- --nocapture`
- `cargo test --release --test test_syng_integration test_syng_agc_parallel_reduce_roundtrip_query -- --nocapture`
- `cargo test --release --test test_syng_integration test_syng_fasta_parallel_reduce_build_produces_non_empty_index -- --nocapture`