### PR TITLE
Use explicit syng position sample rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,11 @@ impg stats -a f1.paf f2.1aln
 
 `impg syng` builds a [syng](https://github.com/richarddurbin/syng) index from FASTA or AGC. Six sidecars are written under one prefix (`<prefix>.1khash` dictionary, `.1gbwt` GBWT, `.syng.names`, `.syng.spos` sampled node positions, `.syng.pstep` sampled path-step checkpoints, `.syng.meta` parameters — auto-loaded on read). Any later `impg query` / `partition` / `map` can then point `-a` at the prefix (or any sidecar) and skip pairwise alignment.
 
-Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid: `--position-sample-shift 8` samples steps `0, 256, 512, ...` on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
+Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid: `--position-sample-rate 256` samples steps `0, 256, 512, ...` on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
 
 `impg map` projects FASTA/FASTQ queries onto a syng index via shared syncmers: PAF (projected genome coords) or GAF (syncmer-node walk).
+
+Use `impg syng-repair -a <prefix> --position-sample-rate <N> --force` to rebuild or resample `.syng.spos` and `.syng.pstep` from an existing `.1gbwt` / `.1khash` syng index without re-reading the original sequences.
 
 End-to-end walkthrough using ODGI's C4 test GFA (90 HPRC haplotypes, ~6.9 Mb total):
 
@@ -296,7 +298,7 @@ samtools faidx chr6.C4.fa
 # 2. Build the syng index (~80 ms on this dataset, 4 threads)
 impg syng -f chr6.C4.fa -o c4.syng \
           --syncmer-length 63 --smer-length 8 --syncmer-seed 7 \
-          --position-sample-shift 8 --position-sample-seed 7 -t 4
+          --position-sample-rate 256 -t 4
 # writes c4.syng.1khash / .1gbwt / .syng.names / .syng.spos / .syng.pstep / .syng.meta
 
 # 3. Query a 10 kb grch38 sub-window onto all 90 haplotypes

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ impg stats -a f1.paf f2.1aln
 
 `impg syng` builds a [syng](https://github.com/richarddurbin/syng) index from FASTA or AGC. Six sidecars are written under one prefix (`<prefix>.1khash` dictionary, `.1gbwt` GBWT, `.syng.names`, `.syng.spos` sampled node positions, `.syng.pstep` sampled path-step checkpoints, `.syng.meta` parameters — auto-loaded on read). Any later `impg query` / `partition` / `map` can then point `-a` at the prefix (or any sidecar) and skip pairwise alignment.
 
-Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid: `--position-sample-rate 256` samples steps `0, 256, 512, ...` on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
+Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid plus the terminal syncmer: `--position-sample-rate 256` samples steps `0, 256, 512, ...` and the final step on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
 
 `impg map` projects FASTA/FASTQ queries onto a syng index via shared syncmers: PAF (projected genome coords) or GAF (syncmer-node walk).
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ impg stats -a f1.paf f2.1aln
 
 ### `syng` and `map` — alignment-free syncmer backend
 
-`impg syng` builds a [syng](https://github.com/richarddurbin/syng) index from FASTA or AGC. Five sidecars are written under one prefix (`<prefix>.1khash` dictionary, `.1gbwt` GBWT, `.syng.names`, `.syng.spos` sampled positions, `.syng.meta` parameters — auto-loaded on read). Any later `impg query` / `partition` / `map` can then point `-a` at the prefix (or any sidecar) and skip pairwise alignment.
+`impg syng` builds a [syng](https://github.com/richarddurbin/syng) index from FASTA or AGC. Six sidecars are written under one prefix (`<prefix>.1khash` dictionary, `.1gbwt` GBWT, `.syng.names`, `.syng.spos` sampled node positions, `.syng.pstep` sampled path-step checkpoints, `.syng.meta` parameters — auto-loaded on read). Any later `impg query` / `partition` / `map` can then point `-a` at the prefix (or any sidecar) and skip pairwise alignment.
 
-Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). `--parallel-dictionary` adds a deterministic prepass for large inputs.
+Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid: `--position-sample-shift 8` samples steps `0, 256, 512, ...` on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
 
 `impg map` projects FASTA/FASTQ queries onto a syng index via shared syncmers: PAF (projected genome coords) or GAF (syncmer-node walk).
 
@@ -297,7 +297,7 @@ samtools faidx chr6.C4.fa
 impg syng -f chr6.C4.fa -o c4.syng \
           --syncmer-length 63 --smer-length 8 --syncmer-seed 7 \
           --position-sample-shift 8 --position-sample-seed 7 -t 4
-# writes c4.syng.1khash / .1gbwt / .syng.names / .syng.spos / .syng.meta
+# writes c4.syng.1khash / .1gbwt / .syng.names / .syng.spos / .syng.pstep / .syng.meta
 
 # 3. Query a 10 kb grch38 sub-window onto all 90 haplotypes
 impg query -a c4.syng -r 'grch38#chr6:31972046-32055647:0-10000' \

--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -10,6 +10,7 @@ must produce a normal syng index:
 - `{prefix}.1gbwt`
 - `{prefix}.syng.names`
 - `{prefix}.syng.spos`
+- `{prefix}.syng.pstep`
 - `{prefix}.syng.meta`
 
 The output does not need to assign the same numeric syncmer node ids as the
@@ -46,8 +47,8 @@ Every path is then encoded as signed global node ids:
 P_p = [(strand_i * phi(x_i), pos_i)]
 ```
 
-The GBWT and sampled-position sidecar are functions of the ordered collection
-of `P_p` streams. A parallel build is correct if all shards use the same `phi`
+The GBWT and positional sidecars are functions of the ordered collection of
+`P_p` streams. A parallel build is correct if all shards use the same `phi`
 and the final path order is the chosen global path order.
 
 ## Production Algorithm
@@ -59,10 +60,10 @@ The clean end-state is a two-pass parallel dictionary plus per-node reduce:
 3. Sort/deduplicate the union and assign global ids.
 4. In parallel, stream inputs again and map syncmers through the global
    dictionary.
-5. For each shard, emit per-node occurrence records and sampled-position
-   records using global node ids and global path coordinates.
+5. For each shard, emit per-node occurrence records and regular-grid
+   positional samples using global node ids and global path coordinates.
 6. Reduce per-node occurrence records into the final GBWT node structures.
-7. Sort/group sampled-position records and write `.syng.spos`.
+7. Sort/group sampled-position records and write `.syng.spos` plus `.syng.pstep`.
 
 Step 6 is the only part not exposed by the current syng C API. The existing
 API has one mutable `syngBWTpathAdd` stream, but no `syngBWTmerge` or builder
@@ -93,8 +94,10 @@ AGC inputs.
   `kmerHashAdd`.
 - The frozen dictionary rejects duplicate packed syncmers.
 - Replay fails if any extracted syncmer is absent from the frozen dictionary.
-- `.syng.spos` sampling uses global path ids and positions, so it remains
-  merge-compatible.
+- Positional sampling uses a regular per-path syncmer-step grid. For
+  `sample_shift = s`, sampled steps are `0, 2^s, 2*2^s, ...` on each path.
+  `.syng.spos` stores sampled node-to-position records and `.syng.pstep`
+  stores the inverse path-position checkpoints for the same sampled steps.
 
 ## Next Step: True GBWT Reduce
 

--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -94,8 +94,9 @@ AGC inputs.
   `kmerHashAdd`.
 - The frozen dictionary rejects duplicate packed syncmers.
 - Replay fails if any extracted syncmer is absent from the frozen dictionary.
-- Positional sampling uses a regular per-path syncmer-step grid. For
-  `sample_rate = r`, sampled steps are `0, r, 2*r, ...` on each path.
+- Positional sampling uses a regular per-path syncmer-step grid plus each
+  path's terminal syncmer. For `sample_rate = r`, sampled steps are
+  `0, r, 2*r, ...` plus the final syncmer step on each path.
   `.syng.spos` stores sampled node-to-position records and `.syng.pstep`
   stores the inverse path-position checkpoints for the same sampled steps.
 

--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -95,7 +95,7 @@ AGC inputs.
 - The frozen dictionary rejects duplicate packed syncmers.
 - Replay fails if any extracted syncmer is absent from the frozen dictionary.
 - Positional sampling uses a regular per-path syncmer-step grid. For
-  `sample_shift = s`, sampled steps are `0, 2^s, 2*2^s, ...` on each path.
+  `sample_rate = r`, sampled steps are `0, r, 2*r, ...` on each path.
   `.syng.spos` stores sampled node-to-position records and `.syng.pstep`
   stores the inverse path-position checkpoints for the same sampled steps.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1875,15 +1875,10 @@ enum Args {
         #[clap(short = 'o', long, value_parser)]
         output: String,
 
-        /// Sample every 2^N syncmer steps per path for positional sidecars.
+        /// Sample every N syncmer steps per path for positional sidecars.
         #[arg(help_heading = "Position sampling")]
-        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SHIFT)]
-        position_sample_shift: u32,
-
-        /// Compatibility seed stored in sidecars; regular-grid sampling ignores it.
-        #[arg(help_heading = "Position sampling")]
-        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SEED)]
-        position_sample_seed: u64,
+        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_RATE)]
+        position_sample_rate: u32,
 
         /// Build a deterministic global syncmer dictionary in a parallel prepass, then replay paths through it.
         #[arg(help_heading = "Construction")]
@@ -1961,15 +1956,10 @@ enum Args {
         #[clap(long, action)]
         force: bool,
 
-        /// Sample every 2^N syncmer steps per path for positional sidecars.
+        /// Sample every N syncmer steps per path for positional sidecars.
         #[arg(help_heading = "Position sampling")]
-        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SHIFT)]
-        position_sample_shift: u32,
-
-        /// Compatibility seed stored in sidecars; regular-grid sampling ignores it.
-        #[arg(help_heading = "Position sampling")]
-        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SEED)]
-        position_sample_seed: u64,
+        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_RATE)]
+        position_sample_rate: u32,
 
         /// Rebuild sidecars serially instead of walking paths in parallel.
         #[arg(help_heading = "Position sampling")]
@@ -3839,8 +3829,7 @@ fn run() -> io::Result<()> {
             syncmer_w,
             syncmer_length,
             syncmer_seed,
-            position_sample_shift,
-            position_sample_seed,
+            position_sample_rate,
             parallel_dictionary,
             common,
         } => {
@@ -3872,16 +3861,18 @@ fn run() -> io::Result<()> {
                 syncmer_seed,
                 common.threads.get(),
             );
+            if position_sample_rate == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--position-sample-rate must be greater than zero",
+                ));
+            }
             let configure_position_sampling =
                 |index: &mut impg::syng::SyngIndex| -> io::Result<()> {
-                    index.enable_online_sampled_positions(
-                        position_sample_shift,
-                        position_sample_seed,
-                    )?;
+                    index.enable_online_sampled_positions(position_sample_rate)?;
                     info!(
-                        "Online regular sampled position sidecars enabled: sample_shift={} (every {} syncmer steps per path)",
-                        position_sample_shift,
-                        1u64 << position_sample_shift,
+                        "Online regular sampled position sidecars enabled: every {} syncmer steps per path",
+                        position_sample_rate,
                     );
                     Ok(())
                 };
@@ -4329,15 +4320,14 @@ fn run() -> io::Result<()> {
             let position_start = Instant::now();
             if let Some(stats) = index.finalize_online_sampled_positions()? {
                 info!(
-                    "Regular sampled position sidecars compacted in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths (sample_shift={}, period={} syncmer steps) at +{}",
+                    "Regular sampled position sidecars compacted in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths (sample_rate={} syncmer steps) at +{}",
                     format_duration(position_start.elapsed()),
                     stats.sampled_occurrences,
                     stats.sampled_nodes,
                     stats.sampled_path_steps,
                     stats.sampled_step_paths,
                     stats.walked_paths,
-                    stats.sample_shift,
-                    1u64 << stats.sample_shift,
+                    stats.sample_rate,
                     format_duration(total_start.elapsed()),
                 );
             }
@@ -4376,8 +4366,7 @@ fn run() -> io::Result<()> {
         Args::SyngRepair {
             index,
             force,
-            position_sample_shift,
-            position_sample_seed,
+            position_sample_rate,
             serial_position_sampling,
             position_progress_interval,
             common,
@@ -4386,15 +4375,6 @@ fn run() -> io::Result<()> {
             let prefix = detect_syng_prefix(&index).unwrap_or(index);
             let spos_path = impg::syng::syng_spos_path(&prefix);
             let pstep_path = impg::syng::syng_pstep_path(&prefix);
-            let have_spos = std::path::Path::new(&spos_path).exists();
-            let have_pstep = std::path::Path::new(&pstep_path).exists();
-            if !force && have_spos && have_pstep {
-                info!(
-                    "Syng position sidecars already exist: {}, {}. Use --force to rebuild regular-grid sidecars.",
-                    spos_path, pstep_path
-                );
-                return Ok(());
-            }
 
             let total_start = Instant::now();
             info!(
@@ -4424,28 +4404,34 @@ fn run() -> io::Result<()> {
             }
 
             let rebuild_start = Instant::now();
-            if position_sample_shift >= 63 {
+            if position_sample_rate == 0 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "--position-sample-shift must be less than 63",
+                    "--position-sample-rate must be greater than zero",
                 ));
             }
-            let sample_period = 1u64 << position_sample_shift;
-            if have_spos && !force {
+            let have_requested_spos =
+                syng_index.sampled_positions_rate() == Some(position_sample_rate);
+            let have_requested_pstep =
+                syng_index.sampled_path_steps_rate() == Some(position_sample_rate);
+            if !force && have_requested_spos && have_requested_pstep {
                 info!(
-                    "Rebuilding regular sampled path-step sidecar: sample_shift={} (every {} syncmer steps per path)",
-                    position_sample_shift,
-                    sample_period,
+                    "Syng position sidecars already exist at sample rate {}: {}, {}. Use --force to rebuild.",
+                    position_sample_rate, spos_path, pstep_path
+                );
+                return Ok(());
+            }
+
+            if !force && have_requested_spos {
+                info!(
+                    "Rebuilding regular sampled path-step sidecar: every {} syncmer steps per path",
+                    position_sample_rate,
                 );
                 let stats = if serial_position_sampling {
-                    syng_index.rebuild_sampled_path_steps_from_gbwt(
-                        position_sample_shift,
-                        position_sample_seed,
-                    )?
+                    syng_index.rebuild_sampled_path_steps_from_gbwt(position_sample_rate)?
                 } else {
                     syng_index.rebuild_sampled_path_steps_from_gbwt_parallel(
-                        position_sample_shift,
-                        position_sample_seed,
+                        position_sample_rate,
                         position_progress_interval,
                     )?
                 };
@@ -4465,19 +4451,14 @@ fn run() -> io::Result<()> {
                 );
             } else {
                 info!(
-                    "Rebuilding regular sampled position sidecars: sample_shift={} (every {} syncmer steps per path)",
-                    position_sample_shift,
-                    sample_period,
+                    "Rebuilding regular sampled position sidecars: every {} syncmer steps per path",
+                    position_sample_rate,
                 );
                 let stats = if serial_position_sampling {
-                    syng_index.rebuild_sampled_position_indexes_from_gbwt(
-                        position_sample_shift,
-                        position_sample_seed,
-                    )?
+                    syng_index.rebuild_sampled_position_indexes_from_gbwt(position_sample_rate)?
                 } else {
                     syng_index.rebuild_sampled_position_indexes_from_gbwt_parallel(
-                        position_sample_shift,
-                        position_sample_seed,
+                        position_sample_rate,
                         position_progress_interval,
                     )?
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1875,7 +1875,7 @@ enum Args {
         #[clap(short = 'o', long, value_parser)]
         output: String,
 
-        /// Sample every N syncmer steps per path for positional sidecars.
+        /// Sample every N syncmer steps plus each path's terminal syncmer.
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_RATE)]
         position_sample_rate: u32,
@@ -1956,7 +1956,7 @@ enum Args {
         #[clap(long, action)]
         force: bool,
 
-        /// Sample every N syncmer steps per path for positional sidecars.
+        /// Sample every N syncmer steps plus each path's terminal syncmer.
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_RATE)]
         position_sample_rate: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1875,12 +1875,12 @@ enum Args {
         #[clap(short = 'o', long, value_parser)]
         output: String,
 
-        /// Sample one path occurrence per 2^N occurrences for .syng.spos.
+        /// Sample every 2^N syncmer steps per path for positional sidecars.
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SHIFT)]
         position_sample_shift: u32,
 
-        /// Hash seed for online position sampling.
+        /// Compatibility seed stored in sidecars; regular-grid sampling ignores it.
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SEED)]
         position_sample_seed: u64,
@@ -1961,15 +1961,25 @@ enum Args {
         #[clap(long, action)]
         force: bool,
 
-        /// Sample one path occurrence per 2^N occurrences.
+        /// Sample every 2^N syncmer steps per path for positional sidecars.
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SHIFT)]
         position_sample_shift: u32,
 
-        /// Hash seed for position sampling.
+        /// Compatibility seed stored in sidecars; regular-grid sampling ignores it.
         #[arg(help_heading = "Position sampling")]
         #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_POSITION_SAMPLE_SEED)]
         position_sample_seed: u64,
+
+        /// Rebuild sidecars serially instead of walking paths in parallel.
+        #[arg(help_heading = "Position sampling")]
+        #[clap(long, action)]
+        serial_position_sampling: bool,
+
+        /// Log positional repair progress after this many completed paths (0 disables).
+        #[arg(help_heading = "Position sampling")]
+        #[clap(long, value_parser, default_value_t = 1)]
+        position_progress_interval: usize,
 
         // --- General ---
         #[clap(flatten)]
@@ -3869,10 +3879,9 @@ fn run() -> io::Result<()> {
                         position_sample_seed,
                     )?;
                     info!(
-                        "Online sampled position sidecar enabled: sample_shift={} (~1/{} path occurrences), seed={}",
+                        "Online regular sampled position sidecars enabled: sample_shift={} (every {} syncmer steps per path)",
                         position_sample_shift,
                         1u64 << position_sample_shift,
-                        position_sample_seed,
                     );
                     Ok(())
                 };
@@ -4320,7 +4329,7 @@ fn run() -> io::Result<()> {
             let position_start = Instant::now();
             if let Some(stats) = index.finalize_online_sampled_positions()? {
                 info!(
-                    "Sampled position sidecars compacted in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths (sample_shift={} ~=1/{}) at +{}",
+                    "Regular sampled position sidecars compacted in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths (sample_shift={}, period={} syncmer steps) at +{}",
                     format_duration(position_start.elapsed()),
                     stats.sampled_occurrences,
                     stats.sampled_nodes,
@@ -4369,6 +4378,8 @@ fn run() -> io::Result<()> {
             force,
             position_sample_shift,
             position_sample_seed,
+            serial_position_sampling,
+            position_progress_interval,
             common,
         } => {
             initialize_threads_and_log(&common);
@@ -4379,7 +4390,7 @@ fn run() -> io::Result<()> {
             let have_pstep = std::path::Path::new(&pstep_path).exists();
             if !force && have_spos && have_pstep {
                 info!(
-                    "Syng position sidecars already exist: {}, {}. Use --force to rebuild.",
+                    "Syng position sidecars already exist: {}, {}. Use --force to rebuild regular-grid sidecars.",
                     spos_path, pstep_path
                 );
                 return Ok(());
@@ -4422,15 +4433,22 @@ fn run() -> io::Result<()> {
             let sample_period = 1u64 << position_sample_shift;
             if have_spos && !force {
                 info!(
-                    "Rebuilding sampled path-step sidecar: sample_shift={} (~1/{} path occurrences), seed={}",
+                    "Rebuilding regular sampled path-step sidecar: sample_shift={} (every {} syncmer steps per path)",
                     position_sample_shift,
                     sample_period,
-                    position_sample_seed
                 );
-                let stats = syng_index.rebuild_sampled_path_steps_from_gbwt(
-                    position_sample_shift,
-                    position_sample_seed,
-                )?;
+                let stats = if serial_position_sampling {
+                    syng_index.rebuild_sampled_path_steps_from_gbwt(
+                        position_sample_shift,
+                        position_sample_seed,
+                    )?
+                } else {
+                    syng_index.rebuild_sampled_path_steps_from_gbwt_parallel(
+                        position_sample_shift,
+                        position_sample_seed,
+                        position_progress_interval,
+                    )?
+                };
                 info!(
                     "Rebuilt sampled path-step sidecar in {}: {} checkpoints across {} paths from {} walked paths",
                     format_duration(rebuild_start.elapsed()),
@@ -4447,15 +4465,22 @@ fn run() -> io::Result<()> {
                 );
             } else {
                 info!(
-                    "Rebuilding sampled position sidecars: sample_shift={} (~1/{} path occurrences), seed={}",
+                    "Rebuilding regular sampled position sidecars: sample_shift={} (every {} syncmer steps per path)",
                     position_sample_shift,
                     sample_period,
-                    position_sample_seed
                 );
-                let stats = syng_index.rebuild_sampled_position_indexes_from_gbwt(
-                    position_sample_shift,
-                    position_sample_seed,
-                )?;
+                let stats = if serial_position_sampling {
+                    syng_index.rebuild_sampled_position_indexes_from_gbwt(
+                        position_sample_shift,
+                        position_sample_seed,
+                    )?
+                } else {
+                    syng_index.rebuild_sampled_position_indexes_from_gbwt_parallel(
+                        position_sample_shift,
+                        position_sample_seed,
+                        position_progress_interval,
+                    )?
+                };
                 info!(
                     "Rebuilt sampled position sidecars in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths",
                     format_duration(rebuild_start.elapsed()),

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -3,10 +3,12 @@
 //! Provides `SyngIndex` for building, loading, saving, and querying
 //! GBWT-based syncmer indices.
 
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::ffi::CString;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::Path;
+use std::sync::Mutex;
 
 use crate::syng_ffi;
 
@@ -46,6 +48,22 @@ struct PathStepRecord {
     prev_node: i32,
     prev_offset: u32,
     traversal_rank: u32,
+}
+
+#[derive(Debug)]
+struct EncodedPositionSampleChunk {
+    position_samples: Vec<(u32, u64)>,
+    path_step_data: Vec<u8>,
+    path_step_sample_count: u64,
+    walked_steps: u64,
+}
+
+#[derive(Debug, Default)]
+struct PositionRepairProgress {
+    completed_paths: usize,
+    completed_steps: u64,
+    completed_position_samples: u64,
+    completed_path_step_samples: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -104,10 +122,10 @@ pub fn syng_meta_path(prefix: &str) -> String {
 
 /// Succinct sampled path-position sidecar for projected syng mapping.
 ///
-/// This mirrors the sampled suffix-array idea used by ropebwt3: store only a
-/// deterministic fraction of path occurrences, then resolve mapping positions
-/// from those samples instead of materializing every visit for every node.
-/// Occurrences are grouped by syncmer node id and varint delta encoded.
+/// This mirrors the sampled suffix-array idea used by ropebwt3: store a regular
+/// per-path grid of occurrences, then resolve mapping positions from those
+/// samples instead of materializing every visit for every node. Occurrences are
+/// grouped by syncmer node id and varint delta encoded.
 pub struct SampledPositions {
     pub sample_shift: u32,
     pub seed: u64,
@@ -120,7 +138,7 @@ pub struct SampledPositions {
 
 impl SampledPositions {
     const MAGIC: u64 = 0x494D50_53504F53; // "IMPSPOS"
-    const VERSION: u64 = 1;
+    const VERSION: u64 = 2;
 
     fn from_samples(
         sample_shift: u32,
@@ -265,6 +283,15 @@ impl SampledPositions {
         w.flush()
     }
 
+    fn save_atomic(&self, path: &str) -> io::Result<()> {
+        let tmp_path = format!("{}.tmp.{}", path, std::process::id());
+        self.save(&tmp_path)?;
+        std::fs::rename(&tmp_path, path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            e
+        })
+    }
+
     fn load(path: &str) -> io::Result<Self> {
         let mut r = BufReader::new(std::fs::File::open(path)?);
         let magic = read_u64(&mut r)?;
@@ -373,7 +400,7 @@ pub struct SampledPathSteps {
 
 impl SampledPathSteps {
     const MAGIC: u64 = 0x494D50_50535450; // "IMPPSTP"
-    const VERSION: u64 = 1;
+    const VERSION: u64 = 2;
 
     #[allow(dead_code)]
     fn from_samples(
@@ -580,6 +607,15 @@ impl SampledPathSteps {
         w.flush()
     }
 
+    fn save_atomic(&self, path: &str) -> io::Result<()> {
+        let tmp_path = format!("{}.tmp.{}", path, std::process::id());
+        self.save(&tmp_path)?;
+        std::fs::rename(&tmp_path, path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            e
+        })
+    }
+
     fn load(path: &str) -> io::Result<Self> {
         let mut r = BufReader::new(std::fs::File::open(path)?);
         let magic = read_u64(&mut r)?;
@@ -642,7 +678,6 @@ impl SampledPathSteps {
 struct SampledPositionBuilder {
     sample_shift: u32,
     seed: u64,
-    sample_mask: u64,
     collect_positions: bool,
     position_samples: Vec<(u32, u64)>,
     path_step_offsets: Vec<u64>,
@@ -689,11 +724,6 @@ impl SampledPositionBuilder {
         Ok(Self {
             sample_shift,
             seed,
-            sample_mask: if sample_shift == 0 {
-                0
-            } else {
-                (1u64 << sample_shift) - 1
-            },
             collect_positions,
             position_samples: Vec::new(),
             path_step_offsets: vec![0; paths_seen + 1],
@@ -726,16 +756,7 @@ impl SampledPositionBuilder {
         for step in steps {
             let node_id = step.signed_node.unsigned_abs();
             let bp_pos = step.bp_pos;
-            if self.sample_shift > 0
-                && sampled_position_hash(
-                    node_id,
-                    path_idx,
-                    step.step_idx as usize,
-                    bp_pos,
-                    self.seed,
-                ) & self.sample_mask
-                    != 0
-            {
+            if !sample_regular_path_step(step.step_idx, self.sample_shift) {
                 continue;
             }
             if self.collect_positions {
@@ -917,26 +938,77 @@ fn decode_i32(value: u64) -> io::Result<i32> {
     })
 }
 
-fn splitmix64(mut value: u64) -> u64 {
-    value = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
-    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    value ^ (value >> 31)
+fn sample_regular_path_step(step_idx: u32, sample_shift: u32) -> bool {
+    if sample_shift == 0 {
+        true
+    } else {
+        let period = 1u64 << sample_shift;
+        (step_idx as u64) % period == 0
+    }
 }
 
-fn sampled_position_hash(
-    node_id: u32,
-    path_idx: usize,
-    node_idx: usize,
-    bp_pos: u64,
-    seed: u64,
-) -> u64 {
-    let mut value = seed;
-    value ^= (node_id as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
-    value ^= (path_idx as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    value ^= (node_idx as u64).wrapping_mul(0x94D0_49BB_1331_11EB);
-    value ^= bp_pos.rotate_left(17);
-    splitmix64(value)
+#[allow(clippy::too_many_arguments)]
+fn encode_regular_position_sample_if_selected(
+    path_start: u64,
+    sample_shift: u32,
+    collect_positions: bool,
+    step: PathStepRecord,
+    prev_sample_bp: &mut u64,
+    prev_sample_step: &mut u32,
+    path_step_sample_count: &mut u64,
+    position_samples: &mut Vec<(u32, u64)>,
+    path_step_data: &mut Vec<u8>,
+) -> io::Result<()> {
+    if !sample_regular_path_step(step.step_idx, sample_shift) {
+        return Ok(());
+    }
+
+    if collect_positions {
+        let global_pos = path_start.checked_add(step.bp_pos).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sampled path coordinate overflowed u64",
+            )
+        })?;
+        let packed = global_pos
+            .checked_mul(2)
+            .and_then(|p| p.checked_add(if step.signed_node >= 0 { 0 } else { 1 }))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "sampled packed coordinate overflowed u64",
+                )
+            })?;
+        position_samples.push((step.signed_node.unsigned_abs(), packed));
+    }
+
+    let bp_delta = step.bp_pos.checked_sub(*prev_sample_bp).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "sampled path-step bp positions are not sorted within path",
+        )
+    })?;
+    let step_delta = step.step_idx.checked_sub(*prev_sample_step).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "sampled path-step indices are not sorted within path",
+        )
+    })?;
+    push_varint(path_step_data, bp_delta);
+    push_varint(path_step_data, step_delta as u64);
+    push_varint(path_step_data, encode_i32(step.signed_node));
+    push_varint(path_step_data, encode_i32(step.prev_node));
+    push_varint(path_step_data, step.prev_offset as u64);
+    push_varint(path_step_data, step.traversal_rank as u64);
+    *prev_sample_bp = step.bp_pos;
+    *prev_sample_step = step.step_idx;
+    *path_step_sample_count = path_step_sample_count.checked_add(1).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "path-step sample count overflowed u64",
+        )
+    })?;
+    Ok(())
 }
 
 /// Parameters controlling syncmer extraction.
@@ -1863,14 +1935,14 @@ impl SyngIndex {
                 "cannot save syng index without sampled positions",
             )
         })?;
-        sampled_positions.save(&syng_spos_path(prefix))?;
+        sampled_positions.save_atomic(&syng_spos_path(prefix))?;
         let sampled_path_steps = self.sampled_path_steps.as_ref().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 "cannot save syng index without sampled path-step checkpoints",
             )
         })?;
-        sampled_path_steps.save(&syng_pstep_path(prefix))
+        sampled_path_steps.save_atomic(&syng_pstep_path(prefix))
     }
 
     /// Save only the inverted path-step sidecar for an existing syng index prefix.
@@ -1881,7 +1953,7 @@ impl SyngIndex {
                 "cannot save syng index without sampled path-step checkpoints",
             )
         })?;
-        sampled_path_steps.save(&syng_pstep_path(prefix))
+        sampled_path_steps.save_atomic(&syng_pstep_path(prefix))
     }
 
     /// Load an index from disk.
@@ -2007,12 +2079,21 @@ impl SyngIndex {
             match SampledPositions::load(&sampled_positions_path) {
                 Ok(sp) => Some(sp),
                 Err(e) => {
-                    unsafe {
-                        syng_ffi::syngBWTdestroy(gbwt);
-                        syng_ffi::kmerHashDestroy(kmer_hash);
-                        syng_ffi::impg_seqhashDestroy(seqhash);
+                    if !require_sampled_positions {
+                        log::warn!(
+                            "ignoring sampled-position sidecar during repair: {} ({})",
+                            sampled_positions_path,
+                            e
+                        );
+                        None
+                    } else {
+                        unsafe {
+                            syng_ffi::syngBWTdestroy(gbwt);
+                            syng_ffi::kmerHashDestroy(kmer_hash);
+                            syng_ffi::impg_seqhashDestroy(seqhash);
+                        }
+                        return Err(e);
                     }
-                    return Err(e);
                 }
             }
         } else if require_sampled_positions {
@@ -2038,12 +2119,21 @@ impl SyngIndex {
             match SampledPathSteps::load(&sampled_path_steps_path) {
                 Ok(ps) => Some(ps),
                 Err(e) => {
-                    unsafe {
-                        syng_ffi::syngBWTdestroy(gbwt);
-                        syng_ffi::kmerHashDestroy(kmer_hash);
-                        syng_ffi::impg_seqhashDestroy(seqhash);
+                    if !require_sampled_positions {
+                        log::warn!(
+                            "ignoring sampled path-step sidecar during repair: {} ({})",
+                            sampled_path_steps_path,
+                            e
+                        );
+                        None
+                    } else {
+                        unsafe {
+                            syng_ffi::syngBWTdestroy(gbwt);
+                            syng_ffi::kmerHashDestroy(kmer_hash);
+                            syng_ffi::impg_seqhashDestroy(seqhash);
+                        }
+                        return Err(e);
                     }
-                    return Err(e);
                 }
             }
         } else {
@@ -2246,6 +2336,353 @@ impl SyngIndex {
         let (sampled_path_steps, stats) = builder.finish_path_steps(self.name_map.path_to_name.len())?;
         self.sampled_path_steps = Some(sampled_path_steps);
         Ok(stats)
+    }
+
+    /// Rebuild both sampled positional sidecars by walking existing GBWT paths
+    /// in parallel. Sampling is a regular per-path syncmer-step grid.
+    pub fn rebuild_sampled_position_indexes_from_gbwt_parallel(
+        &mut self,
+        sample_shift: u32,
+        seed: u64,
+        progress_interval: usize,
+    ) -> io::Result<SampledPositionBuildStats> {
+        let (sampled_positions, sampled_path_steps, stats) =
+            self.rebuild_sampled_position_chunks_from_gbwt_parallel(
+                sample_shift,
+                seed,
+                true,
+                progress_interval,
+            )?;
+        let sampled_positions = sampled_positions.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "parallel positional repair did not build sampled positions",
+            )
+        })?;
+        self.sampled_positions = Some(sampled_positions);
+        self.sampled_path_steps = Some(sampled_path_steps);
+        Ok(stats)
+    }
+
+    /// Rebuild only the inverted path-step sidecar by walking existing GBWT
+    /// paths in parallel. Sampling is a regular per-path syncmer-step grid.
+    pub fn rebuild_sampled_path_steps_from_gbwt_parallel(
+        &mut self,
+        sample_shift: u32,
+        seed: u64,
+        progress_interval: usize,
+    ) -> io::Result<SampledPositionBuildStats> {
+        let (_, sampled_path_steps, stats) = self.rebuild_sampled_position_chunks_from_gbwt_parallel(
+            sample_shift,
+            seed,
+            false,
+            progress_interval,
+        )?;
+        self.sampled_path_steps = Some(sampled_path_steps);
+        Ok(stats)
+    }
+
+    fn rebuild_sampled_position_chunks_from_gbwt_parallel(
+        &self,
+        sample_shift: u32,
+        seed: u64,
+        collect_positions: bool,
+        progress_interval: usize,
+    ) -> io::Result<(
+        Option<SampledPositions>,
+        SampledPathSteps,
+        SampledPositionBuildStats,
+    )> {
+        if sample_shift >= 63 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "position sample shift must be less than 63",
+            ));
+        }
+        unsafe { syng_ffi::impg_syng_suppress_debug() };
+
+        let path_count = self.name_map.path_to_name.len();
+        let path_starts =
+            SampledPositions::path_starts_from_lengths(&self.name_map.path_to_length)?;
+        let syncmer_len = (self.params.k + self.params.w) as u64;
+        let total_steps: u64 = self
+            .name_map
+            .path_starts
+            .iter()
+            .filter_map(|start| start.as_ref())
+            .map(|start| start.num_syncmers as u64)
+            .sum();
+        let period = 1u64 << sample_shift;
+        log::info!(
+            "Parallel regular sampled-position rebuild: {} paths, {} syncmer steps, grid period {}, {} rayon threads",
+            path_count,
+            total_steps,
+            period,
+            rayon::current_num_threads()
+        );
+
+        let progress = Mutex::new(PositionRepairProgress::default());
+        let results: Vec<io::Result<EncodedPositionSampleChunk>> = (0..path_count)
+            .into_par_iter()
+            .map(|path_idx| {
+                let seq_len = self.name_map.path_to_length[path_idx];
+                let path_start = path_starts[path_idx];
+                let result = match self.name_map.path_starts.get(path_idx).and_then(|s| s.as_ref()) {
+                    Some(start) => self.encode_regular_position_sample_chunk(
+                        path_start,
+                        start,
+                        sample_shift,
+                        collect_positions,
+                    ),
+                    None if seq_len < syncmer_len => Ok(EncodedPositionSampleChunk {
+                        position_samples: Vec::new(),
+                        path_step_data: Vec::new(),
+                        path_step_sample_count: 0,
+                        walked_steps: 0,
+                    }),
+                    None => Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "cannot rebuild positional sidecars: missing GBWT path start for {}",
+                            self.name_map.path_to_name[path_idx]
+                        ),
+                    )),
+                };
+
+                if let Ok(chunk) = &result {
+                    let mut progress = progress.lock().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            "sampled-position repair progress lock was poisoned",
+                        )
+                    })?;
+                    progress.completed_paths += 1;
+                    progress.completed_steps =
+                        progress.completed_steps.checked_add(chunk.walked_steps).ok_or_else(
+                            || {
+                                io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    "sampled-position progress step count overflowed u64",
+                                )
+                            },
+                        )?;
+                    progress.completed_position_samples = progress
+                        .completed_position_samples
+                        .checked_add(chunk.position_samples.len() as u64)
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "sampled-position progress count overflowed u64",
+                            )
+                        })?;
+                    progress.completed_path_step_samples = progress
+                        .completed_path_step_samples
+                        .checked_add(chunk.path_step_sample_count)
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "path-step progress count overflowed u64",
+                            )
+                        })?;
+                    let done = progress.completed_paths;
+                    if progress_interval > 0
+                        && (done == path_count || done % progress_interval == 0)
+                    {
+                        let path_pct = if path_count > 0 {
+                            (done as f64 * 100.0) / path_count as f64
+                        } else {
+                            100.0
+                        };
+                        let step_pct = if total_steps > 0 {
+                            (progress.completed_steps as f64 * 100.0) / total_steps as f64
+                        } else {
+                            100.0
+                        };
+                        log::info!(
+                            "Sampled-position repair progress: {}/{} paths complete ({:.1}%), {}/{} syncmer steps ({:.1}%), {} node-position samples, {} path-step checkpoints; completed path {}/{} {}",
+                            done,
+                            path_count,
+                            path_pct,
+                            progress.completed_steps,
+                            total_steps,
+                            step_pct,
+                            progress.completed_position_samples,
+                            progress.completed_path_step_samples,
+                            path_idx + 1,
+                            path_count,
+                            self.name_map.path_to_name[path_idx]
+                        );
+                    }
+                }
+
+                result
+            })
+            .collect();
+
+        let mut position_samples = Vec::new();
+        let mut path_step_offsets = Vec::with_capacity(path_count + 1);
+        let mut path_step_data = Vec::new();
+        let mut path_step_sample_count = 0u64;
+        let mut sampled_step_paths = 0usize;
+        let mut walked_paths = 0usize;
+        path_step_offsets.push(0);
+
+        for result in results {
+            let chunk = result?;
+            if chunk.walked_steps > 0 {
+                walked_paths += 1;
+            }
+            if !chunk.path_step_data.is_empty() {
+                sampled_step_paths += 1;
+            }
+            path_step_sample_count = path_step_sample_count
+                .checked_add(chunk.path_step_sample_count)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "path-step sample count overflowed u64",
+                    )
+                })?;
+            if collect_positions {
+                position_samples.extend_from_slice(&chunk.position_samples);
+            }
+            path_step_data.extend_from_slice(&chunk.path_step_data);
+            path_step_offsets.push(path_step_data.len() as u64);
+        }
+
+        let sampled_path_steps = SampledPathSteps::from_encoded(
+            sample_shift,
+            seed,
+            path_step_sample_count,
+            path_step_offsets,
+            path_step_data,
+        )?;
+        let sampled_positions = if collect_positions {
+            Some(SampledPositions::from_samples(
+                sample_shift,
+                seed,
+                &self.name_map.path_to_length,
+                position_samples,
+            )?)
+        } else {
+            None
+        };
+        let stats = SampledPositionBuildStats {
+            sampled_occurrences: sampled_positions
+                .as_ref()
+                .map(|sp| sp.sample_count())
+                .unwrap_or(0),
+            sampled_nodes: sampled_positions
+                .as_ref()
+                .map(|sp| sp.node_count())
+                .unwrap_or(0),
+            sampled_path_steps: sampled_path_steps.sample_count(),
+            sampled_step_paths,
+            walked_paths,
+            sample_shift,
+        };
+        Ok((sampled_positions, sampled_path_steps, stats))
+    }
+
+    fn encode_regular_position_sample_chunk(
+        &self,
+        path_start: u64,
+        start: &GbwtPathStart,
+        sample_shift: u32,
+        collect_positions: bool,
+    ) -> io::Result<EncodedPositionSampleChunk> {
+        if start.num_syncmers == 0 {
+            return Ok(EncodedPositionSampleChunk {
+                position_samples: Vec::new(),
+                path_step_data: Vec::new(),
+                path_step_sample_count: 0,
+                walked_steps: 0,
+            });
+        }
+
+        let expected_steps = start.num_syncmers as usize;
+        let mut position_samples = Vec::new();
+        let mut path_step_data = Vec::new();
+        let mut path_step_sample_count = 0u64;
+        let mut prev_sample_bp = 0u64;
+        let mut prev_sample_step = 0u32;
+        let mut steps_seen = 0usize;
+
+        let mut state = self.path_state_from_start(start);
+        let mut acc_pos = start.first_syncmer_pos;
+        let first_step = PathStepRecord {
+            step_idx: 0,
+            bp_pos: acc_pos,
+            signed_node: start.start_node,
+            prev_node: 0,
+            prev_offset: 0,
+            traversal_rank: start.start_count,
+        };
+        encode_regular_position_sample_if_selected(
+            path_start,
+            sample_shift,
+            collect_positions,
+            first_step,
+            &mut prev_sample_bp,
+            &mut prev_sample_step,
+            &mut path_step_sample_count,
+            &mut position_samples,
+            &mut path_step_data,
+        )?;
+        steps_seen += 1;
+
+        let mut next_node: i32 = 0;
+        let mut offset: u32 = 0;
+        while unsafe { syng_ffi::syngBWTpathNext(&mut state, &mut next_node, &mut offset) } {
+            if steps_seen >= expected_steps {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "GBWT path has more steps than name map reports ({})",
+                        expected_steps
+                    ),
+                ));
+            }
+            acc_pos = acc_pos.checked_add(offset as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "GBWT path coordinate overflow")
+            })?;
+            let step = PathStepRecord {
+                step_idx: steps_seen as u32,
+                bp_pos: acc_pos,
+                signed_node: next_node,
+                prev_node: state.last_node,
+                prev_offset: offset,
+                traversal_rank: state.j_last,
+            };
+            encode_regular_position_sample_if_selected(
+                path_start,
+                sample_shift,
+                collect_positions,
+                step,
+                &mut prev_sample_bp,
+                &mut prev_sample_step,
+                &mut path_step_sample_count,
+                &mut position_samples,
+                &mut path_step_data,
+            )?;
+            steps_seen += 1;
+        }
+        if steps_seen != expected_steps {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "GBWT path has {} steps but name map reports {}",
+                    steps_seen, expected_steps
+                ),
+            ));
+        }
+
+        Ok(EncodedPositionSampleChunk {
+            position_samples,
+            path_step_data,
+            path_step_sample_count,
+            walked_steps: steps_seen as u64,
+        })
     }
 
     fn path_state_from_checkpoint(&self, checkpoint: &SampledPathStepHit) -> syng_ffi::SyngBWTpath {
@@ -4066,6 +4503,45 @@ mod tests {
     }
 
     #[test]
+    fn test_regular_sampled_positions_use_step_grid() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let mut index = SyngIndex::new(params);
+        index.enable_online_sampled_positions(3, 999).unwrap();
+        index.add_sequence(
+            "sampleA#0#chr1".to_string(),
+            make_test_sequence(12_000, 91),
+        );
+        index.finalize_online_sampled_positions().unwrap().unwrap();
+
+        let path_idx = *index.name_map.name_to_path.get("sampleA#0#chr1").unwrap() as usize;
+        let sampled_steps = index
+            .sampled_path_steps
+            .as_ref()
+            .unwrap()
+            .decode_path(path_idx)
+            .unwrap();
+        assert!(
+            sampled_steps.len() > 4,
+            "test sequence should produce several regular checkpoints"
+        );
+        assert_eq!(sampled_steps[0].step_idx, 0);
+        for step in &sampled_steps {
+            assert_eq!(
+                step.step_idx % 8,
+                0,
+                "regular sampled checkpoint is off-grid: {:?}",
+                step
+            );
+        }
+        assert_eq!(
+            index.sampled_positions.as_ref().unwrap().sample_count(),
+            index.sampled_path_steps.as_ref().unwrap().sample_count(),
+            "forward and inverted sidecars should sample the same path steps"
+        );
+    }
+
+    #[test]
     fn test_rebuild_sampled_position_indexes_from_gbwt_repairs_sidecars() {
         let _guard = lock_syng();
         let params = SyncmerParams::default();
@@ -4111,6 +4587,73 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    #[test]
+    fn test_parallel_regular_position_rebuild_matches_serial() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let seqs = vec![
+            ("sampleA#0#chr1".to_string(), make_test_sequence(5000, 21)),
+            ("sampleB#0#chr1".to_string(), make_test_sequence(4200, 22)),
+            ("sampleC#0#chr1".to_string(), make_test_sequence(3500, 23)),
+            ("short".to_string(), make_test_sequence(12, 24)),
+        ];
+        let mut index = SyngIndex::build(params, seqs.into_iter());
+
+        let dir = std::env::temp_dir().join("impg_test_syng_parallel_regular_repair");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prefix = dir.join("idx");
+        let prefix_str = prefix.to_str().unwrap();
+        index.save(prefix_str).unwrap();
+
+        let mut serial = SyngIndex::load_for_repair(prefix_str, params).unwrap();
+        let serial_stats = serial
+            .rebuild_sampled_position_indexes_from_gbwt(3, 11)
+            .unwrap();
+        let mut parallel = SyngIndex::load_for_repair(prefix_str, params).unwrap();
+        let parallel_stats = parallel
+            .rebuild_sampled_position_indexes_from_gbwt_parallel(3, 11, 0)
+            .unwrap();
+
+        assert_eq!(
+            serial_stats.sampled_occurrences,
+            parallel_stats.sampled_occurrences
+        );
+        assert_eq!(serial_stats.sampled_nodes, parallel_stats.sampled_nodes);
+        assert_eq!(
+            serial_stats.sampled_path_steps,
+            parallel_stats.sampled_path_steps
+        );
+        assert_eq!(
+            serial_stats.sampled_step_paths,
+            parallel_stats.sampled_step_paths
+        );
+        assert_eq!(serial_stats.walked_paths, parallel_stats.walked_paths);
+
+        let serial_positions = serial.sampled_positions.as_ref().unwrap();
+        let parallel_positions = parallel.sampled_positions.as_ref().unwrap();
+        assert_eq!(serial_positions.sample_count, parallel_positions.sample_count);
+        assert_eq!(serial_positions.path_starts, parallel_positions.path_starts);
+        assert_eq!(serial_positions.node_ids, parallel_positions.node_ids);
+        assert_eq!(serial_positions.byte_offsets, parallel_positions.byte_offsets);
+        assert_eq!(serial_positions.data, parallel_positions.data);
+
+        let serial_steps = serial.sampled_path_steps.as_ref().unwrap();
+        let parallel_steps = parallel.sampled_path_steps.as_ref().unwrap();
+        assert_eq!(serial_steps.sample_count(), parallel_steps.sample_count());
+        assert_eq!(serial_steps.path_count(), parallel_steps.path_count());
+        for path_idx in 0..serial_steps.path_count() {
+            assert_eq!(
+                serial_steps.decode_path(path_idx).unwrap(),
+                parallel_steps.decode_path(path_idx).unwrap(),
+                "path-step checkpoints differ for path {}",
+                path_idx
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     // ── 11. CLI integration test ────────────────────────────────────
 
     #[test]
@@ -4119,6 +4662,7 @@ mod tests {
         // Run `impg syng -f <fasta> -o <prefix>` via Command,
         // verify output files exist.
         let dir = std::env::temp_dir().join("impg_test_syng_cli");
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
 
         // Write a small synthetic FASTA

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -73,11 +73,10 @@ pub struct SampledPositionBuildStats {
     pub sampled_path_steps: u64,
     pub sampled_step_paths: usize,
     pub walked_paths: usize,
-    pub sample_shift: u32,
+    pub sample_rate: u32,
 }
 
-pub const DEFAULT_POSITION_SAMPLE_SHIFT: u32 = 8;
-pub const DEFAULT_POSITION_SAMPLE_SEED: u64 = 7;
+pub const DEFAULT_POSITION_SAMPLE_RATE: u32 = 256;
 
 fn syng_sidecar_path(prefix: &str, suffix: &str) -> String {
     if prefix.ends_with(".syng") {
@@ -127,8 +126,7 @@ pub fn syng_meta_path(prefix: &str) -> String {
 /// samples instead of materializing every visit for every node. Occurrences are
 /// grouped by syncmer node id and varint delta encoded.
 pub struct SampledPositions {
-    pub sample_shift: u32,
-    pub seed: u64,
+    pub sample_rate: u32,
     sample_count: u64,
     path_starts: Vec<u64>,
     node_ids: Vec<u32>,
@@ -138,14 +136,14 @@ pub struct SampledPositions {
 
 impl SampledPositions {
     const MAGIC: u64 = 0x494D50_53504F53; // "IMPSPOS"
-    const VERSION: u64 = 2;
+    const VERSION: u64 = 3;
 
     fn from_samples(
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         path_lengths: &[u64],
         mut samples: Vec<(u32, u64)>,
     ) -> io::Result<Self> {
+        validate_position_sample_rate(sample_rate)?;
         let path_starts = Self::path_starts_from_lengths(path_lengths)?;
         samples.sort_unstable();
         samples.dedup();
@@ -177,8 +175,7 @@ impl SampledPositions {
         }
 
         Ok(Self {
-            sample_shift,
-            seed,
+            sample_rate,
             sample_count,
             path_starts,
             node_ids,
@@ -259,8 +256,7 @@ impl SampledPositions {
         let mut w = BufWriter::new(std::fs::File::create(path)?);
         write_u64(&mut w, Self::MAGIC)?;
         write_u64(&mut w, Self::VERSION)?;
-        write_u64(&mut w, self.sample_shift as u64)?;
-        write_u64(&mut w, self.seed)?;
+        write_u64(&mut w, self.sample_rate as u64)?;
         write_u64(&mut w, self.sample_count)?;
 
         write_u64(&mut w, self.path_starts.len() as u64)?;
@@ -308,8 +304,8 @@ impl SampledPositions {
                 format!("SampledPositions: unsupported version {}", version),
             ));
         }
-        let sample_shift = read_u64(&mut r)? as u32;
-        let seed = read_u64(&mut r)?;
+        let sample_rate = read_u64(&mut r)? as u32;
+        validate_position_sample_rate(sample_rate)?;
         let sample_count = read_u64(&mut r)?;
 
         let n_paths = read_u64(&mut r)? as usize;
@@ -373,8 +369,7 @@ impl SampledPositions {
         }
 
         Ok(Self {
-            sample_shift,
-            seed,
+            sample_rate,
             sample_count,
             path_starts,
             node_ids,
@@ -391,8 +386,7 @@ impl SampledPositions {
 /// coordinate, including enough GBWT path state to resume walking from the
 /// sampled step.
 pub struct SampledPathSteps {
-    pub sample_shift: u32,
-    pub seed: u64,
+    pub sample_rate: u32,
     sample_count: u64,
     path_byte_offsets: Vec<u64>,
     data: Vec<u8>,
@@ -400,15 +394,15 @@ pub struct SampledPathSteps {
 
 impl SampledPathSteps {
     const MAGIC: u64 = 0x494D50_50535450; // "IMPPSTP"
-    const VERSION: u64 = 2;
+    const VERSION: u64 = 3;
 
     #[allow(dead_code)]
     fn from_samples(
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         path_count: usize,
         mut samples: Vec<(usize, PathStepRecord)>,
     ) -> io::Result<Self> {
+        validate_position_sample_rate(sample_rate)?;
         samples.sort_unstable_by(|a, b| {
             (a.0, a.1.bp_pos, a.1.step_idx).cmp(&(b.0, b.1.bp_pos, b.1.step_idx))
         });
@@ -466,16 +460,16 @@ impl SampledPathSteps {
             ));
         }
 
-        Self::from_encoded(sample_shift, seed, sample_count, path_byte_offsets, data)
+        Self::from_encoded(sample_rate, sample_count, path_byte_offsets, data)
     }
 
     fn from_encoded(
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         sample_count: u64,
         path_byte_offsets: Vec<u64>,
         data: Vec<u8>,
     ) -> io::Result<Self> {
+        validate_position_sample_rate(sample_rate)?;
         if path_byte_offsets.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -496,8 +490,7 @@ impl SampledPathSteps {
         }
 
         Ok(Self {
-            sample_shift,
-            seed,
+            sample_rate,
             sample_count,
             path_byte_offsets,
             data,
@@ -593,8 +586,7 @@ impl SampledPathSteps {
         let mut w = BufWriter::new(std::fs::File::create(path)?);
         write_u64(&mut w, Self::MAGIC)?;
         write_u64(&mut w, Self::VERSION)?;
-        write_u64(&mut w, self.sample_shift as u64)?;
-        write_u64(&mut w, self.seed)?;
+        write_u64(&mut w, self.sample_rate as u64)?;
         write_u64(&mut w, self.sample_count)?;
 
         write_u64(&mut w, self.path_byte_offsets.len() as u64)?;
@@ -632,8 +624,8 @@ impl SampledPathSteps {
                 format!("SampledPathSteps: unsupported version {}", version),
             ));
         }
-        let sample_shift = read_u64(&mut r)? as u32;
-        let seed = read_u64(&mut r)?;
+        let sample_rate = read_u64(&mut r)? as u32;
+        validate_position_sample_rate(sample_rate)?;
         let sample_count = read_u64(&mut r)?;
 
         let n_offsets = read_u64(&mut r)? as usize;
@@ -666,8 +658,7 @@ impl SampledPathSteps {
         }
 
         Ok(Self {
-            sample_shift,
-            seed,
+            sample_rate,
             sample_count,
             path_byte_offsets,
             data,
@@ -676,8 +667,7 @@ impl SampledPathSteps {
 }
 
 struct SampledPositionBuilder {
-    sample_shift: u32,
-    seed: u64,
+    sample_rate: u32,
     collect_positions: bool,
     position_samples: Vec<(u32, u64)>,
     path_step_offsets: Vec<u64>,
@@ -691,39 +681,30 @@ struct SampledPositionBuilder {
 
 impl SampledPositionBuilder {
     fn new(
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         next_path_start: u64,
         paths_seen: usize,
     ) -> io::Result<Self> {
-        Self::new_with_mode(sample_shift, seed, next_path_start, paths_seen, true)
+        Self::new_with_mode(sample_rate, next_path_start, paths_seen, true)
     }
 
     fn new_path_steps_only(
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         next_path_start: u64,
         paths_seen: usize,
     ) -> io::Result<Self> {
-        Self::new_with_mode(sample_shift, seed, next_path_start, paths_seen, false)
+        Self::new_with_mode(sample_rate, next_path_start, paths_seen, false)
     }
 
     fn new_with_mode(
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         next_path_start: u64,
         paths_seen: usize,
         collect_positions: bool,
     ) -> io::Result<Self> {
-        if sample_shift >= 63 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "position sample shift must be less than 63",
-            ));
-        }
+        validate_position_sample_rate(sample_rate)?;
         Ok(Self {
-            sample_shift,
-            seed,
+            sample_rate,
             collect_positions,
             position_samples: Vec::new(),
             path_step_offsets: vec![0; paths_seen + 1],
@@ -756,7 +737,7 @@ impl SampledPositionBuilder {
         for step in steps {
             let node_id = step.signed_node.unsigned_abs();
             let bp_pos = step.bp_pos;
-            if !sample_regular_path_step(step.step_idx, self.sample_shift) {
+            if !sample_regular_path_step(step.step_idx, self.sample_rate) {
                 continue;
             }
             if self.collect_positions {
@@ -808,8 +789,7 @@ impl SampledPositionBuilder {
         SampledPositionBuildStats,
     )> {
         let SampledPositionBuilder {
-            sample_shift,
-            seed,
+            sample_rate,
             position_samples,
             path_step_offsets,
             path_step_data,
@@ -818,14 +798,12 @@ impl SampledPositionBuilder {
             ..
         } = self;
         let sampled_positions = SampledPositions::from_samples(
-            sample_shift,
-            seed,
+            sample_rate,
             path_lengths,
             position_samples,
         )?;
         let sampled_path_steps = SampledPathSteps::from_encoded(
-            sample_shift,
-            seed,
+            sample_rate,
             path_step_sample_count,
             path_step_offsets,
             path_step_data,
@@ -846,7 +824,7 @@ impl SampledPositionBuilder {
             sampled_path_steps: sampled_path_steps.sample_count(),
             sampled_step_paths: sampled_path_steps.sampled_path_count(),
             walked_paths,
-            sample_shift,
+            sample_rate,
         };
         Ok((sampled_positions, sampled_path_steps, stats))
     }
@@ -855,7 +833,7 @@ impl SampledPositionBuilder {
         self,
         path_count: usize,
     ) -> io::Result<(SampledPathSteps, SampledPositionBuildStats)> {
-        let sample_shift = self.sample_shift;
+        let sample_rate = self.sample_rate;
         let walked_paths = self.walked_paths;
         let sampled_step_paths = self.sampled_step_paths;
         let sampled_path_steps = self.finish_path_steps_index(path_count)?;
@@ -865,7 +843,7 @@ impl SampledPositionBuilder {
             sampled_path_steps: sampled_path_steps.sample_count(),
             sampled_step_paths,
             walked_paths,
-            sample_shift,
+            sample_rate,
         };
         Ok((sampled_path_steps, stats))
     }
@@ -882,8 +860,7 @@ impl SampledPositionBuilder {
             ));
         }
         SampledPathSteps::from_encoded(
-            self.sample_shift,
-            self.seed,
+            self.sample_rate,
             self.path_step_sample_count,
             self.path_step_offsets,
             self.path_step_data,
@@ -938,19 +915,24 @@ fn decode_i32(value: u64) -> io::Result<i32> {
     })
 }
 
-fn sample_regular_path_step(step_idx: u32, sample_shift: u32) -> bool {
-    if sample_shift == 0 {
-        true
-    } else {
-        let period = 1u64 << sample_shift;
-        (step_idx as u64) % period == 0
+fn validate_position_sample_rate(sample_rate: u32) -> io::Result<()> {
+    if sample_rate == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "position sample rate must be greater than zero",
+        ));
     }
+    Ok(())
+}
+
+fn sample_regular_path_step(step_idx: u32, sample_rate: u32) -> bool {
+    (step_idx as u64) % (sample_rate as u64) == 0
 }
 
 #[allow(clippy::too_many_arguments)]
 fn encode_regular_position_sample_if_selected(
     path_start: u64,
-    sample_shift: u32,
+    sample_rate: u32,
     collect_positions: bool,
     step: PathStepRecord,
     prev_sample_bp: &mut u64,
@@ -959,7 +941,7 @@ fn encode_regular_position_sample_if_selected(
     position_samples: &mut Vec<(u32, u64)>,
     path_step_data: &mut Vec<u8>,
 ) -> io::Result<()> {
-    if !sample_regular_path_step(step.step_idx, sample_shift) {
+    if !sample_regular_path_step(step.step_idx, sample_rate) {
         return Ok(());
     }
 
@@ -1491,12 +1473,7 @@ impl SyngIndex {
             sampled_positions: None,
             sampled_path_steps: None,
             sampled_position_builder: Some(
-                SampledPositionBuilder::new(
-                    DEFAULT_POSITION_SAMPLE_SHIFT,
-                    DEFAULT_POSITION_SAMPLE_SEED,
-                    0,
-                    0,
-                )
+                SampledPositionBuilder::new(DEFAULT_POSITION_SAMPLE_RATE, 0, 0)
                 .expect("default sampled-position parameters are valid"),
             ),
         }
@@ -1572,15 +1549,21 @@ impl SyngIndex {
         self.sampled_path_steps.is_some()
     }
 
+    /// Sampling interval for the node-to-position sidecar, if present.
+    pub fn sampled_positions_rate(&self) -> Option<u32> {
+        self.sampled_positions.as_ref().map(|positions| positions.sample_rate)
+    }
+
+    /// Sampling interval for the path-step checkpoint sidecar, if present.
+    pub fn sampled_path_steps_rate(&self) -> Option<u32> {
+        self.sampled_path_steps.as_ref().map(|steps| steps.sample_rate)
+    }
+
     /// Enable online sampled-position collection for subsequently added paths.
     ///
     /// This should be called before adding any sequence. The sampled position
     /// index is intentionally built online as part of syng construction.
-    pub fn enable_online_sampled_positions(
-        &mut self,
-        sample_shift: u32,
-        seed: u64,
-    ) -> io::Result<()> {
+    pub fn enable_online_sampled_positions(&mut self, sample_rate: u32) -> io::Result<()> {
         let next_path_start = self
             .name_map
             .path_to_length
@@ -1593,8 +1576,7 @@ impl SyngIndex {
                 )
             })?;
         self.sampled_position_builder = Some(SampledPositionBuilder::new(
-            sample_shift,
-            seed,
+            sample_rate,
             next_path_start,
             self.name_map.path_to_name.len(),
         )?);
@@ -1630,7 +1612,7 @@ impl SyngIndex {
         sequences: impl Iterator<Item = (String, Vec<u8>)>,
     ) -> Self {
         let mut index = Self::new(params);
-        if let Err(e) = index.enable_online_sampled_positions(0, DEFAULT_POSITION_SAMPLE_SEED) {
+        if let Err(e) = index.enable_online_sampled_positions(1) {
             log::warn!(
                 "failed to enable exact sampled positions for in-memory build: {}",
                 e
@@ -2272,11 +2254,10 @@ impl SyngIndex {
     /// `.meta`, without re-decompressing sequences or reconstructing the graph.
     pub fn rebuild_sampled_position_indexes_from_gbwt(
         &mut self,
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
     ) -> io::Result<SampledPositionBuildStats> {
         unsafe { syng_ffi::impg_syng_suppress_debug() };
-        let mut builder = SampledPositionBuilder::new(sample_shift, seed, 0, 0)?;
+        let mut builder = SampledPositionBuilder::new(sample_rate, 0, 0)?;
         let syncmer_len = (self.params.k + self.params.w) as u64;
         for path_idx in 0..self.name_map.path_to_name.len() {
             let seq_len = self.name_map.path_to_length[path_idx];
@@ -2310,11 +2291,10 @@ impl SyngIndex {
     /// Rebuild only the inverted path-step sidecar by walking existing GBWT paths.
     pub fn rebuild_sampled_path_steps_from_gbwt(
         &mut self,
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
     ) -> io::Result<SampledPositionBuildStats> {
         unsafe { syng_ffi::impg_syng_suppress_debug() };
-        let mut builder = SampledPositionBuilder::new_path_steps_only(sample_shift, seed, 0, 0)?;
+        let mut builder = SampledPositionBuilder::new_path_steps_only(sample_rate, 0, 0)?;
         let syncmer_len = (self.params.k + self.params.w) as u64;
         for path_idx in 0..self.name_map.path_to_name.len() {
             let seq_len = self.name_map.path_to_length[path_idx];
@@ -2342,14 +2322,12 @@ impl SyngIndex {
     /// in parallel. Sampling is a regular per-path syncmer-step grid.
     pub fn rebuild_sampled_position_indexes_from_gbwt_parallel(
         &mut self,
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         progress_interval: usize,
     ) -> io::Result<SampledPositionBuildStats> {
         let (sampled_positions, sampled_path_steps, stats) =
             self.rebuild_sampled_position_chunks_from_gbwt_parallel(
-                sample_shift,
-                seed,
+                sample_rate,
                 true,
                 progress_interval,
             )?;
@@ -2368,13 +2346,11 @@ impl SyngIndex {
     /// paths in parallel. Sampling is a regular per-path syncmer-step grid.
     pub fn rebuild_sampled_path_steps_from_gbwt_parallel(
         &mut self,
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         progress_interval: usize,
     ) -> io::Result<SampledPositionBuildStats> {
         let (_, sampled_path_steps, stats) = self.rebuild_sampled_position_chunks_from_gbwt_parallel(
-            sample_shift,
-            seed,
+            sample_rate,
             false,
             progress_interval,
         )?;
@@ -2384,8 +2360,7 @@ impl SyngIndex {
 
     fn rebuild_sampled_position_chunks_from_gbwt_parallel(
         &self,
-        sample_shift: u32,
-        seed: u64,
+        sample_rate: u32,
         collect_positions: bool,
         progress_interval: usize,
     ) -> io::Result<(
@@ -2393,12 +2368,7 @@ impl SyngIndex {
         SampledPathSteps,
         SampledPositionBuildStats,
     )> {
-        if sample_shift >= 63 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "position sample shift must be less than 63",
-            ));
-        }
+        validate_position_sample_rate(sample_rate)?;
         unsafe { syng_ffi::impg_syng_suppress_debug() };
 
         let path_count = self.name_map.path_to_name.len();
@@ -2412,12 +2382,11 @@ impl SyngIndex {
             .filter_map(|start| start.as_ref())
             .map(|start| start.num_syncmers as u64)
             .sum();
-        let period = 1u64 << sample_shift;
         log::info!(
             "Parallel regular sampled-position rebuild: {} paths, {} syncmer steps, grid period {}, {} rayon threads",
             path_count,
             total_steps,
-            period,
+            sample_rate,
             rayon::current_num_threads()
         );
 
@@ -2431,7 +2400,7 @@ impl SyngIndex {
                     Some(start) => self.encode_regular_position_sample_chunk(
                         path_start,
                         start,
-                        sample_shift,
+                        sample_rate,
                         collect_positions,
                     ),
                     None if seq_len < syncmer_len => Ok(EncodedPositionSampleChunk {
@@ -2551,16 +2520,14 @@ impl SyngIndex {
         }
 
         let sampled_path_steps = SampledPathSteps::from_encoded(
-            sample_shift,
-            seed,
+            sample_rate,
             path_step_sample_count,
             path_step_offsets,
             path_step_data,
         )?;
         let sampled_positions = if collect_positions {
             Some(SampledPositions::from_samples(
-                sample_shift,
-                seed,
+                sample_rate,
                 &self.name_map.path_to_length,
                 position_samples,
             )?)
@@ -2579,7 +2546,7 @@ impl SyngIndex {
             sampled_path_steps: sampled_path_steps.sample_count(),
             sampled_step_paths,
             walked_paths,
-            sample_shift,
+            sample_rate,
         };
         Ok((sampled_positions, sampled_path_steps, stats))
     }
@@ -2588,7 +2555,7 @@ impl SyngIndex {
         &self,
         path_start: u64,
         start: &GbwtPathStart,
-        sample_shift: u32,
+        sample_rate: u32,
         collect_positions: bool,
     ) -> io::Result<EncodedPositionSampleChunk> {
         if start.num_syncmers == 0 {
@@ -2620,7 +2587,7 @@ impl SyngIndex {
         };
         encode_regular_position_sample_if_selected(
             path_start,
-            sample_shift,
+            sample_rate,
             collect_positions,
             first_step,
             &mut prev_sample_bp,
@@ -2656,7 +2623,7 @@ impl SyngIndex {
             };
             encode_regular_position_sample_if_selected(
                 path_start,
-                sample_shift,
+                sample_rate,
                 collect_positions,
                 step,
                 &mut prev_sample_bp,
@@ -3414,7 +3381,7 @@ impl SyngIndex {
     /// called on a freshly constructed index).
     pub fn build_region_gbwt(&self, sequences: &[(String, &[u8])], prefix: &str) -> io::Result<()> {
         let mut region_index = SyngIndex::new(self.params);
-        region_index.enable_online_sampled_positions(0, DEFAULT_POSITION_SAMPLE_SEED)?;
+        region_index.enable_online_sampled_positions(1)?;
         for (name, seq) in sequences {
             region_index.add_sequence(name.clone(), seq.to_vec());
         }
@@ -3679,7 +3646,7 @@ mod tests {
 
         let mut index = SyngIndex::new_with_packed_syncmer_dictionary(params, &dictionary).unwrap();
         index
-            .enable_online_sampled_positions(0, DEFAULT_POSITION_SAMPLE_SEED)
+            .enable_online_sampled_positions(1)
             .unwrap();
         for (name, seq) in sequences {
             let stats = index
@@ -4320,7 +4287,7 @@ mod tests {
         seq_b.extend_from_slice(&make_test_sequence(400, 2));
 
         let mut index = SyngIndex::new(params);
-        index.enable_online_sampled_positions(0, 7).unwrap();
+        index.enable_online_sampled_positions(1).unwrap();
         index.add_sequence("sampleA#0#chr1".to_string(), seq_a);
         index.add_sequence("sampleB#0#chr1".to_string(), seq_b);
         let stats = index.finalize_online_sampled_positions().unwrap().unwrap();
@@ -4391,7 +4358,7 @@ mod tests {
         let params = SyncmerParams::default();
         let seq = make_test_sequence(5000, 123);
         let mut index = SyngIndex::new(params);
-        index.enable_online_sampled_positions(0, 7).unwrap();
+        index.enable_online_sampled_positions(1).unwrap();
         index.add_sequence("sampleA#0#chr1".to_string(), seq);
         index.finalize_online_sampled_positions().unwrap().unwrap();
 
@@ -4450,7 +4417,7 @@ mod tests {
         let syncmer_len = (params.k + params.w) as u64;
         let seq = make_test_sequence(12_000, 77);
         let mut index = SyngIndex::new(params);
-        index.enable_online_sampled_positions(4, 7).unwrap();
+        index.enable_online_sampled_positions(16).unwrap();
         index.add_sequence("sampleA#0#chr1".to_string(), seq);
         index.finalize_online_sampled_positions().unwrap().unwrap();
 
@@ -4507,7 +4474,7 @@ mod tests {
         let _guard = lock_syng();
         let params = SyncmerParams::default();
         let mut index = SyngIndex::new(params);
-        index.enable_online_sampled_positions(3, 999).unwrap();
+        index.enable_online_sampled_positions(8).unwrap();
         index.add_sequence(
             "sampleA#0#chr1".to_string(),
             make_test_sequence(12_000, 91),
@@ -4564,7 +4531,7 @@ mod tests {
         assert!(!repair.has_sampled_positions());
         assert!(!repair.has_sampled_path_steps());
         let stats = repair
-            .rebuild_sampled_position_indexes_from_gbwt(0, DEFAULT_POSITION_SAMPLE_SEED)
+            .rebuild_sampled_position_indexes_from_gbwt(1)
             .unwrap();
         assert!(stats.sampled_occurrences > 0);
         assert_eq!(stats.sampled_occurrences, stats.sampled_path_steps);
@@ -4608,11 +4575,11 @@ mod tests {
 
         let mut serial = SyngIndex::load_for_repair(prefix_str, params).unwrap();
         let serial_stats = serial
-            .rebuild_sampled_position_indexes_from_gbwt(3, 11)
+            .rebuild_sampled_position_indexes_from_gbwt(8)
             .unwrap();
         let mut parallel = SyngIndex::load_for_repair(prefix_str, params).unwrap();
         let parallel_stats = parallel
-            .rebuild_sampled_position_indexes_from_gbwt_parallel(3, 11, 0)
+            .rebuild_sampled_position_indexes_from_gbwt_parallel(8, 0)
             .unwrap();
 
         assert_eq!(
@@ -5646,8 +5613,8 @@ mod tests {
                 fasta_path.to_str().unwrap(),
                 "-o",
                 output_prefix.to_str().unwrap(),
-                "--position-sample-shift",
-                "0",
+                "--position-sample-rate",
+                "1",
             ])
             .output()
             .expect("Failed to run impg syng");
@@ -5732,8 +5699,8 @@ mod tests {
                 fasta_path.to_str().unwrap(),
                 "-o",
                 output_prefix.to_str().unwrap(),
-                "--position-sample-shift",
-                "0",
+                "--position-sample-rate",
+                "1",
             ])
             .output()
             .expect("Failed to run impg syng");
@@ -6444,8 +6411,8 @@ mod tests {
                 fasta_path.to_str().unwrap(),
                 "-o",
                 idx_prefix.to_str().unwrap(),
-                "--position-sample-shift",
-                "0",
+                "--position-sample-rate",
+                "1",
             ])
             .output()
             .expect("Failed to run impg syng");

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -136,7 +136,7 @@ pub struct SampledPositions {
 
 impl SampledPositions {
     const MAGIC: u64 = 0x494D50_53504F53; // "IMPSPOS"
-    const VERSION: u64 = 3;
+    const VERSION: u64 = 4;
 
     fn from_samples(
         sample_rate: u32,
@@ -394,7 +394,7 @@ pub struct SampledPathSteps {
 
 impl SampledPathSteps {
     const MAGIC: u64 = 0x494D50_50535450; // "IMPPSTP"
-    const VERSION: u64 = 3;
+    const VERSION: u64 = 4;
 
     #[allow(dead_code)]
     fn from_samples(
@@ -734,10 +734,11 @@ impl SampledPositionBuilder {
         let path_step_start = self.path_step_data.len();
         let mut prev_bp = 0u64;
         let mut prev_step = 0u32;
+        let last_step_idx = steps.last().map(|step| step.step_idx).unwrap_or(0);
         for step in steps {
             let node_id = step.signed_node.unsigned_abs();
             let bp_pos = step.bp_pos;
-            if !sample_regular_path_step(step.step_idx, self.sample_rate) {
+            if !sample_path_step(step.step_idx, self.sample_rate, last_step_idx) {
                 continue;
             }
             if self.collect_positions {
@@ -925,14 +926,15 @@ fn validate_position_sample_rate(sample_rate: u32) -> io::Result<()> {
     Ok(())
 }
 
-fn sample_regular_path_step(step_idx: u32, sample_rate: u32) -> bool {
-    (step_idx as u64) % (sample_rate as u64) == 0
+fn sample_path_step(step_idx: u32, sample_rate: u32, last_step_idx: u32) -> bool {
+    (step_idx as u64) % (sample_rate as u64) == 0 || step_idx == last_step_idx
 }
 
 #[allow(clippy::too_many_arguments)]
 fn encode_regular_position_sample_if_selected(
     path_start: u64,
     sample_rate: u32,
+    last_step_idx: u32,
     collect_positions: bool,
     step: PathStepRecord,
     prev_sample_bp: &mut u64,
@@ -941,7 +943,7 @@ fn encode_regular_position_sample_if_selected(
     position_samples: &mut Vec<(u32, u64)>,
     path_step_data: &mut Vec<u8>,
 ) -> io::Result<()> {
-    if !sample_regular_path_step(step.step_idx, sample_rate) {
+    if !sample_path_step(step.step_idx, sample_rate, last_step_idx) {
         return Ok(());
     }
 
@@ -2568,6 +2570,12 @@ impl SyngIndex {
         }
 
         let expected_steps = start.num_syncmers as usize;
+        let last_step_idx = u32::try_from(expected_steps - 1).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "GBWT path step count exceeds u32",
+            )
+        })?;
         let mut position_samples = Vec::new();
         let mut path_step_data = Vec::new();
         let mut path_step_sample_count = 0u64;
@@ -2588,6 +2596,7 @@ impl SyngIndex {
         encode_regular_position_sample_if_selected(
             path_start,
             sample_rate,
+            last_step_idx,
             collect_positions,
             first_step,
             &mut prev_sample_bp,
@@ -2624,6 +2633,7 @@ impl SyngIndex {
             encode_regular_position_sample_if_selected(
                 path_start,
                 sample_rate,
+                last_step_idx,
                 collect_positions,
                 step,
                 &mut prev_sample_bp,
@@ -4470,7 +4480,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regular_sampled_positions_use_step_grid() {
+    fn test_regular_sampled_positions_use_step_grid_and_terminal_step() {
         let _guard = lock_syng();
         let params = SyncmerParams::default();
         let mut index = SyngIndex::new(params);
@@ -4482,6 +4492,9 @@ mod tests {
         index.finalize_online_sampled_positions().unwrap().unwrap();
 
         let path_idx = *index.name_map.name_to_path.get("sampleA#0#chr1").unwrap() as usize;
+        let path_start = index.name_map.path_starts[path_idx].as_ref().unwrap();
+        let full_steps = index.walk_path_steps(path_start).unwrap();
+        let last_step_idx = full_steps.last().unwrap().step_idx;
         let sampled_steps = index
             .sampled_path_steps
             .as_ref()
@@ -4493,10 +4506,10 @@ mod tests {
             "test sequence should produce several regular checkpoints"
         );
         assert_eq!(sampled_steps[0].step_idx, 0);
+        assert_eq!(sampled_steps.last().unwrap().step_idx, last_step_idx);
         for step in &sampled_steps {
-            assert_eq!(
-                step.step_idx % 8,
-                0,
+            assert!(
+                step.step_idx % 8 == 0 || step.step_idx == last_step_idx,
                 "regular sampled checkpoint is off-grid: {:?}",
                 step
             );
@@ -4505,6 +4518,40 @@ mod tests {
             index.sampled_positions.as_ref().unwrap().sample_count(),
             index.sampled_path_steps.as_ref().unwrap().sample_count(),
             "forward and inverted sidecars should sample the same path steps"
+        );
+    }
+
+    #[test]
+    fn test_terminal_sampled_for_short_paths() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let mut index = SyngIndex::new(params);
+        index.enable_online_sampled_positions(256).unwrap();
+        index.add_sequence(
+            "sampleA#0#chr1".to_string(),
+            make_test_sequence(2_000, 92),
+        );
+        index.finalize_online_sampled_positions().unwrap().unwrap();
+
+        let path_idx = *index.name_map.name_to_path.get("sampleA#0#chr1").unwrap() as usize;
+        let path_start = index.name_map.path_starts[path_idx].as_ref().unwrap();
+        let full_steps = index.walk_path_steps(path_start).unwrap();
+        assert!(
+            full_steps.len() > 1 && full_steps.len() < 256,
+            "test setup should produce a short nonempty syncmer path"
+        );
+
+        let sampled_steps = index
+            .sampled_path_steps
+            .as_ref()
+            .unwrap()
+            .decode_path(path_idx)
+            .unwrap();
+        assert_eq!(sampled_steps.len(), 2);
+        assert_eq!(sampled_steps[0].step_idx, 0);
+        assert_eq!(
+            sampled_steps[1].step_idx,
+            full_steps.last().unwrap().step_idx
         );
     }
 
@@ -4854,12 +4901,15 @@ mod tests {
         seq_a.extend_from_slice(&make_test_sequence(400, 1));
         let mut seq_b = shared.clone();
         seq_b.extend_from_slice(&make_test_sequence(400, 2));
-        let seqs = vec![("ga".to_string(), seq_a.clone()), ("gb".to_string(), seq_b)];
+        let mut index = SyngIndex::new(params);
+        index.enable_online_sampled_positions(16).unwrap();
+        index.add_sequence("ga".to_string(), seq_a.clone());
+        index.add_sequence("gb".to_string(), seq_b);
+        index.finalize_online_sampled_positions().unwrap().unwrap();
 
-        let index = SyngIndex::build(params, seqs.into_iter());
-        let path_intervals = index.query_region("ga", 0, 1000, 120).unwrap();
+        let path_intervals = index.query_region("ga", 200, 800, 120).unwrap();
         let sequence_intervals = index
-            .query_region_from_sequence_ext(&seq_a, 0, 0, 1000, 120, 0)
+            .query_region_from_sequence_ext(&seq_a, 0, 200, 800, 120, 0)
             .unwrap();
 
         let to_set =

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -205,8 +205,8 @@ fn test_syng_agc_roundtrip_query() {
             agc_path.to_str().unwrap(),
             "-o",
             out_prefix_str,
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("Failed to run impg syng --agc");
@@ -291,8 +291,8 @@ fn test_syng_agc_parallel_dictionary_roundtrip_query() {
             "--parallel-dictionary",
             "-o",
             out_prefix_str,
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("Failed to run impg syng --agc --parallel-dictionary");
@@ -501,8 +501,8 @@ fn test_syng_map_cli_gaf_and_paf() {
             fasta_path.to_str().unwrap(),
             "-o",
             idx_prefix.to_str().unwrap(),
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("failed to run impg syng");
@@ -635,8 +635,8 @@ fn test_syng_map_cli_sampled_positions_paf() {
             fasta_path.to_str().unwrap(),
             "-o",
             idx_prefix.to_str().unwrap(),
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("failed to run impg syng with sampled positions");
@@ -742,8 +742,8 @@ fn test_syng_identical_sequences_build_and_query() {
             fasta_path.to_str().unwrap(),
             "-o",
             out_prefix.to_str().unwrap(),
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("impg syng failed to run");
@@ -831,8 +831,8 @@ fn test_partition_syng_end_to_end_bed() {
             fasta_path.to_str().unwrap(),
             "-o",
             syng_prefix.to_str().unwrap(),
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("Failed to run impg syng");
@@ -954,8 +954,8 @@ fn test_query_syng_gfa_subwindow_splitter() {
             fasta_path.to_str().unwrap(),
             "-o",
             syng_prefix.to_str().unwrap(),
-            "--position-sample-shift",
-            "0",
+            "--position-sample-rate",
+            "1",
         ])
         .output()
         .expect("Failed to run impg syng");


### PR DESCRIPTION
## Summary
- replace `--position-sample-shift` with explicit `--position-sample-rate` on syng build and repair
- remove the unused positional sampling seed and bump `.spos` / `.pstep` sidecar versions
- make `syng-repair` rebuild stale or differently sampled sidecars instead of no-oping on filenames

## Tests
- `cargo check`
- `cargo test regular --lib -- --nocapture`
- `cargo test syng --lib -- --nocapture`
- `cargo test --test test_syng_integration -- --nocapture`
- rebuilt HPRCv2 `.spos/.pstep` with `--position-sample-rate 256 -t 32`
