### PR TITLE
Require explicit merge distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ your LLVM install (see `env -i … LIBCLANG_PATH=…`).
 ## Quick start
 
 ```bash
-impg query -a cerevisiae.pan.paf.gz -r S288C#1#chrI:50000-100000 -x
+impg query -a cerevisiae.pan.paf.gz -r S288C#1#chrI:50000-100000 -d 1000 -x
 ```
 
 - `-a` — alignment file (PAF / 1ALN / TPA). PAF must use `=`/`X` CIGAR ops
   (from `wfmash` or `minimap2 --eqx`).
 - `-r` — target range, `seq:start-end`.
+- `-d` — merge query-gathered ranges separated by up to this many bp.
+  This is also the largest internal gap/SV one query hop can absorb into
+  one reported interval.
 - `-x` — walk the transitive closure: find everything aligned to the
   initial result, recursively.
 
@@ -104,31 +107,31 @@ exhaustive flag list — this section covers the flags you'll actually turn.
 
 ```bash
 # A single range
-impg query -a aln.paf -r chr1:1000-2000
+impg query -a aln.paf -r chr1:1000-2000 -d 100
 
 # Transitive closure (depth 2 by default)
-impg query -a aln.paf -r chr1:1000-2000 -x -m 3
+impg query -a aln.paf -r chr1:1000-2000 -d 100 -x -m 3
 
 # Many regions from a BED, mixed PAF + 1ALN
-impg query -a f1.paf f2.1aln -b regions.bed
+impg query -a f1.paf f2.1aln -b regions.bed -d 100
 
 # Output formats: auto | bed | bedpe | paf | gfa | maf | fasta | fasta+paf | fasta-aln
-impg query -a aln.paf -r chr1:1000-2000 -o bed
-impg query -a aln.paf -r chr1:1000-2000 -o gfa --sequence-files genomes.fa
-impg query -a aln.1aln -r chr1:1000-2000 -o fasta --sequence-files *.fa \
+impg query -a aln.paf -r chr1:1000-2000 -d 100 -o bed
+impg query -a aln.paf -r chr1:1000-2000 -d 100 -o gfa --sequence-files genomes.fa
+impg query -a aln.1aln -r chr1:1000-2000 -d 100 -o fasta --sequence-files *.fa \
            --reverse-complement
 
 # Filter / shape the result
 impg query -a aln.paf -r chr1:1000-2000 --min-identity 0.9 -l 5000 -d 1000
 
 # Restrict to a sequence whitelist (also filters transitive intermediates)
-impg query -a aln.paf -r chr1:1000-2000 -x --subset-sequence-list seqs.txt
+impg query -a aln.paf -r chr1:1000-2000 -d 100 -x --subset-sequence-list seqs.txt
 
 # Fast approximate mode (.1aln only; bed/bedpe output)
-impg query -a aln.1aln -r chr1:1000-2000 --approximate
+impg query -a aln.1aln -r chr1:1000-2000 -d 100 --approximate
 
 # Alignment-free path: -a accepts a syng index prefix (see `syng` below)
-impg query -a pan.syng -r chr1:1000-2000 --sequence-files genomes.fa
+impg query -a pan.syng -r chr1:1000-2000 -d 100 --sequence-files genomes.fa
 ```
 
 GFA / MAF / FASTA outputs need `--sequence-files` (FASTA or AGC
@@ -162,26 +165,26 @@ sequence files for `query`; FASTAs directly for `graph`).
 
 ```bash
 # 1Mb windows, single BED output
-impg partition -a aln.paf -w 1000000
+impg partition -a aln.paf -w 1000000 -d 100000
 
 # One FASTA per partition (for downstream pipelines)
-impg partition -a aln.1aln -w 1000000 -o fasta --sequence-files *.fa \
+impg partition -a aln.1aln -w 1000000 -d 100000 -o fasta --sequence-files *.fa \
                --separate-files --output-folder partitions/
 
 # Selection strategies pick the next starting sequence
-impg partition -a aln.paf -w 1000000 --selection-mode longest     # default
-impg partition -a aln.paf -w 1000000 --selection-mode sample      # PanSN sample
-impg partition -a aln.paf -w 1000000 --selection-mode haplotype   # PanSN haplotype
+impg partition -a aln.paf -w 1000000 -d 100000 --selection-mode longest     # default
+impg partition -a aln.paf -w 1000000 -d 100000 --selection-mode sample      # PanSN sample
+impg partition -a aln.paf -w 1000000 -d 100000 --selection-mode haplotype   # PanSN haplotype
 
 # Start from a fixed list of sequences
-impg partition -a aln.paf -w 1000000 --starting-sequences-file seqs.txt
+impg partition -a aln.paf -w 1000000 -d 100000 --starting-sequences-file seqs.txt
 
 # GFA output per partition; engines: pggb | seqwish | poa
-impg partition -a aln.paf -w 1000000 -o gfa --gfa-engine pggb \
+impg partition -a aln.paf -w 1000000 -d 100000 -o gfa --gfa-engine pggb \
                --sequence-files *.fa --separate-files --output-folder gfas/
 
 # Fully partitioned pipeline: build → lace → one gfaffix pass
-impg partition -a aln.paf -w 100000 -o gfa --gfa-engine pggb:10000 \
+impg partition -a aln.paf -w 100000 -d 100000 -o gfa --gfa-engine pggb:10000 \
                --sequence-files *.fa --output-folder results/
 ```
 
@@ -303,7 +306,7 @@ impg syng -f chr6.C4.fa -o c4.syng \
 
 # 3. Query a 10 kb grch38 sub-window onto all 90 haplotypes
 impg query -a c4.syng -r 'grch38#chr6:31972046-32055647:0-10000' \
-           --sequence-files chr6.C4.fa | head -3
+           -d 150 --sequence-files chr6.C4.fa | head -3
 # HG00673#1#JAHBBZ010000030.1:31835924-31919525  0  10000  grch38...:0-10000  .  +
 # HG01123#2#JAGYYY010000050.1:31954985-32038586  0  10001  grch38...:0-10000  .  +
 # HG01243#1#JAHEOY010000117.1:3252171-3329407    0   9999  grch38...:0-10000  .  +
@@ -311,7 +314,7 @@ impg query -a c4.syng -r 'grch38#chr6:31972046-32055647:0-10000' \
 # 4. Whole grch38 C4 path (length from .fai) → 36 hits, FASTA out
 LEN=$(awk -F'\t' '$1=="grch38#chr6:31972046-32055647"{print $2}' chr6.C4.fa.fai)
 impg query -a c4.syng -r "grch38#chr6:31972046-32055647:0-${LEN}" \
-           --sequence-files chr6.C4.fa -o fasta > c4.homologs.fa
+           -d 150 --sequence-files chr6.C4.fa -o fasta > c4.homologs.fa
 
 # 5. Map a 2 kb probe back onto the index
 samtools faidx chr6.C4.fa 'grch38#chr6:31972046-32055647:5000-7000' > probe.fa
@@ -354,9 +357,9 @@ Append `:WINDOW` to any engine to build per-window and lace:
 
 ```bash
 impg query    -a aln.paf -r chr1:0-500000 -o gfa \
-              --gfa-engine pggb:10000 --sequence-files *.fa -O out
+              -d 1000 --gfa-engine pggb:10000 --sequence-files *.fa -O out
 impg graph    --sequence-files *.fa -g out.gfa --gfa-engine seqwish:10000
-impg partition -a aln.paf -w 100000 -o gfa --gfa-engine pggb:10000 \
+impg partition -a aln.paf -w 100000 -d 100000 -o gfa --gfa-engine pggb:10000 \
                --sequence-files *.fa --output-folder results/
 ```
 
@@ -412,7 +415,9 @@ with `--fastga-frequency` is rejected at parse time.
 - `-i / --index` — existing IMPG index.
 - `-f / --force-reindex` — rebuild even if the index is up-to-date.
 - `-t / --threads` — default `4`.
-- `-d / --merge-distance` — merge nearby hits within this gap (bp).
+- `-d / --merge-distance` — required for query/partition/refine/similarity:
+  merge query-gathered ranges within this gap (bp). This is the largest
+  internal gap/SV one query hop can absorb into one reported interval.
 - `--no-merge` — disable merging.
 - `--consider-strandness` — keep strands separate during merge.
 - `--subset-sequence-list` — restrict results to listed sequences.
@@ -435,7 +440,7 @@ impg index -a "$PAF" -i yeast.impg -t "$THREADS"
 # 2. Partition into 100kb windows, one FASTA per window
 mkdir -p partitions gfas
 impg partition -i yeast.impg -w 100000 \
-    --sequence-files "$FASTA" -o fasta \
+    -d 100000 --sequence-files "$FASTA" -o fasta \
     --separate-files --output-folder partitions -t "$THREADS"
 
 # 3. Build per-partition GFAs in parallel
@@ -467,7 +472,7 @@ interactive HTML MSA using [react-msa](https://github.com/GMOD/JBrowseMSA)
 or [ProSeqViewer](https://github.com/BioComputingUP/ProSeqViewer).
 
 ```bash
-impg query -a aln.paf -r chr1:1000-2000 -o fasta-aln --sequence-files *.fa \
+impg query -a aln.paf -r chr1:1000-2000 -d 100 -o fasta-aln --sequence-files *.fa \
   | python scripts/faln2html.py -i - -o alignment.html [--tool proseqviewer]
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1106,6 +1106,34 @@ impl TransitiveOpts {
     }
 }
 
+const MERGE_DISTANCE_REQUIRED_TEXT: &str = "\
+-d/--merge-distance is required. It merges ranges gathered during query before \
+output or partitioning: ranges separated by at most D bp are treated as one \
+range. D is also the largest internal gap/SV that a one-hop query can absorb \
+inside one reported interval; larger gaps remain split. Pick D for your locus \
+(use 0 for only overlapping/touching ranges).";
+
+fn missing_merge_distance_error(command: &str, allow_no_merge: bool) -> io::Error {
+    let mut msg =
+        format!("{MERGE_DISTANCE_REQUIRED_TEXT}\n\nFor `impg {command}`, pass `-d <bp>`.");
+    if allow_no_merge {
+        msg.push_str(" Use `--no-merge` to explicitly disable merging.");
+    }
+    io::Error::new(io::ErrorKind::InvalidInput, msg)
+}
+
+fn require_merge_distance(
+    command: &str,
+    merge_distance: Option<i32>,
+    no_merge: bool,
+) -> io::Result<i32> {
+    if no_merge {
+        Ok(-1)
+    } else {
+        merge_distance.ok_or_else(|| missing_merge_distance_error(command, true))
+    }
+}
+
 /// Common query and filtering options
 #[derive(Parser, Debug, Clone)]
 struct QueryOpts {
@@ -1119,18 +1147,15 @@ struct QueryOpts {
     #[clap(short = 'b', long, value_parser, conflicts_with = "target_range")]
     target_bed: Option<String>,
 
-    /// Maximum distance between regions to merge
+    /// Required. Merge query-gathered ranges separated by at most this many bp.
+    /// This also sets the largest internal gap/SV one query hop can absorb into
+    /// one reported interval; larger gaps stay split. Use 0 for only
+    /// overlapping/touching ranges, or --no-merge to disable merging.
     #[arg(help_heading = "Filtering and merging")]
-    #[clap(
-        short = 'd',
-        long,
-        value_parser,
-        conflicts_with = "no_merge",
-        default_value_t = 0
-    )]
-    merge_distance: i32,
+    #[clap(short = 'd', long, value_parser, conflicts_with = "no_merge")]
+    merge_distance: Option<i32>,
 
-    /// Disable merging for all output formats
+    /// Explicitly disable merging for all output formats
     #[arg(help_heading = "Filtering and merging")]
     #[clap(long, action, conflicts_with = "merge_distance")]
     no_merge: bool,
@@ -1175,13 +1200,14 @@ struct QueryOpts {
 }
 
 impl QueryOpts {
+    fn validate_merge_distance(&self, command: &str) -> io::Result<()> {
+        require_merge_distance(command, self.merge_distance, self.no_merge).map(|_| ())
+    }
+
     /// Get effective merge distance (-1 if merging is disabled)
     fn effective_merge_distance(&self) -> i32 {
-        if self.no_merge {
-            -1
-        } else {
-            self.merge_distance
-        }
+        require_merge_distance("query", self.merge_distance, self.no_merge)
+            .expect("merge distance should be validated before use")
     }
 
     /// Whether merged intervals should collapse opposite strands for a given output format
@@ -1521,10 +1547,19 @@ enum Args {
         separate_files: bool,
 
         // --- Filtering and merging ---
-        /// Maximum distance between regions to merge
+        /// Required. Merge query-gathered ranges separated by at most this many bp
+        /// before partition assignment. This sets the largest internal gap/SV a
+        /// one-hop query can absorb into one partition interval; larger gaps stay
+        /// split. Use 0 for only overlapping/touching ranges, or --no-merge to
+        /// disable merging.
         #[arg(help_heading = "Filtering and merging")]
-        #[clap(short = 'd', long, value_parser, default_value_t = 100000)]
-        merge_distance: i32,
+        #[clap(short = 'd', long, value_parser, conflicts_with = "no_merge")]
+        merge_distance: Option<i32>,
+
+        /// Explicitly disable merging before partition assignment
+        #[arg(help_heading = "Filtering and merging")]
+        #[clap(long, action, conflicts_with = "merge_distance")]
+        no_merge: bool,
 
         /// Minimum gap-compressed identity threshold (0.0-1.0)
         #[arg(help_heading = "Filtering and merging")]
@@ -2116,6 +2151,7 @@ fn run() -> io::Result<()> {
             gfa_maf_fasta,
             engine_cli,
             merge_distance,
+            no_merge,
             min_result_identity,
             transitive_opts,
             starting_sequences_file,
@@ -2126,6 +2162,8 @@ fn run() -> io::Result<()> {
             approximate,
         } => {
             initialize_threads_and_log(&common);
+
+            let merge_distance = require_merge_distance("partition", merge_distance, no_merge)?;
 
             validate_selection_mode(&selection_mode)?;
             validate_output_format(&output_format, &["bed", "gfa", "maf", "fasta"])?;
@@ -2328,6 +2366,7 @@ fn run() -> io::Result<()> {
             engine_cli,
         } => {
             initialize_threads_and_log(&common);
+            query.validate_merge_distance("query")?;
 
             // Migration errors for removed format strings
             if output_format == "gfa-poa" {
@@ -3127,6 +3166,7 @@ fn run() -> io::Result<()> {
         } => {
             initialize_threads_and_log(&common);
             refine.validate()?;
+            refine.query.validate_merge_distance("refine")?;
 
             let alignment_files = resolve_alignment_files(&alignment)?;
             let sequence_files = refine.sequence.resolve_sequence_files()?;
@@ -3299,6 +3339,7 @@ fn run() -> io::Result<()> {
             engine_cli,
         } => {
             initialize_threads_and_log(&common);
+            query.validate_merge_distance("similarity")?;
 
             // Validate delim_pos
             if delim_pos < 1 {
@@ -6964,6 +7005,45 @@ mod tests {
     fn test_resolve_syng_syncmer_params_rejects_even_total_length() {
         let err = resolve_syng_syncmer_params(None, Some(8), None, Some(64), 7).unwrap_err();
         assert!(err.to_string().contains("must be odd"));
+    }
+
+    fn minimal_query_opts(merge_distance: Option<i32>, no_merge: bool) -> QueryOpts {
+        QueryOpts {
+            target_range: Some("chr1:0-100".to_string()),
+            target_bed: None,
+            merge_distance,
+            no_merge,
+            min_result_identity: None,
+            min_output_length: None,
+            subset_sequence_list: None,
+            transitive: false,
+            transitive_opts: TransitiveOpts {
+                transitive_dfs: false,
+                max_depth: 2,
+                min_transitive_len: None,
+                min_distance_between_ranges: 10,
+            },
+            original_sequence_coordinates: false,
+            approximate: false,
+            consider_strandness: false,
+        }
+    }
+
+    #[test]
+    fn test_query_merge_distance_requires_explicit_choice() {
+        let err = minimal_query_opts(None, false)
+            .validate_merge_distance("query")
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("-d/--merge-distance is required"));
+        assert!(msg.contains("largest internal gap/SV"));
+    }
+
+    #[test]
+    fn test_query_no_merge_is_explicit_choice() {
+        let opts = minimal_query_opts(None, true);
+        opts.validate_merge_distance("query").unwrap();
+        assert_eq!(opts.effective_merge_distance(), -1);
     }
 
     #[test]

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -5945,6 +5945,8 @@ mod tests {
         let output = std::process::Command::new(&bin)
             .args([
                 "query",
+                "-d",
+                "0",
                 "-a",
                 output_prefix.to_str().unwrap(),
                 "--sequence-files",
@@ -6031,6 +6033,8 @@ mod tests {
         let output = std::process::Command::new(&bin)
             .args([
                 "query",
+                "-d",
+                "0",
                 "-a",
                 output_prefix.to_str().unwrap(),
                 "--sequence-files",
@@ -6744,6 +6748,8 @@ mod tests {
         let output = std::process::Command::new(&bin)
             .args([
                 "query",
+                "-d",
+                "0",
                 "-a",
                 idx_prefix.to_str().unwrap(),
                 "--sequence-files",
@@ -6838,6 +6844,8 @@ mod tests {
         let output = std::process::Command::new(&bin)
             .args([
                 "query",
+                "-d",
+                "0",
                 "-a",
                 paf_path.to_str().unwrap(),
                 "--sequence-files",
@@ -6886,6 +6894,8 @@ mod tests {
         let output = std::process::Command::new(&bin)
             .args([
                 "query",
+                "-d",
+                "0",
                 "-a",
                 "/tmp/nonexistent_prefix",
                 "-r",

--- a/tests/test_pipeline_integration.rs
+++ b/tests/test_pipeline_integration.rs
@@ -132,6 +132,8 @@ fn test_full_pipeline() -> std::io::Result<()> {
         &work_dir,
         &[
             "partition",
+            "-d",
+            "100000",
             "-a",
             "alignments.paf",
             "-i",

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -848,6 +848,8 @@ fn test_partition_syng_end_to_end_bed() {
     let part = Command::new(&bin)
         .args([
             "partition",
+            "-d",
+            "100000",
             "-a",
             syng_prefix.to_str().unwrap(),
             "-w",
@@ -977,6 +979,8 @@ fn test_query_syng_gfa_subwindow_splitter() {
     let out = Command::new(&bin)
         .args([
             "query",
+            "-d",
+            "0",
             "-a", syng_prefix.to_str().unwrap(),
             "--sequence-files", fasta_path.to_str().unwrap(),
             "-r", "sampleA#0#chr1:0-3000",

--- a/tests/test_transitive_integrity.rs
+++ b/tests/test_transitive_integrity.rs
@@ -92,6 +92,8 @@ fn test_non_overlapping_regions_stay_separate() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -120,6 +122,8 @@ fn test_non_overlapping_regions_stay_separate() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -167,6 +171,8 @@ fn test_transitive_coordinate_accuracy() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -233,6 +239,8 @@ fn test_bidirectional_symmetry() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -258,6 +266,8 @@ fn test_bidirectional_symmetry() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -300,6 +310,8 @@ fn test_reverse_strand_coordinates() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -359,6 +371,8 @@ fn test_distant_regions_no_collapse() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -397,6 +411,8 @@ fn test_distant_regions_no_collapse() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -454,6 +470,8 @@ fn test_indel_coordinate_accuracy() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -483,6 +501,8 @@ fn test_indel_coordinate_accuracy() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -531,6 +551,8 @@ fn test_multiple_alignments_stay_separate() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -590,6 +612,8 @@ fn test_partition_window_separation() {
         &work_dir,
         &[
             "partition",
+            "-d",
+            "100000",
             "-a",
             "test.paf",
             "-i",
@@ -637,6 +661,8 @@ fn test_empty_query_region() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -680,6 +706,8 @@ fn test_transitive_depth_limit() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",
@@ -711,6 +739,8 @@ fn test_transitive_depth_limit() {
         &work_dir,
         &[
             "query",
+            "-d",
+            "0",
             "-i",
             "test.impg",
             "-a",


### PR DESCRIPTION
## Summary
- require an explicit -d/--merge-distance for query-like workflows instead of silently defaulting
- add an explicit --no-merge opt-out for partition, matching query/refine/similarity behavior
- document that merge distance controls query-gathered range merging and the largest one-hop internal gap/SV absorbed into one interval

## Tests
- cargo test
- target/debug/impg query -a /tmp/nope.paf -r chr1:0-1
- target/debug/impg partition -a /tmp/nope.paf -w 1000