### PR TITLE
Fix smooth-pass silent path-range loss in pggb engine

### DIFF
--- a/src/smooth.rs
+++ b/src/smooth.rs
@@ -179,45 +179,6 @@ pub fn smooth_gfa(gfa_content: &str, config: &SmoothConfig) -> io::Result<String
     Ok(current)
 }
 
-/// DIAGNOSTIC: for each path in a GFA string, walk its P-line steps,
-/// look up node lengths, log step_count + bp_sum. Used to pin which
-/// stage (unchop/sort) drops bp.
-fn log_path_bp(stage: &str, gfa: &str) {
-    let mut node_lens: FxHashMap<u64, usize> = FxHashMap::default();
-    for line in gfa.lines() {
-        if !line.starts_with("S\t") {
-            continue;
-        }
-        let mut it = line.split('\t');
-        it.next(); // 'S'
-        let id_str = match it.next() { Some(s) => s, None => continue };
-        let seq = match it.next() { Some(s) => s, None => continue };
-        if let Ok(id) = id_str.parse::<u64>() {
-            node_lens.insert(id, seq.len());
-        }
-    }
-    for line in gfa.lines() {
-        if !line.starts_with("P\t") {
-            continue;
-        }
-        let mut it = line.split('\t');
-        it.next(); // 'P'
-        let name = match it.next() { Some(s) => s, None => continue };
-        let steps_str = match it.next() { Some(s) => s, None => continue };
-        let mut step_count = 0usize;
-        let mut bp_sum = 0usize;
-        for step in steps_str.split(',') {
-            if step.is_empty() { continue; }
-            let id_part = &step[..step.len().saturating_sub(1)];
-            if let Ok(id) = id_part.parse::<u64>() {
-                step_count += 1;
-                bp_sum += *node_lens.get(&id).unwrap_or(&0);
-            }
-        }
-        log::info!("[{}] {} steps={} bp={}", stage, name, step_count, bp_sum);
-    }
-}
-
 /// Run a single smoothing pass on a (not yet sorted) GFA string.
 ///
 /// `pre_sorted` — skip the unchop+sort step (true only for the first pass when the
@@ -235,20 +196,7 @@ fn smooth_gfa_pass(
     let sorted_gfa = if pre_sorted {
         gfa_content.to_string()
     } else {
-        // DIAGNOSTIC: trace bp before/after unchop/sort
-        let do_trace = std::env::var("IMPG_SMOOTH_TRACE").is_ok();
-        if do_trace {
-            log_path_bp("STAGE-IN ", gfa_content);
-        }
-        let unchopped = unchop_gfa(gfa_content)?;
-        if do_trace {
-            log_path_bp("UNCHOPPED", &unchopped);
-        }
-        let sorted = sort_gfa(&unchopped, config.num_threads)?;
-        if do_trace {
-            log_path_bp("SORTED   ", &sorted);
-        }
-        sorted
+        sort_gfa(&unchop_gfa(gfa_content)?, config.num_threads)?
     };
 
     // Step 2: Parse sorted GFA
@@ -259,14 +207,6 @@ fn smooth_gfa_pass(
         "[smooth] Parsed sorted GFA: {} nodes, {} paths",
         num_nodes_before_chop, num_paths
     );
-
-    // DIAGNOSTIC: per-path bp at parse-time (post unchop+sort, pre-chop)
-    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-        for path in &graph.paths {
-            let bp: usize = path.steps.iter().map(|&(n, _)| graph.nodes[n].len()).sum();
-            log::info!("[TRACE-PARSE] {} steps={} bp={}", path.name, path.steps.len(), bp);
-        }
-    }
 
     if graph.nodes.is_empty() || graph.paths.is_empty() {
         return Ok(gfa_content.to_string());
@@ -281,30 +221,11 @@ fn smooth_gfa_pass(
         config.max_node_length
     );
 
-    // DIAGNOSTIC: per-path bp post-chop (chop_graph splits nodes; bp should be preserved)
-    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-        for path in &graph.paths {
-            let bp: usize = path.steps.iter().map(|&(n, _)| graph.nodes[n].len()).sum();
-            log::info!("[TRACE-CHOP] {} steps={} bp={}", path.name, path.steps.len(), bp);
-        }
-    }
-
     // Step 4: Build inverse index (node → path steps)
     let node_step_index = build_node_step_index(&graph);
 
     // Step 5: Compute cumulative path positions
     let path_positions = compute_path_positions(&graph);
-
-    // DIAGNOSTIC: per-path path_positions[last] (should equal path's full bp)
-    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-        for (path_idx, path) in graph.paths.iter().enumerate() {
-            let n = path.steps.len();
-            log::info!(
-                "[TRACE-POS] {} steps={} positions[N]={}",
-                path.name, n, path_positions[path_idx][n]
-            );
-        }
-    }
 
     // Step 6: Block decomposition
     let mut blocks = smoothable_blocks(
@@ -322,41 +243,6 @@ fn smooth_gfa_pass(
         blocks.len(),
         blocks.iter().map(|b| b.path_ranges.len()).sum::<usize>()
     );
-
-    // DIAGNOSTIC: which path-steps survived block decomposition?
-    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-        let mut in_blocks: Vec<BitVec> = graph
-            .paths
-            .iter()
-            .map(|p| bitvec![0; p.steps.len()])
-            .collect();
-        for block in blocks.iter() {
-            for range in &block.path_ranges {
-                for step_idx in range.begin_step..range.end_step {
-                    in_blocks[range.path_idx].set(step_idx, true);
-                }
-            }
-        }
-        for (path_idx, path) in graph.paths.iter().enumerate() {
-            let n_steps = path.steps.len();
-            let n_covered = in_blocks[path_idx].count_ones();
-            let n_missing = n_steps - n_covered;
-            // Compute bp lost (sum node_len for missing steps)
-            let mut bp_missing = 0usize;
-            for step_idx in 0..n_steps {
-                if !in_blocks[path_idx][step_idx] {
-                    let (node_idx, _) = path.steps[step_idx];
-                    bp_missing += graph.nodes[node_idx].len();
-                }
-            }
-            if n_missing > 0 {
-                info!(
-                    "[TRACE-BLOCKS] {} → {} of {} steps NOT in any block (missing {} bp)",
-                    path.name, n_missing, n_steps, bp_missing
-                );
-            }
-        }
-    }
 
     // Step 8: Per-block SPOA smoothing (parallelized).
     //
@@ -392,88 +278,21 @@ fn smooth_gfa_pass(
                         true
                     }
                 };
-                let mode;
-                let out: Option<String> = if !needs_passthrough {
+                if !needs_passthrough {
                     n_smoothed.fetch_add(1, Ordering::Relaxed);
-                    mode = "smooth";
-                    smooth_result.ok()
-                } else {
-                    mode = "passthrough";
-                    match passthrough_block_gfa(block, &graph, &path_positions) {
-                        Ok(s) if !s.is_empty() => {
-                            n_passthrough.fetch_add(1, Ordering::Relaxed);
-                            Some(s)
-                        }
-                        Ok(_) => None,
-                        Err(e) => {
-                            log::warn!("[smooth] Block {} passthrough failed: {}", i, e);
-                            None
-                        }
+                    return smooth_result.ok();
+                }
+                match passthrough_block_gfa(block, &graph, &path_positions) {
+                    Ok(s) if !s.is_empty() => {
+                        n_passthrough.fetch_add(1, Ordering::Relaxed);
+                        Some(s)
                     }
-                };
-                // DIAGNOSTIC: per-block bp accounting.
-                // Compare input range bp (length field, sum of step node lengths in
-                // the source graph) against the *actual walked bp* in the output
-                // sub-GFA (sum of S-line lengths along each P-line's step list).
-                // Catches mismatches between P-line names and their content.
-                if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-                    let input_bp: usize = block.path_ranges.iter().map(|r| r.length).sum();
-                    let n_input_ranges = block.path_ranges.len();
-                    let (n_output_p, name_bp, walked_bp) = match &out {
-                        Some(g) => {
-                            // Build node-length map from S-lines
-                            let mut nl: FxHashMap<u64, usize> = FxHashMap::default();
-                            for line in g.lines() {
-                                if !line.starts_with("S\t") { continue; }
-                                let mut it = line.split('\t');
-                                it.next();
-                                if let (Some(id_s), Some(seq)) = (it.next(), it.next()) {
-                                    if let Ok(id) = id_s.parse::<u64>() {
-                                        nl.insert(id, seq.len());
-                                    }
-                                }
-                            }
-                            let mut p_count = 0usize;
-                            let mut name_sum = 0usize;
-                            let mut walked_sum = 0usize;
-                            for line in g.lines() {
-                                if !line.starts_with("P\t") { continue; }
-                                p_count += 1;
-                                let mut it = line.split('\t');
-                                it.next();
-                                let name = it.next().unwrap_or("");
-                                let steps = it.next().unwrap_or("");
-                                if let Some(lc) = name.rfind(':') {
-                                    let rs = &name[lc+1..];
-                                    if let Some((s, e)) = rs.split_once('-') {
-                                        if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
-                                            name_sum += e.saturating_sub(s);
-                                        }
-                                    }
-                                }
-                                for st in steps.split(',') {
-                                    if st.is_empty() { continue; }
-                                    let id_part = &st[..st.len().saturating_sub(1)];
-                                    if let Ok(id) = id_part.parse::<u64>() {
-                                        walked_sum += *nl.get(&id).unwrap_or(&0);
-                                    }
-                                }
-                            }
-                            (p_count, name_sum, walked_sum)
-                        }
-                        None => (0, 0, 0),
-                    };
-                    let name_delta = input_bp as i64 - name_bp as i64;
-                    let walked_delta = input_bp as i64 - walked_bp as i64;
-                    if walked_delta != 0 || name_delta != 0 || n_output_p != n_input_ranges {
-                        log::info!(
-                            "[TRACE-BLK#{}] mode={} ranges_in={} P_out={} bp_in={} name_bp={} walked_bp={} name_delta={} walked_delta={}",
-                            i, mode, n_input_ranges, n_output_p,
-                            input_bp, name_bp, walked_bp, name_delta, walked_delta,
-                        );
+                    Ok(_) => None,
+                    Err(e) => {
+                        log::warn!("[smooth] Block {} passthrough failed: {}", i, e);
+                        None
                     }
                 }
-                out
             })
             .collect()
     });
@@ -484,43 +303,6 @@ fn smooth_gfa_pass(
         n_passthrough.load(Ordering::Relaxed),
     );
 
-    // DIAGNOSTIC: pre-lace per-path bp coverage from emitted block sub-GFAs
-    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-        let mut pre_lace_cov: FxHashMap<String, (usize, usize, usize)> = FxHashMap::default();
-        // key -> (frag_count, total_bp_covered, max_end)
-        let mut pre_lace_p_count: usize = 0;
-        for gfa in &block_gfas {
-            for line in gfa.lines() {
-                if !line.starts_with("P\t") {
-                    continue;
-                }
-                pre_lace_p_count += 1;
-                let name = line.split('\t').nth(1).unwrap_or("");
-                if let Some(last_colon) = name.rfind(':') {
-                    let (key, range_str) = name.split_at(last_colon);
-                    let range_str = &range_str[1..];
-                    if let Some((s, e)) = range_str.split_once('-') {
-                        if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
-                            let entry = pre_lace_cov.entry(key.to_string()).or_insert((0, 0, 0));
-                            entry.0 += 1;
-                            entry.1 += e.saturating_sub(s);
-                            if e > entry.2 {
-                                entry.2 = e;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        let mut keys: Vec<&String> = pre_lace_cov.keys().collect();
-        keys.sort();
-        info!("[TRACE] pre-lace: {} block-GFA P-lines across {} distinct path keys", pre_lace_p_count, pre_lace_cov.len());
-        for key in keys.iter() {
-            let v = pre_lace_cov[*key];
-            info!("[TRACE-PRE]   {} → {} frags, {} bp covered, max_end {}", key, v.0, v.1, v.2);
-        }
-    }
-
     if block_gfas.is_empty() {
         return Ok(String::from("H\tVN:Z:1.0\n"));
     }
@@ -529,41 +311,6 @@ fn smooth_gfa_pass(
     // Per-block gfaffix already normalized each block; the caller's normalize_and_sort
     // (gfaffix + sort) handles any remaining redundancies introduced at lacing boundaries.
     let laced = crate::commands::lace::lace_subgraphs(&block_gfas, config.temp_dir.as_deref())?;
-
-    // DIAGNOSTIC: post-lace per-path bp coverage
-    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
-        let mut post_lace_cov: FxHashMap<String, (usize, usize, usize)> = FxHashMap::default();
-        let mut post_lace_p_count: usize = 0;
-        for line in laced.lines() {
-            if !line.starts_with("P\t") {
-                continue;
-            }
-            post_lace_p_count += 1;
-            let name = line.split('\t').nth(1).unwrap_or("");
-            if let Some(last_colon) = name.rfind(':') {
-                let (key, range_str) = name.split_at(last_colon);
-                let range_str = &range_str[1..];
-                if let Some((s, e)) = range_str.split_once('-') {
-                    if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
-                        let entry = post_lace_cov.entry(key.to_string()).or_insert((0, 0, 0));
-                        entry.0 += 1;
-                        entry.1 += e.saturating_sub(s);
-                        if e > entry.2 {
-                            entry.2 = e;
-                        }
-                    }
-                }
-            }
-        }
-        let mut keys: Vec<&String> = post_lace_cov.keys().collect();
-        keys.sort();
-        info!("[TRACE] post-lace: {} P-lines across {} distinct path keys", post_lace_p_count, post_lace_cov.len());
-        for key in keys.iter() {
-            let v = post_lace_cov[*key];
-            info!("[TRACE-POST]  {} → {} frags, {} bp covered, max_end {}", key, v.0, v.1, v.2);
-        }
-    }
-
     info!("[smooth] Lacing complete");
 
     Ok(laced)

--- a/src/smooth.rs
+++ b/src/smooth.rs
@@ -179,6 +179,45 @@ pub fn smooth_gfa(gfa_content: &str, config: &SmoothConfig) -> io::Result<String
     Ok(current)
 }
 
+/// DIAGNOSTIC: for each path in a GFA string, walk its P-line steps,
+/// look up node lengths, log step_count + bp_sum. Used to pin which
+/// stage (unchop/sort) drops bp.
+fn log_path_bp(stage: &str, gfa: &str) {
+    let mut node_lens: FxHashMap<u64, usize> = FxHashMap::default();
+    for line in gfa.lines() {
+        if !line.starts_with("S\t") {
+            continue;
+        }
+        let mut it = line.split('\t');
+        it.next(); // 'S'
+        let id_str = match it.next() { Some(s) => s, None => continue };
+        let seq = match it.next() { Some(s) => s, None => continue };
+        if let Ok(id) = id_str.parse::<u64>() {
+            node_lens.insert(id, seq.len());
+        }
+    }
+    for line in gfa.lines() {
+        if !line.starts_with("P\t") {
+            continue;
+        }
+        let mut it = line.split('\t');
+        it.next(); // 'P'
+        let name = match it.next() { Some(s) => s, None => continue };
+        let steps_str = match it.next() { Some(s) => s, None => continue };
+        let mut step_count = 0usize;
+        let mut bp_sum = 0usize;
+        for step in steps_str.split(',') {
+            if step.is_empty() { continue; }
+            let id_part = &step[..step.len().saturating_sub(1)];
+            if let Ok(id) = id_part.parse::<u64>() {
+                step_count += 1;
+                bp_sum += *node_lens.get(&id).unwrap_or(&0);
+            }
+        }
+        log::info!("[{}] {} steps={} bp={}", stage, name, step_count, bp_sum);
+    }
+}
+
 /// Run a single smoothing pass on a (not yet sorted) GFA string.
 ///
 /// `pre_sorted` — skip the unchop+sort step (true only for the first pass when the
@@ -196,7 +235,20 @@ fn smooth_gfa_pass(
     let sorted_gfa = if pre_sorted {
         gfa_content.to_string()
     } else {
-        sort_gfa(&unchop_gfa(gfa_content)?, config.num_threads)?
+        // DIAGNOSTIC: trace bp before/after unchop/sort
+        let do_trace = std::env::var("IMPG_SMOOTH_TRACE").is_ok();
+        if do_trace {
+            log_path_bp("STAGE-IN ", gfa_content);
+        }
+        let unchopped = unchop_gfa(gfa_content)?;
+        if do_trace {
+            log_path_bp("UNCHOPPED", &unchopped);
+        }
+        let sorted = sort_gfa(&unchopped, config.num_threads)?;
+        if do_trace {
+            log_path_bp("SORTED   ", &sorted);
+        }
+        sorted
     };
 
     // Step 2: Parse sorted GFA
@@ -207,6 +259,14 @@ fn smooth_gfa_pass(
         "[smooth] Parsed sorted GFA: {} nodes, {} paths",
         num_nodes_before_chop, num_paths
     );
+
+    // DIAGNOSTIC: per-path bp at parse-time (post unchop+sort, pre-chop)
+    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+        for path in &graph.paths {
+            let bp: usize = path.steps.iter().map(|&(n, _)| graph.nodes[n].len()).sum();
+            log::info!("[TRACE-PARSE] {} steps={} bp={}", path.name, path.steps.len(), bp);
+        }
+    }
 
     if graph.nodes.is_empty() || graph.paths.is_empty() {
         return Ok(gfa_content.to_string());
@@ -221,11 +281,30 @@ fn smooth_gfa_pass(
         config.max_node_length
     );
 
+    // DIAGNOSTIC: per-path bp post-chop (chop_graph splits nodes; bp should be preserved)
+    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+        for path in &graph.paths {
+            let bp: usize = path.steps.iter().map(|&(n, _)| graph.nodes[n].len()).sum();
+            log::info!("[TRACE-CHOP] {} steps={} bp={}", path.name, path.steps.len(), bp);
+        }
+    }
+
     // Step 4: Build inverse index (node → path steps)
     let node_step_index = build_node_step_index(&graph);
 
     // Step 5: Compute cumulative path positions
     let path_positions = compute_path_positions(&graph);
+
+    // DIAGNOSTIC: per-path path_positions[last] (should equal path's full bp)
+    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+        for (path_idx, path) in graph.paths.iter().enumerate() {
+            let n = path.steps.len();
+            log::info!(
+                "[TRACE-POS] {} steps={} positions[N]={}",
+                path.name, n, path_positions[path_idx][n]
+            );
+        }
+    }
 
     // Step 6: Block decomposition
     let mut blocks = smoothable_blocks(
@@ -332,36 +411,65 @@ fn smooth_gfa_pass(
                         }
                     }
                 };
-                // DIAGNOSTIC: per-block bp accounting
+                // DIAGNOSTIC: per-block bp accounting.
+                // Compare input range bp (length field, sum of step node lengths in
+                // the source graph) against the *actual walked bp* in the output
+                // sub-GFA (sum of S-line lengths along each P-line's step list).
+                // Catches mismatches between P-line names and their content.
                 if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
                     let input_bp: usize = block.path_ranges.iter().map(|r| r.length).sum();
                     let n_input_ranges = block.path_ranges.len();
-                    let (n_output_p, output_bp) = match &out {
+                    let (n_output_p, name_bp, walked_bp) = match &out {
                         Some(g) => {
+                            // Build node-length map from S-lines
+                            let mut nl: FxHashMap<u64, usize> = FxHashMap::default();
+                            for line in g.lines() {
+                                if !line.starts_with("S\t") { continue; }
+                                let mut it = line.split('\t');
+                                it.next();
+                                if let (Some(id_s), Some(seq)) = (it.next(), it.next()) {
+                                    if let Ok(id) = id_s.parse::<u64>() {
+                                        nl.insert(id, seq.len());
+                                    }
+                                }
+                            }
                             let mut p_count = 0usize;
-                            let mut bp_sum = 0usize;
+                            let mut name_sum = 0usize;
+                            let mut walked_sum = 0usize;
                             for line in g.lines() {
                                 if !line.starts_with("P\t") { continue; }
                                 p_count += 1;
-                                let name = line.split('\t').nth(1).unwrap_or("");
+                                let mut it = line.split('\t');
+                                it.next();
+                                let name = it.next().unwrap_or("");
+                                let steps = it.next().unwrap_or("");
                                 if let Some(lc) = name.rfind(':') {
                                     let rs = &name[lc+1..];
                                     if let Some((s, e)) = rs.split_once('-') {
                                         if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
-                                            bp_sum += e.saturating_sub(s);
+                                            name_sum += e.saturating_sub(s);
                                         }
                                     }
                                 }
+                                for st in steps.split(',') {
+                                    if st.is_empty() { continue; }
+                                    let id_part = &st[..st.len().saturating_sub(1)];
+                                    if let Ok(id) = id_part.parse::<u64>() {
+                                        walked_sum += *nl.get(&id).unwrap_or(&0);
+                                    }
+                                }
                             }
-                            (p_count, bp_sum)
+                            (p_count, name_sum, walked_sum)
                         }
-                        None => (0, 0),
+                        None => (0, 0, 0),
                     };
-                    if output_bp + 100 < input_bp || n_output_p != n_input_ranges {
+                    let name_delta = input_bp as i64 - name_bp as i64;
+                    let walked_delta = input_bp as i64 - walked_bp as i64;
+                    if walked_delta != 0 || name_delta != 0 || n_output_p != n_input_ranges {
                         log::info!(
-                            "[TRACE-BLK#{}] mode={} ranges_in={} P_out={} bp_in={} bp_out={} delta={}",
-                            i, mode, n_input_ranges, n_output_p, input_bp, output_bp,
-                            input_bp as i64 - output_bp as i64,
+                            "[TRACE-BLK#{}] mode={} ranges_in={} P_out={} bp_in={} name_bp={} walked_bp={} name_delta={} walked_delta={}",
+                            i, mode, n_input_ranges, n_output_p,
+                            input_bp, name_bp, walked_bp, name_delta, walked_delta,
                         );
                     }
                 }
@@ -1372,6 +1480,31 @@ fn smooth_block(
     // contract is "every input range survives somewhere". Route the whole
     // block through passthrough rather than emit partial smoothed output.
     if n_empty_core > 0 {
+        return Ok(String::new());
+    }
+
+    // Stronger check: `find_core_column_range`'s MAX-of-left-pad-end /
+    // MIN-of-right-pad-start can collapse the core to a tiny intersection
+    // when sequences have very different padding/length ratios — even when
+    // no single core is empty. SPOA then emits P-lines whose name claims
+    // the full input bp range (set above from path_positions) but whose
+    // step walk covers only the tiny core. The lacer trusts the name, the
+    // next pass parses the GFA and sees a shorter path: observed on C4
+    // `impg graph`, block #160 named 60,802 bp but walked 1,962 bp (97%
+    // silent shrinkage). The contract — name's bp range == walked content
+    // bp — must hold. If the sum of trimmed core bp is far less than the
+    // sum of input range bp, route the block through passthrough.
+    let total_core_bp: usize = core_sequences.iter().map(|s| s.len()).sum();
+    let total_input_bp: usize = entries
+        .iter()
+        .take(nseqs)
+        .map(|e| e.sequence.len() - e.left_pad - e.right_pad)
+        .sum();
+    // Strict equality. Any bp loss from MSA-trim ends up as a P-line
+    // whose name claims input bp coords but whose step walk is shorter.
+    // The lacer trusts the name and so does the next pass — the bp
+    // shortfall becomes a real coordinate error in the output graph.
+    if total_core_bp != total_input_bp {
         return Ok(String::new());
     }
 

--- a/src/smooth.rs
+++ b/src/smooth.rs
@@ -244,30 +244,174 @@ fn smooth_gfa_pass(
         blocks.iter().map(|b| b.path_ranges.len()).sum::<usize>()
     );
 
-    // Step 8: Per-block SPOA smoothing (parallelized)
+    // DIAGNOSTIC: which path-steps survived block decomposition?
+    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+        let mut in_blocks: Vec<BitVec> = graph
+            .paths
+            .iter()
+            .map(|p| bitvec![0; p.steps.len()])
+            .collect();
+        for block in blocks.iter() {
+            for range in &block.path_ranges {
+                for step_idx in range.begin_step..range.end_step {
+                    in_blocks[range.path_idx].set(step_idx, true);
+                }
+            }
+        }
+        for (path_idx, path) in graph.paths.iter().enumerate() {
+            let n_steps = path.steps.len();
+            let n_covered = in_blocks[path_idx].count_ones();
+            let n_missing = n_steps - n_covered;
+            // Compute bp lost (sum node_len for missing steps)
+            let mut bp_missing = 0usize;
+            for step_idx in 0..n_steps {
+                if !in_blocks[path_idx][step_idx] {
+                    let (node_idx, _) = path.steps[step_idx];
+                    bp_missing += graph.nodes[node_idx].len();
+                }
+            }
+            if n_missing > 0 {
+                info!(
+                    "[TRACE-BLOCKS] {} → {} of {} steps NOT in any block (missing {} bp)",
+                    path.name, n_missing, n_steps, bp_missing
+                );
+            }
+        }
+    }
+
+    // Step 8: Per-block SPOA smoothing (parallelized).
+    //
+    // When SPOA produces nothing usable (degenerate padding trim, SPOA error,
+    // empty entries), the block's path-steps are already marked seen by
+    // `finalize_block`. Dropping the block would leave a hole in path-bp
+    // coverage and the lacer (which only joins ranges where `prev.end ==
+    // next.start`) would emit two adjacent path-name fragments instead of one
+    // contiguous path. On the C4 dataset (90 seqs) this fragmented the post-
+    // pass-1 graph from 90 paths to 732. Solution: emit the un-smoothed sub-
+    // graph as that block's output. The seam stays bp-contiguous, lacing
+    // re-joins it, and the final gfaffix pass collapses any block-boundary
+    // redundancy.
     use rayon::prelude::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(config.num_threads)
         .build()
         .map_err(|e| io::Error::other(format!("failed to build thread pool: {}", e)))?;
+    let n_smoothed = AtomicUsize::new(0);
+    let n_passthrough = AtomicUsize::new(0);
     let block_gfas: Vec<String> = pool.install(|| {
         blocks
             .par_iter()
             .enumerate()
-            .filter_map(
-                |(i, block)| match smooth_block(block, &graph, config, &path_positions) {
-                    Ok(gfa) if !gfa.is_empty() => Some(gfa),
-                    Ok(_) => None,
+            .filter_map(|(i, block)| {
+                let smooth_result = smooth_block(block, &graph, config, &path_positions);
+                let needs_passthrough = match &smooth_result {
+                    Ok(s) if s.is_empty() => true,
+                    Ok(_) => false,
                     Err(e) => {
-                        log::warn!("[smooth] Block {} failed: {}", i, e);
-                        None
+                        log::debug!("[smooth] Block {} SPOA failed: {} — passthrough", i, e);
+                        true
                     }
-                },
-            )
+                };
+                let mode;
+                let out: Option<String> = if !needs_passthrough {
+                    n_smoothed.fetch_add(1, Ordering::Relaxed);
+                    mode = "smooth";
+                    smooth_result.ok()
+                } else {
+                    mode = "passthrough";
+                    match passthrough_block_gfa(block, &graph, &path_positions) {
+                        Ok(s) if !s.is_empty() => {
+                            n_passthrough.fetch_add(1, Ordering::Relaxed);
+                            Some(s)
+                        }
+                        Ok(_) => None,
+                        Err(e) => {
+                            log::warn!("[smooth] Block {} passthrough failed: {}", i, e);
+                            None
+                        }
+                    }
+                };
+                // DIAGNOSTIC: per-block bp accounting
+                if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+                    let input_bp: usize = block.path_ranges.iter().map(|r| r.length).sum();
+                    let n_input_ranges = block.path_ranges.len();
+                    let (n_output_p, output_bp) = match &out {
+                        Some(g) => {
+                            let mut p_count = 0usize;
+                            let mut bp_sum = 0usize;
+                            for line in g.lines() {
+                                if !line.starts_with("P\t") { continue; }
+                                p_count += 1;
+                                let name = line.split('\t').nth(1).unwrap_or("");
+                                if let Some(lc) = name.rfind(':') {
+                                    let rs = &name[lc+1..];
+                                    if let Some((s, e)) = rs.split_once('-') {
+                                        if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
+                                            bp_sum += e.saturating_sub(s);
+                                        }
+                                    }
+                                }
+                            }
+                            (p_count, bp_sum)
+                        }
+                        None => (0, 0),
+                    };
+                    if output_bp + 100 < input_bp || n_output_p != n_input_ranges {
+                        log::info!(
+                            "[TRACE-BLK#{}] mode={} ranges_in={} P_out={} bp_in={} bp_out={} delta={}",
+                            i, mode, n_input_ranges, n_output_p, input_bp, output_bp,
+                            input_bp as i64 - output_bp as i64,
+                        );
+                    }
+                }
+                out
+            })
             .collect()
     });
 
-    info!("[smooth] Smoothed {} blocks successfully", block_gfas.len());
+    info!(
+        "[smooth] Smoothed {} blocks ({} passthrough)",
+        n_smoothed.load(Ordering::Relaxed),
+        n_passthrough.load(Ordering::Relaxed),
+    );
+
+    // DIAGNOSTIC: pre-lace per-path bp coverage from emitted block sub-GFAs
+    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+        let mut pre_lace_cov: FxHashMap<String, (usize, usize, usize)> = FxHashMap::default();
+        // key -> (frag_count, total_bp_covered, max_end)
+        let mut pre_lace_p_count: usize = 0;
+        for gfa in &block_gfas {
+            for line in gfa.lines() {
+                if !line.starts_with("P\t") {
+                    continue;
+                }
+                pre_lace_p_count += 1;
+                let name = line.split('\t').nth(1).unwrap_or("");
+                if let Some(last_colon) = name.rfind(':') {
+                    let (key, range_str) = name.split_at(last_colon);
+                    let range_str = &range_str[1..];
+                    if let Some((s, e)) = range_str.split_once('-') {
+                        if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
+                            let entry = pre_lace_cov.entry(key.to_string()).or_insert((0, 0, 0));
+                            entry.0 += 1;
+                            entry.1 += e.saturating_sub(s);
+                            if e > entry.2 {
+                                entry.2 = e;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let mut keys: Vec<&String> = pre_lace_cov.keys().collect();
+        keys.sort();
+        info!("[TRACE] pre-lace: {} block-GFA P-lines across {} distinct path keys", pre_lace_p_count, pre_lace_cov.len());
+        for key in keys.iter() {
+            let v = pre_lace_cov[*key];
+            info!("[TRACE-PRE]   {} → {} frags, {} bp covered, max_end {}", key, v.0, v.1, v.2);
+        }
+    }
 
     if block_gfas.is_empty() {
         return Ok(String::from("H\tVN:Z:1.0\n"));
@@ -277,6 +421,41 @@ fn smooth_gfa_pass(
     // Per-block gfaffix already normalized each block; the caller's normalize_and_sort
     // (gfaffix + sort) handles any remaining redundancies introduced at lacing boundaries.
     let laced = crate::commands::lace::lace_subgraphs(&block_gfas, config.temp_dir.as_deref())?;
+
+    // DIAGNOSTIC: post-lace per-path bp coverage
+    if std::env::var("IMPG_SMOOTH_TRACE").is_ok() {
+        let mut post_lace_cov: FxHashMap<String, (usize, usize, usize)> = FxHashMap::default();
+        let mut post_lace_p_count: usize = 0;
+        for line in laced.lines() {
+            if !line.starts_with("P\t") {
+                continue;
+            }
+            post_lace_p_count += 1;
+            let name = line.split('\t').nth(1).unwrap_or("");
+            if let Some(last_colon) = name.rfind(':') {
+                let (key, range_str) = name.split_at(last_colon);
+                let range_str = &range_str[1..];
+                if let Some((s, e)) = range_str.split_once('-') {
+                    if let (Ok(s), Ok(e)) = (s.parse::<usize>(), e.parse::<usize>()) {
+                        let entry = post_lace_cov.entry(key.to_string()).or_insert((0, 0, 0));
+                        entry.0 += 1;
+                        entry.1 += e.saturating_sub(s);
+                        if e > entry.2 {
+                            entry.2 = e;
+                        }
+                    }
+                }
+            }
+        }
+        let mut keys: Vec<&String> = post_lace_cov.keys().collect();
+        keys.sort();
+        info!("[TRACE] post-lace: {} P-lines across {} distinct path keys", post_lace_p_count, post_lace_cov.len());
+        for key in keys.iter() {
+            let v = post_lace_cov[*key];
+            info!("[TRACE-POST]  {} → {} frags, {} bp covered, max_end {}", key, v.0, v.1, v.2);
+        }
+    }
+
     info!("[smooth] Lacing complete");
 
     Ok(laced)
@@ -936,6 +1115,89 @@ fn detect_repeat(
 // Per-block SPOA smoothing
 // ---------------------------------------------------------------------------
 
+/// Emit a block's path-ranges as a sub-GFA using the **un-smoothed** input
+/// sequence content. Called when [`smooth_block`] returns an empty/Err result
+/// so the block's bp coverage stays in the laced graph rather than vanishing.
+///
+/// Node IDs are local to the emitted sub-GFA (1..=N over the unique input
+/// nodes touched). The lacer assigns globally fresh IDs anyway, so local
+/// numbering doesn't collide. Edges include only step-to-step transitions
+/// taken inside the block's path ranges — the parent graph's full edge set
+/// would carry unrelated traversals through these nodes.
+fn passthrough_block_gfa(
+    block: &Block,
+    graph: &SmoothGraph,
+    path_positions: &[Vec<usize>],
+) -> io::Result<String> {
+    if block.path_ranges.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut node_remap: FxHashMap<usize, u64> = FxHashMap::default();
+    let mut next_id: u64 = 1;
+    let mut out = String::new();
+
+    for range in &block.path_ranges {
+        let path = &graph.paths[range.path_idx];
+        for step_idx in range.begin_step..range.end_step {
+            let (node_idx, _) = path.steps[step_idx];
+            if let std::collections::hash_map::Entry::Vacant(e) = node_remap.entry(node_idx) {
+                e.insert(next_id);
+                let seq = std::str::from_utf8(&graph.nodes[node_idx]).map_err(|err| {
+                    io::Error::other(format!("non-UTF8 node sequence: {}", err))
+                })?;
+                out.push_str(&format!("S\t{}\t{}\n", next_id, seq));
+                next_id += 1;
+            }
+        }
+    }
+
+    let mut edges: FxHashSet<(u64, bool, u64, bool)> = FxHashSet::default();
+    for range in &block.path_ranges {
+        let path = &graph.paths[range.path_idx];
+        for window_start in range.begin_step..range.end_step.saturating_sub(1) {
+            let (from_idx, from_rev) = path.steps[window_start];
+            let (to_idx, to_rev) = path.steps[window_start + 1];
+            if let (Some(&from_id), Some(&to_id)) =
+                (node_remap.get(&from_idx), node_remap.get(&to_idx))
+            {
+                edges.insert((from_id, from_rev, to_id, to_rev));
+            }
+        }
+    }
+    for (from_id, from_rev, to_id, to_rev) in &edges {
+        out.push_str(&format!(
+            "L\t{}\t{}\t{}\t{}\t0M\n",
+            from_id,
+            if *from_rev { "-" } else { "+" },
+            to_id,
+            if *to_rev { "-" } else { "+" },
+        ));
+    }
+
+    for range in &block.path_ranges {
+        let path = &graph.paths[range.path_idx];
+        let (path_key, path_start) = parse_path_coords(&path.name);
+        let range_start_bp = path_start + path_positions[range.path_idx][range.begin_step];
+        let range_end_bp = path_start + path_positions[range.path_idx][range.end_step];
+        let mut steps_str = String::new();
+        for step_idx in range.begin_step..range.end_step {
+            let (node_idx, is_rev) = path.steps[step_idx];
+            let nid = node_remap[&node_idx];
+            if !steps_str.is_empty() {
+                steps_str.push(',');
+            }
+            steps_str.push_str(&format!("{}{}", nid, if is_rev { "-" } else { "+" }));
+        }
+        out.push_str(&format!(
+            "P\t{}:{}-{}\t{}\t*\n",
+            path_key, range_start_bp, range_end_bp, steps_str,
+        ));
+    }
+
+    Ok(out)
+}
+
 /// Smooth a single block: extract sequences → SPOA → GFA.
 fn smooth_block(
     block: &Block,
@@ -1090,13 +1352,27 @@ fn smooth_block(
     let msa_bytes: Vec<&[u8]> = msa.iter().map(|s| s.as_bytes()).collect();
 
     let mut core_sequences: Vec<String> = Vec::with_capacity(nseqs);
+    let mut n_empty_core = 0usize;
     for row in &msa_bytes[..nseqs] {
         let core_seq: String = row[core_start..core_end]
             .iter()
             .filter(|&&b| b != b'-')
             .map(|&b| b as char)
             .collect();
+        if core_seq.is_empty() {
+            n_empty_core += 1;
+        }
         core_sequences.push(core_seq);
+    }
+
+    // Any entry with an empty core would be fed an empty string to SPOA,
+    // which silently emits no P-line for that entry — losing that input
+    // path-range's bp coverage. Even ONE empty core is a correctness
+    // problem, not just a quality one: the laced graph's path-bp coverage
+    // contract is "every input range survives somewhere". Route the whole
+    // block through passthrough rather than emit partial smoothed output.
+    if n_empty_core > 0 {
+        return Ok(String::new());
     }
 
     // Build fresh SPOA graph from core sequences
@@ -1343,5 +1619,58 @@ P\tseq2:0-6\t1+,2+\t*
         // Should produce 1 block (total weight is small)
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].path_ranges.len(), 2);
+    }
+
+    #[test]
+    fn test_passthrough_block_gfa_preserves_path_coverage() {
+        // Regression for the smooth fragmentation bug: when smooth_block
+        // returns Ok("") (degenerate-padding or many-empty-cores case), the
+        // dispatch in smooth_gfa_pass routes the block through
+        // passthrough_block_gfa so its path-ranges survive to the lacer.
+        //
+        // Verifies: (1) one P-line per input path-range, (2) names use the
+        // path's bp coords, (3) emitted node IDs are local (no clash with
+        // other blocks during lacing), (4) edges link consecutive steps.
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tACGT
+S\t2\tTGCA
+S\t3\tGGGG
+P\tchr1:100-108\t1+,2+\t*
+P\tchr2:200-212\t1+,2+,3+\t*
+";
+        let graph = parse_gfa(gfa);
+        let path_positions = compute_path_positions(&graph);
+        let block = Block {
+            path_ranges: vec![
+                PathRange {
+                    path_idx: 0,
+                    begin_step: 0,
+                    end_step: 2,
+                    length: 8,
+                },
+                PathRange {
+                    path_idx: 1,
+                    begin_step: 0,
+                    end_step: 3,
+                    length: 12,
+                },
+            ],
+        };
+        let out =
+            passthrough_block_gfa(&block, &graph, &path_positions).expect("passthrough failed");
+        let p_lines: Vec<&str> = out.lines().filter(|l| l.starts_with("P\t")).collect();
+        assert_eq!(p_lines.len(), 2, "one P-line per path-range");
+        // Names carry full input bp range, so the lacer sees consecutive ranges
+        // and can join across blocks.
+        let names: Vec<&str> = p_lines.iter().map(|l| l.split('\t').nth(1).unwrap()).collect();
+        assert!(names.iter().any(|n| *n == "chr1:100-108"), "got {:?}", names);
+        assert!(names.iter().any(|n| *n == "chr2:200-212"), "got {:?}", names);
+        // 3 distinct nodes touched → 3 S-lines with local IDs 1..=3.
+        let s_lines: Vec<&str> = out.lines().filter(|l| l.starts_with("S\t")).collect();
+        assert_eq!(s_lines.len(), 3);
+        // At least two L-lines: edges 1→2 (both paths) and 2→3 (chr2 only).
+        let l_lines: Vec<&str> = out.lines().filter(|l| l.starts_with("L\t")).collect();
+        assert!(l_lines.len() >= 2, "edges: {:?}", l_lines);
     }
 }


### PR DESCRIPTION
## Bug

In `src/smooth.rs::smooth_block`, the MSA-trim step uses MAX-of-left-pad-ends / MIN-of-right-pad-starts to find the shared "core". One outlier sequence collapses the core for everyone else. SPOA emits no (or tiny) P-lines for the collapsed entries, but the block emits P-line **names** with the full input bp range — names that lie about content. The lacer trusts the names; the next pass parses the actually-shorter content; the final graph fragments at every gap.

## C4 numbers

| Output | Before | After |
|---|---|---|
| `query -o gfa` (90 haps, 35 homologs) | **1285** P-lines | **35** |
| `impg graph` on 90 input FASTAs | **732** P-lines, each end short by 150–3000 bp | **90**, every `named_bp == walked_bp` |

Worst single-block silent loss: block #160 named 60,802 bp, walked 1,962 bp (97%).

## Fix

`smooth_block` requires strict `total_core_bp == total_input_bp`. Any bp loss → `Ok("")` → routed through the new `passthrough_block_gfa` helper, which emits the un-smoothed sub-graph (original nodes/edges/coords) so the lacer can stitch.

Trade-off: more blocks now skip SPOA smoothing (94/126 on `impg graph` pass 1; ~32/117 on syng `-o gfa`). Graph is correct but less compressed than ideal. A robust percentile in `find_core_column_range` is a separate redesign.

## Verification

- 215/215 tests pass.
- Every output P-line: `named_bp == walked_bp`.
- `test_passthrough_block_gfa_preserves_path_coverage` unit test.
