### PR TITLE
Add cosine graph genotype command

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,17 +338,18 @@ compact cohort/archive setting that is slower to write but just as fast to
 read in practice.
 
 `impg genotype` (`impg gt`) is the namespace for graph-based genotyping
-methods. The first method is COSIGT-style cosine genotyping over syng node
-coverage:
+methods. The first listed method is `cos`: cosine genotyping over graph-feature
+coverage, following the COSIGT/LikeGT scoring model:
 
 ```bash
-impg genotype cosigt -a c4.syng -p sample.packbin \
+impg genotype cos -a c4.syng -p sample.packbin \
   -r 'grch38#chr6:31972046-32055647:0-10000' \
   --ploidy 2 --top-n 20
 ```
 
-`cosigt` extracts haplotype candidates from the requested reference path range,
-builds traversal-count vectors over the candidate syncmer nodes, and ranks
+`cosigt` is accepted as an alias for `cos` to make the paper/tool lineage
+clear. `cos` extracts haplotype candidates from the requested reference path
+range, builds traversal-count vectors over the candidate syncmer nodes, and ranks
 ploidy-sized haplotype combinations against the sample `pack`/`packbin`
 coverage vector by cosine similarity. The default candidate mode is
 `spanning`: candidates must have shared anchors spanning the requested

--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ ploidy-sized haplotype combinations against the sample `pack`/`packbin`
 coverage vector by cosine similarity. The default candidate mode is
 `spanning`: candidates must have shared anchors spanning the requested
 reference interval. Use `--candidate-mode overlapping` to score each gathered
-candidate interval independently.
+candidate interval independently. See `docs/genotype-architecture.md` for the
+graph-feature evidence model this is built around.
 
 `-r` splits on the **last** `:`. Path names from `odgi paths -f`
 already contain coordinates (`grch38#chr6:31972046-32055647`), so a

--- a/README.md
+++ b/README.md
@@ -357,6 +357,22 @@ reference interval. Use `--candidate-mode overlapping` to score each gathered
 candidate interval independently. See `docs/genotype-architecture.md` for the
 graph-feature evidence model this is built around.
 
+`impg infer` lifts the same pack/cos scoring path over ranges or partitions and
+emits allele calls over genomic intervals:
+
+```bash
+impg infer -a hprc.syng -p sample.packbin \
+  --partitions partitions.bed --top-n 1 -O sample.infer.tsv.zst
+```
+
+Inputs choose the operation mode: `-r/--target-range` types one range,
+`--target-bed` types a BED-like range list, `--partitions` consumes ready
+`impg partition` BED output, and omitting all three runs internal syng partition
+discovery, which requires `-d/--merge-distance`. The first evidence backend is
+native `pack`/`packbin` from `impg map`; the design intentionally keeps BWA/local
+realignment evidence as future pack-producing backends. See
+`docs/infer-design.md`.
+
 `-r` splits on the **last** `:`. Path names from `odgi paths -f`
 already contain coordinates (`grch38#chr6:31972046-32055647`), so a
 whole-sequence query still needs an explicit trailing sub-range

--- a/README.md
+++ b/README.md
@@ -337,6 +337,24 @@ counts above 255. `--pack-compression-level` defaults to 12; level 19 is a
 compact cohort/archive setting that is slower to write but just as fast to
 read in practice.
 
+`impg genotype` (`impg gt`) is the namespace for graph-based genotyping
+methods. The first method is COSIGT-style cosine genotyping over syng node
+coverage:
+
+```bash
+impg genotype cosigt -a c4.syng -p sample.packbin \
+  -r 'grch38#chr6:31972046-32055647:0-10000' \
+  --ploidy 2 --top-n 20
+```
+
+`cosigt` extracts haplotype candidates from the requested reference path range,
+builds traversal-count vectors over the candidate syncmer nodes, and ranks
+ploidy-sized haplotype combinations against the sample `pack`/`packbin`
+coverage vector by cosine similarity. The default candidate mode is
+`spanning`: candidates must have shared anchors spanning the requested
+reference interval. Use `--candidate-mode overlapping` to score each gathered
+candidate interval independently.
+
 `-r` splits on the **last** `:`. Path names from `odgi paths -f`
 already contain coordinates (`grch38#chr6:31972046-32055647`), so a
 whole-sequence query still needs an explicit trailing sub-range

--- a/docs/genotype-architecture.md
+++ b/docs/genotype-architecture.md
@@ -1,0 +1,41 @@
+# IMPG Genotype Architecture
+
+`impg genotype` is organized around graph-feature evidence rather than a
+particular graph representation.
+
+The shared model is:
+
+1. Choose a locus.
+2. Extract candidate haplotypes or paths that cover the locus.
+3. Represent each candidate as a vector over graph features.
+4. Represent the sample as a coverage/support vector over the same feature IDs.
+5. Score ploidy-sized candidate combinations.
+
+For `impg genotype cosigt`, the scoring step is COSIGT-style cosine similarity:
+
+```text
+sample vector S
+candidate haplotype vectors H_i
+genotype vector G = H_i + H_j + ...
+score = cosine(S, G)
+```
+
+The current backend is syng:
+
+- graph features are syng syncmer node IDs
+- sample evidence comes from `impg map -o pack` or `impg map -o packbin`
+- candidates are path intervals gathered by querying a reference path range
+- candidate vectors are syncmer-node traversal counts through those intervals
+
+This is intentionally the first backend, not the whole model. Other projection
+methods should be able to feed the same `pack` abstraction:
+
+- MEM/syncmer matching to graph features for high-quality WGS
+- read alignment to local variation graph nodes
+- read alignment to extracted haplotypes for short or damaged ancient DNA
+- condensed graph or bubble-level features
+
+`packbin` is the binary coverage-vector format used by the current syng path,
+but the abstraction is feature coverage. Future versions should carry graph
+identity metadata so packs cannot be accidentally combined with the wrong graph
+or feature namespace.

--- a/docs/genotype-architecture.md
+++ b/docs/genotype-architecture.md
@@ -11,7 +11,9 @@ The shared model is:
 4. Represent the sample as a coverage/support vector over the same feature IDs.
 5. Score ploidy-sized candidate combinations.
 
-For `impg genotype cosigt`, the scoring step is COSIGT-style cosine similarity:
+For `impg genotype cos`, the scoring step is COSIGT/LikeGT-style cosine
+similarity over graph-feature coverage. `cosigt` is accepted as an alias for
+`cos` to make that lineage explicit:
 
 ```text
 sample vector S

--- a/docs/infer-design.md
+++ b/docs/infer-design.md
@@ -1,0 +1,174 @@
+# IMPG Genome Inference Design
+
+`impg infer` is the genome-scale layer above `partition`, `map`, `pack`, and
+`genotype`. Its job is to turn sample evidence into allele calls over genomic
+ranges, and eventually into a coherent inferred diploid or polyploid genome.
+
+The key design rule is that every evidence backend produces a pack-like vector
+in a declared feature space. Genotyping and inference consume those vectors;
+they should not care whether the evidence came from native syncmer mapping,
+BWA-aln reads, local realignment, GAF, or MEM hits.
+
+## Core Pipeline
+
+```text
+reads / alignments
+  -> evidence projection
+  -> typed feature pack
+  -> partition/range selection
+  -> local candidate haplotypes
+  -> local genotype scoring
+  -> optional genome-wide imputation / stitching
+  -> allele calls over ranges
+```
+
+For modern WGS, the first-class evidence path is native:
+
+```text
+FASTQ + impg map -a panel.syng -o packbin -> sample.packbin
+```
+
+For ancient DNA or very short degraded reads, the intended path is:
+
+```text
+BWA-aln/MEM BAM/CRAM
+  -> collect reads by partition/reference interval
+  -> local realign against candidate haplotypes
+  -> local pack
+```
+
+The second path should still produce the same abstraction: a feature support
+vector with enough metadata to say how it was made.
+
+## Inputs Drive Operation
+
+`infer` should choose its work pattern from the inputs:
+
+1. `--target-range`: type exactly one coordinate range.
+2. `--target-bed`: type each coordinate range from a BED-like file.
+3. `--partitions`: type each ready partition from an `impg partition` BED.
+4. No explicit ranges/partitions: run partition-style discovery first.
+
+Discovery mode must require `-d/--merge-distance` (or an explicit no-merge
+mode if we add one later). This is the same biological knob as in
+`query`/`partition`: it defines the maximum internal gap/SV that one query hop
+can absorb into one typed range.
+
+The initial implementation supports pack-based evidence. BWA/local-realignment
+is a backend, not a separate genotyping model.
+
+## Partitions
+
+Partitioning defines where to type. It is not a syncmer-ID windowing scheme.
+
+The first implementation reuses `impg partition` semantics:
+
+```bash
+impg partition -a panel.syng -w 1000000 -d 10000 -o bed --output-folder parts
+impg infer -a panel.syng -p sample.packbin --partitions parts/partitions.bed
+```
+
+`infer` may also run the partition step internally:
+
+```bash
+impg infer -a panel.syng -p sample.packbin --window-size 1000000 -d 10000
+```
+
+Internal partition discovery writes temporary partitions, parses them back, then
+types each partition. This keeps the first implementation aligned with existing
+partition behavior and avoids inventing a parallel windowing model.
+
+## Feature Packs
+
+Current pack feature space:
+
+```text
+syng-syncmer-node: node_id -> count
+```
+
+Future pack feature spaces should include:
+
+```text
+local-haplotype-segment
+variation-graph-node
+reference-interval
+mem-hit
+```
+
+Pack metadata should eventually record:
+
+```text
+feature_space
+sample
+graph/index identity
+evidence_backend = impg-map | bwa-aln | local-align | gaf | mem
+weighting / normalization
+```
+
+The important invariant is compatibility: candidate allele vectors and sample
+evidence vectors must live in the same feature space.
+
+## Scoring
+
+The first scoring method is `cos`, the same cosine scorer used by
+`impg genotype cos`.
+
+For a local typing range:
+
+```text
+candidate haplotype h -> vector v_h
+genotype G=(h1,h2,...) -> vector g = v_h1 + v_h2 + ...
+sample evidence -> vector x
+score = cosine(x, g)
+```
+
+Later scoring methods can include count likelihoods, damage-aware ancient-DNA
+likelihoods, learned scoring functions, or GBWT/panel-based imputers.
+
+## Genome-Wide Inference
+
+The first implementation emits independent local calls per range/partition.
+
+The next layer should stitch those local calls into a haplotype mosaic:
+
+```text
+state_j = haplotype tuple in window j
+emission_j(state_j) = local evidence score
+transition(state_j-1, state_j) = panel/GBWT continuity + switch penalty
+best genome = argmax sum_j emission_j + transition_j
+```
+
+This can start as beam search over the top local genotype states, then move to
+more principled HMM/Viterbi inference.
+
+## Output
+
+The first output is a TSV of allele calls over ranges:
+
+```text
+#impg infer
+#evidence_backend pack
+#score cos
+#feature_space syng-syncmer-node
+#rank  partition  chrom  start  end  method  ploidy  similarity  qv  haplotypes  regions  candidate_anchors  candidate_span_fractions
+```
+
+Each row is a local genotype state. Adjacent rows with compatible inferred
+haplotypes can later be merged into longer genome segments.
+
+## Testing Strategy
+
+Tests should cover:
+
+- explicit single range
+- BED/range list input
+- ready partition BED input
+- internal partition discovery requiring `-d`
+- pack, compressed pack, and packbin evidence
+- short-read simulation against a panel with a decoy haplotype
+- invalid CLI combinations
+- output compression and deterministic row shape
+
+The synthetic graphs are not substitutes for real population graph validation.
+They should progressively add SNPs, indels, nested SVs, repeats/paralogy,
+coverage variation, sequencing error, and recombination/mosaic samples.

--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -1,0 +1,552 @@
+use clap::ValueEnum;
+use log::info;
+use rustc_hash::FxHashMap;
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+
+use crate::commands::partition;
+use crate::pack;
+use crate::syng;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CandidateMode {
+    /// Keep path candidates whose shared anchors span the requested reference range.
+    Spanning,
+    /// Score every query-gathered candidate interval independently.
+    Overlapping,
+}
+
+#[derive(Debug, Clone)]
+pub struct HaplotypeCandidate {
+    pub path_name: String,
+    pub start: u64,
+    pub end: u64,
+    pub strand: char,
+    pub anchors: usize,
+    pub query_span_fraction: f64,
+    pub features: Vec<(u32, u64)>,
+    single_similarity: f64,
+}
+
+#[derive(Debug)]
+struct SyngCandidateGroup {
+    start: u64,
+    end: u64,
+    anchors: Vec<syng::Anchor>,
+}
+
+#[derive(Debug)]
+pub struct CosigtResult {
+    pub combination: Vec<usize>,
+    pub similarity: f64,
+    pub qv: f64,
+    pub dot: f64,
+    pub sample_norm: f64,
+    pub genotype_norm: f64,
+}
+
+pub struct SyngCosigtConfig<'a> {
+    pub syng_prefix: &'a str,
+    pub pack_path: &'a str,
+    pub target_range: &'a str,
+    pub candidate_mode: CandidateMode,
+    pub ploidy: usize,
+    pub top_n: usize,
+    pub candidate_top_k: usize,
+    pub max_combinations: u64,
+    pub syng_padding: u64,
+    pub syng_extension: u64,
+    pub min_anchors: usize,
+    pub min_span_fraction: f64,
+}
+
+fn anchor_span_fraction(
+    anchors: &[syng::Anchor],
+    region_start: u64,
+    region_end: u64,
+    syncmer_len: u64,
+) -> f64 {
+    if anchors.is_empty() || region_end <= region_start {
+        return 0.0;
+    }
+    let anchor_start = anchors
+        .iter()
+        .map(|a| a.query_pos)
+        .min()
+        .unwrap_or(region_start);
+    let anchor_end = anchors
+        .iter()
+        .map(|a| a.query_pos.saturating_add(syncmer_len))
+        .max()
+        .unwrap_or(anchor_start);
+    let clipped_start = anchor_start.max(region_start);
+    let clipped_end = anchor_end.min(region_end);
+    if clipped_end <= clipped_start {
+        return 0.0;
+    }
+    (clipped_end - clipped_start) as f64 / (region_end - region_start) as f64
+}
+
+fn syng_candidate_features(
+    syng_index: &syng::SyngIndex,
+    path_name: &str,
+    start: u64,
+    end: u64,
+) -> io::Result<Vec<(u32, u64)>> {
+    let path_idx = syng_index
+        .name_map
+        .name_to_path
+        .get(path_name)
+        .copied()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "candidate path '{}' is missing from syng name map",
+                    path_name
+                ),
+            )
+        })? as usize;
+    let mut counts: FxHashMap<u32, u64> = FxHashMap::default();
+    for (signed_node, _) in syng_index.walk_path_range(path_idx, start, end)? {
+        *counts.entry(signed_node.unsigned_abs()).or_insert(0) += 1;
+    }
+    let mut features: Vec<(u32, u64)> = counts.into_iter().collect();
+    features.sort_unstable_by_key(|&(feature_id, _)| feature_id);
+    Ok(features)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_syng_candidates(
+    syng_index: &syng::SyngIndex,
+    target_name: &str,
+    region_start: u64,
+    region_end: u64,
+    padding: u64,
+    extension: u64,
+    mode: CandidateMode,
+    min_anchors: usize,
+    min_span_fraction: f64,
+) -> io::Result<Vec<HaplotypeCandidate>> {
+    let syncmer_len = syng_index.syncmer_length_bp() as u64;
+    let hits = syng_index.query_region_with_anchors_ext(
+        target_name,
+        region_start,
+        region_end,
+        padding,
+        extension,
+    )?;
+    let mut candidates = Vec::new();
+
+    match mode {
+        CandidateMode::Overlapping => {
+            for hit in hits {
+                if hit.anchors.len() < min_anchors || hit.end <= hit.start {
+                    continue;
+                }
+                let query_span_fraction =
+                    anchor_span_fraction(&hit.anchors, region_start, region_end, syncmer_len);
+                let features =
+                    syng_candidate_features(syng_index, &hit.genome, hit.start, hit.end)?;
+                if features.is_empty() {
+                    continue;
+                }
+                candidates.push(HaplotypeCandidate {
+                    path_name: hit.genome,
+                    start: hit.start,
+                    end: hit.end,
+                    strand: hit.strand,
+                    anchors: hit.anchors.len(),
+                    query_span_fraction,
+                    features,
+                    single_similarity: 0.0,
+                });
+            }
+        }
+        CandidateMode::Spanning => {
+            let mut groups: BTreeMap<(String, char), SyngCandidateGroup> = BTreeMap::new();
+            for hit in hits {
+                if hit.end <= hit.start {
+                    continue;
+                }
+                let entry =
+                    groups
+                        .entry((hit.genome, hit.strand))
+                        .or_insert_with(|| SyngCandidateGroup {
+                            start: u64::MAX,
+                            end: 0,
+                            anchors: Vec::new(),
+                        });
+                entry.start = entry.start.min(hit.start);
+                entry.end = entry.end.max(hit.end);
+                entry.anchors.extend(hit.anchors);
+            }
+
+            for ((path_name, strand), mut group) in groups {
+                group.anchors.sort_by(|a, b| {
+                    a.query_pos
+                        .cmp(&b.query_pos)
+                        .then(a.target_pos.cmp(&b.target_pos))
+                });
+                group.anchors.dedup_by(|a, b| {
+                    a.query_pos == b.query_pos
+                        && a.target_pos == b.target_pos
+                        && a.node_id == b.node_id
+                });
+                let query_span_fraction =
+                    anchor_span_fraction(&group.anchors, region_start, region_end, syncmer_len);
+                if group.anchors.len() < min_anchors || query_span_fraction < min_span_fraction {
+                    continue;
+                }
+                let features =
+                    syng_candidate_features(syng_index, &path_name, group.start, group.end)?;
+                if features.is_empty() {
+                    continue;
+                }
+                candidates.push(HaplotypeCandidate {
+                    path_name,
+                    start: group.start,
+                    end: group.end,
+                    strand,
+                    anchors: group.anchors.len(),
+                    query_span_fraction,
+                    features,
+                    single_similarity: 0.0,
+                });
+            }
+        }
+    }
+
+    candidates.sort_by(|a, b| {
+        a.path_name
+            .cmp(&b.path_name)
+            .then(a.strand.cmp(&b.strand))
+            .then(a.start.cmp(&b.start))
+            .then(a.end.cmp(&b.end))
+    });
+    Ok(candidates)
+}
+
+fn locus_features(candidates: &[HaplotypeCandidate]) -> Vec<u32> {
+    let mut seen: FxHashMap<u32, ()> = FxHashMap::default();
+    for candidate in candidates {
+        for &(feature_id, _) in &candidate.features {
+            seen.insert(feature_id, ());
+        }
+    }
+    let mut features: Vec<u32> = seen.into_keys().collect();
+    features.sort_unstable();
+    features
+}
+
+fn sample_norm_sq_for_features(sample_counts: &FxHashMap<u32, u64>, features: &[u32]) -> f64 {
+    features
+        .iter()
+        .map(|feature_id| sample_counts.get(feature_id).copied().unwrap_or(0) as f64)
+        .map(|v| v * v)
+        .sum()
+}
+
+fn cosine_for_candidate_features(
+    candidate_features: &[(u32, u64)],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+) -> f64 {
+    if sample_norm_sq == 0.0 {
+        return 0.0;
+    }
+    let mut dot = 0.0;
+    let mut genotype_norm_sq = 0.0;
+    for &(feature_id, count) in candidate_features {
+        let g = count as f64;
+        genotype_norm_sq += g * g;
+        dot += g * sample_counts.get(&feature_id).copied().unwrap_or(0) as f64;
+    }
+    if genotype_norm_sq == 0.0 {
+        0.0
+    } else {
+        dot / (sample_norm_sq.sqrt() * genotype_norm_sq.sqrt())
+    }
+}
+
+fn score_combination(
+    combination: &[usize],
+    candidates: &[HaplotypeCandidate],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+) -> CosigtResult {
+    let mut genotype_counts: FxHashMap<u32, u64> = FxHashMap::default();
+    for &idx in combination {
+        for &(feature_id, count) in &candidates[idx].features {
+            *genotype_counts.entry(feature_id).or_insert(0) += count;
+        }
+    }
+
+    let mut dot = 0.0;
+    let mut genotype_norm_sq = 0.0;
+    for (feature_id, count) in genotype_counts {
+        let g = count as f64;
+        genotype_norm_sq += g * g;
+        dot += g * sample_counts.get(&feature_id).copied().unwrap_or(0) as f64;
+    }
+
+    let sample_norm = sample_norm_sq.sqrt();
+    let genotype_norm = genotype_norm_sq.sqrt();
+    let similarity = if sample_norm == 0.0 || genotype_norm == 0.0 {
+        0.0
+    } else {
+        dot / (sample_norm * genotype_norm)
+    };
+    let qv = if similarity >= 1.0 {
+        999.0
+    } else if similarity <= 0.0 {
+        0.0
+    } else {
+        -10.0 * (1.0 - similarity).log10()
+    };
+
+    CosigtResult {
+        combination: combination.to_vec(),
+        similarity,
+        qv,
+        dot,
+        sample_norm,
+        genotype_norm,
+    }
+}
+
+struct CosigtSearch<'a> {
+    candidates: &'a [HaplotypeCandidate],
+    sample_counts: &'a FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+    ploidy: usize,
+    max_combinations: u64,
+    visited: u64,
+    results: Vec<CosigtResult>,
+}
+
+impl CosigtSearch<'_> {
+    fn run(mut self) -> io::Result<Vec<CosigtResult>> {
+        let mut current = Vec::with_capacity(self.ploidy);
+        self.visit(0, &mut current)?;
+        self.results.sort_by(|a, b| {
+            b.similarity
+                .total_cmp(&a.similarity)
+                .then_with(|| b.dot.total_cmp(&a.dot))
+                .then_with(|| a.combination.cmp(&b.combination))
+        });
+        Ok(self.results)
+    }
+
+    fn visit(&mut self, start: usize, current: &mut Vec<usize>) -> io::Result<()> {
+        if current.len() == self.ploidy {
+            self.visited += 1;
+            if self.visited > self.max_combinations {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "genotype combination search exceeded --max-combinations ({})",
+                        self.max_combinations
+                    ),
+                ));
+            }
+            self.results.push(score_combination(
+                current,
+                self.candidates,
+                self.sample_counts,
+                self.sample_norm_sq,
+            ));
+            return Ok(());
+        }
+
+        for idx in start..self.candidates.len() {
+            current.push(idx);
+            self.visit(idx, current)?;
+            current.pop();
+        }
+        Ok(())
+    }
+}
+
+fn rank_cosigt(
+    candidates: &mut Vec<HaplotypeCandidate>,
+    sample_counts: &FxHashMap<u32, u64>,
+    ploidy: usize,
+    top_n: usize,
+    candidate_top_k: usize,
+    max_combinations: u64,
+) -> io::Result<(Vec<CosigtResult>, Vec<u32>)> {
+    let all_locus_features = locus_features(candidates);
+    let all_sample_norm_sq = sample_norm_sq_for_features(sample_counts, &all_locus_features);
+    for candidate in candidates.iter_mut() {
+        candidate.single_similarity =
+            cosine_for_candidate_features(&candidate.features, sample_counts, all_sample_norm_sq);
+    }
+    candidates.sort_by(|a, b| {
+        b.single_similarity
+            .total_cmp(&a.single_similarity)
+            .then(b.anchors.cmp(&a.anchors))
+            .then(a.path_name.cmp(&b.path_name))
+            .then(a.start.cmp(&b.start))
+    });
+    if candidate_top_k > 0 && candidates.len() > candidate_top_k {
+        candidates.truncate(candidate_top_k);
+    }
+
+    let selected_features = locus_features(candidates);
+    let sample_norm_sq = sample_norm_sq_for_features(sample_counts, &selected_features);
+    if sample_norm_sq == 0.0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "sample pack has zero coverage over candidate graph features",
+        ));
+    }
+
+    let search = CosigtSearch {
+        candidates,
+        sample_counts,
+        sample_norm_sq,
+        ploidy,
+        max_combinations,
+        visited: 0,
+        results: Vec::new(),
+    };
+    let mut results = search.run()?;
+    results.truncate(top_n);
+    Ok((results, selected_features))
+}
+
+fn format_candidate_region(candidate: &HaplotypeCandidate) -> String {
+    format!(
+        "{}:{}-{}({})",
+        candidate.path_name, candidate.start, candidate.end, candidate.strand
+    )
+}
+
+pub fn run_syng_cosigt<W: Write>(out: &mut W, config: &SyngCosigtConfig<'_>) -> io::Result<()> {
+    if config.ploidy == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--ploidy must be greater than 0",
+        ));
+    }
+    if config.top_n == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--top-n must be greater than 0",
+        ));
+    }
+    if !(0.0..=1.0).contains(&config.min_span_fraction) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--min-span-fraction must be between 0 and 1",
+        ));
+    }
+
+    let (target_name, (range_start, range_end), region_name) =
+        partition::parse_target_range(config.target_range)?;
+    if range_start < 0 || range_end <= range_start {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "target range must be non-empty with non-negative coordinates: {}",
+                config.target_range
+            ),
+        ));
+    }
+    let region_start = range_start as u64;
+    let region_end = range_end as u64;
+
+    info!("Loading syng index from prefix: {}", config.syng_prefix);
+    let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
+    info!("Loading sample pack coverage from {}", config.pack_path);
+    let coverage = pack::read(config.pack_path)?;
+
+    let mut candidates = collect_syng_candidates(
+        &syng_index,
+        &target_name,
+        region_start,
+        region_end,
+        config.syng_padding,
+        config.syng_extension,
+        config.candidate_mode,
+        config.min_anchors,
+        config.min_span_fraction,
+    )?;
+    if candidates.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "no syng genotype candidates were found for the requested range",
+        ));
+    }
+
+    let (results, selected_features) = rank_cosigt(
+        &mut candidates,
+        &coverage.counts,
+        config.ploidy,
+        config.top_n,
+        config.candidate_top_k,
+        config.max_combinations,
+    )?;
+
+    writeln!(out, "#impg genotype cosigt")?;
+    writeln!(out, "#region\t{}", region_name)?;
+    writeln!(out, "#feature_space\tsyng-syncmer-node")?;
+    writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
+    writeln!(out, "#ploidy\t{}", config.ploidy)?;
+    writeln!(out, "#candidates\t{}", candidates.len())?;
+    writeln!(out, "#locus_features\t{}", selected_features.len())?;
+    writeln!(out, "#pack_nonzero_nodes\t{}", coverage.nonzero_nodes)?;
+    if let Some(universe_nodes) = coverage.universe_nodes {
+        writeln!(out, "#pack_universe_nodes\t{}", universe_nodes)?;
+    }
+    if let Some(retained_records) = coverage.retained_records {
+        writeln!(out, "#pack_retained_records\t{}", retained_records)?;
+    }
+    if let Some(syncmer_anchors) = coverage.syncmer_anchors {
+        writeln!(out, "#pack_syncmer_anchors\t{}", syncmer_anchors)?;
+    }
+    writeln!(
+        out,
+        "#rank\tmethod\tploidy\tsimilarity\tqv\tdot\tsample_norm\tgenotype_norm\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions"
+    )?;
+    for (rank, result) in results.iter().enumerate() {
+        let haplotypes: Vec<&str> = result
+            .combination
+            .iter()
+            .map(|&idx| candidates[idx].path_name.as_str())
+            .collect();
+        let regions: Vec<String> = result
+            .combination
+            .iter()
+            .map(|&idx| format_candidate_region(&candidates[idx]))
+            .collect();
+        let anchors: Vec<String> = result
+            .combination
+            .iter()
+            .map(|&idx| candidates[idx].anchors.to_string())
+            .collect();
+        let spans: Vec<String> = result
+            .combination
+            .iter()
+            .map(|&idx| format!("{:.6}", candidates[idx].query_span_fraction))
+            .collect();
+        writeln!(
+            out,
+            "{}\tcosigt\t{}\t{:.9}\t{:.3}\t{:.3}\t{:.6}\t{:.6}\t{}\t{}\t{}\t{}",
+            rank + 1,
+            config.ploidy,
+            result.similarity,
+            result.qv,
+            result.dot,
+            result.sample_norm,
+            result.genotype_norm,
+            haplotypes.join(","),
+            regions.join(","),
+            anchors.join(","),
+            spans.join(","),
+        )?;
+    }
+
+    Ok(())
+}

--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -60,6 +60,32 @@ pub struct SyngCosigtConfig<'a> {
     pub min_span_fraction: f64,
 }
 
+pub struct SyngCosigtQuery<'a> {
+    pub target_range: &'a str,
+    pub candidate_mode: CandidateMode,
+    pub ploidy: usize,
+    pub top_n: usize,
+    pub candidate_top_k: usize,
+    pub max_combinations: u64,
+    pub syng_padding: u64,
+    pub syng_extension: u64,
+    pub min_anchors: usize,
+    pub min_span_fraction: f64,
+}
+
+pub struct SyngCosigtOutput {
+    pub region_name: String,
+    pub candidate_mode: CandidateMode,
+    pub ploidy: usize,
+    pub candidates: Vec<HaplotypeCandidate>,
+    pub selected_features: Vec<u32>,
+    pub pack_nonzero_nodes: u64,
+    pub pack_universe_nodes: Option<u64>,
+    pub pack_retained_records: Option<u64>,
+    pub pack_syncmer_anchors: Option<u64>,
+    pub results: Vec<CosigtResult>,
+}
+
 fn anchor_span_fraction(
     anchors: &[syng::Anchor],
     region_start: u64,
@@ -424,19 +450,44 @@ fn format_candidate_region(candidate: &HaplotypeCandidate) -> String {
 }
 
 pub fn run_syng_cosigt<W: Write>(out: &mut W, config: &SyngCosigtConfig<'_>) -> io::Result<()> {
-    if config.ploidy == 0 {
+    info!("Loading syng index from prefix: {}", config.syng_prefix);
+    let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
+    info!("Loading sample pack coverage from {}", config.pack_path);
+    let coverage = pack::read(config.pack_path)?;
+    let query = SyngCosigtQuery {
+        target_range: config.target_range,
+        candidate_mode: config.candidate_mode,
+        ploidy: config.ploidy,
+        top_n: config.top_n,
+        candidate_top_k: config.candidate_top_k,
+        max_combinations: config.max_combinations,
+        syng_padding: config.syng_padding,
+        syng_extension: config.syng_extension,
+        min_anchors: config.min_anchors,
+        min_span_fraction: config.min_span_fraction,
+    };
+    let result = compute_syng_cosigt(&syng_index, &coverage, &query)?;
+    write_syng_cosigt_output(out, &result)
+}
+
+pub fn compute_syng_cosigt(
+    syng_index: &syng::SyngIndex,
+    coverage: &pack::Coverage,
+    query: &SyngCosigtQuery<'_>,
+) -> io::Result<SyngCosigtOutput> {
+    if query.ploidy == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "--ploidy must be greater than 0",
         ));
     }
-    if config.top_n == 0 {
+    if query.top_n == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "--top-n must be greater than 0",
         ));
     }
-    if !(0.0..=1.0).contains(&config.min_span_fraction) {
+    if !(0.0..=1.0).contains(&query.min_span_fraction) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "--min-span-fraction must be between 0 and 1",
@@ -444,34 +495,29 @@ pub fn run_syng_cosigt<W: Write>(out: &mut W, config: &SyngCosigtConfig<'_>) -> 
     }
 
     let (target_name, (range_start, range_end), region_name) =
-        partition::parse_target_range(config.target_range)?;
+        partition::parse_target_range(query.target_range)?;
     if range_start < 0 || range_end <= range_start {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
                 "target range must be non-empty with non-negative coordinates: {}",
-                config.target_range
+                query.target_range
             ),
         ));
     }
     let region_start = range_start as u64;
     let region_end = range_end as u64;
 
-    info!("Loading syng index from prefix: {}", config.syng_prefix);
-    let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
-    info!("Loading sample pack coverage from {}", config.pack_path);
-    let coverage = pack::read(config.pack_path)?;
-
     let mut candidates = collect_syng_candidates(
-        &syng_index,
+        syng_index,
         &target_name,
         region_start,
         region_end,
-        config.syng_padding,
-        config.syng_extension,
-        config.candidate_mode,
-        config.min_anchors,
-        config.min_span_fraction,
+        query.syng_padding,
+        query.syng_extension,
+        query.candidate_mode,
+        query.min_anchors,
+        query.min_span_fraction,
     )?;
     if candidates.is_empty() {
         return Err(io::Error::new(
@@ -483,67 +529,85 @@ pub fn run_syng_cosigt<W: Write>(out: &mut W, config: &SyngCosigtConfig<'_>) -> 
     let (results, selected_features) = rank_cosigt(
         &mut candidates,
         &coverage.counts,
-        config.ploidy,
-        config.top_n,
-        config.candidate_top_k,
-        config.max_combinations,
+        query.ploidy,
+        query.top_n,
+        query.candidate_top_k,
+        query.max_combinations,
     )?;
 
+    Ok(SyngCosigtOutput {
+        region_name,
+        candidate_mode: query.candidate_mode,
+        ploidy: query.ploidy,
+        candidates,
+        selected_features,
+        pack_nonzero_nodes: coverage.nonzero_nodes,
+        pack_universe_nodes: coverage.universe_nodes,
+        pack_retained_records: coverage.retained_records,
+        pack_syncmer_anchors: coverage.syncmer_anchors,
+        results,
+    })
+}
+
+pub fn write_syng_cosigt_output<W: Write>(
+    out: &mut W,
+    result: &SyngCosigtOutput,
+) -> io::Result<()> {
     writeln!(out, "#impg genotype cos")?;
-    writeln!(out, "#region\t{}", region_name)?;
+    writeln!(out, "#region\t{}", result.region_name)?;
     writeln!(out, "#method\tcos")?;
     writeln!(out, "#metric\tcosine")?;
     writeln!(out, "#alias\tcosigt")?;
     writeln!(out, "#feature_space\tsyng-syncmer-node")?;
-    writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
-    writeln!(out, "#ploidy\t{}", config.ploidy)?;
-    writeln!(out, "#candidates\t{}", candidates.len())?;
-    writeln!(out, "#locus_features\t{}", selected_features.len())?;
-    writeln!(out, "#pack_nonzero_nodes\t{}", coverage.nonzero_nodes)?;
-    if let Some(universe_nodes) = coverage.universe_nodes {
+    writeln!(out, "#candidate_mode\t{:?}", result.candidate_mode)?;
+    writeln!(out, "#ploidy\t{}", result.ploidy)?;
+    writeln!(out, "#candidates\t{}", result.candidates.len())?;
+    writeln!(out, "#locus_features\t{}", result.selected_features.len())?;
+    writeln!(out, "#pack_nonzero_nodes\t{}", result.pack_nonzero_nodes)?;
+    if let Some(universe_nodes) = result.pack_universe_nodes {
         writeln!(out, "#pack_universe_nodes\t{}", universe_nodes)?;
     }
-    if let Some(retained_records) = coverage.retained_records {
+    if let Some(retained_records) = result.pack_retained_records {
         writeln!(out, "#pack_retained_records\t{}", retained_records)?;
     }
-    if let Some(syncmer_anchors) = coverage.syncmer_anchors {
+    if let Some(syncmer_anchors) = result.pack_syncmer_anchors {
         writeln!(out, "#pack_syncmer_anchors\t{}", syncmer_anchors)?;
     }
     writeln!(
         out,
         "#rank\tmethod\tploidy\tsimilarity\tqv\tdot\tsample_norm\tgenotype_norm\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions"
     )?;
-    for (rank, result) in results.iter().enumerate() {
-        let haplotypes: Vec<&str> = result
+    for (rank, genotype_result) in result.results.iter().enumerate() {
+        let haplotypes: Vec<&str> = genotype_result
             .combination
             .iter()
-            .map(|&idx| candidates[idx].path_name.as_str())
+            .map(|&idx| result.candidates[idx].path_name.as_str())
             .collect();
-        let regions: Vec<String> = result
+        let regions: Vec<String> = genotype_result
             .combination
             .iter()
-            .map(|&idx| format_candidate_region(&candidates[idx]))
+            .map(|&idx| format_candidate_region(&result.candidates[idx]))
             .collect();
-        let anchors: Vec<String> = result
+        let anchors: Vec<String> = genotype_result
             .combination
             .iter()
-            .map(|&idx| candidates[idx].anchors.to_string())
+            .map(|&idx| result.candidates[idx].anchors.to_string())
             .collect();
-        let spans: Vec<String> = result
+        let spans: Vec<String> = genotype_result
             .combination
             .iter()
-            .map(|&idx| format!("{:.6}", candidates[idx].query_span_fraction))
+            .map(|&idx| format!("{:.6}", result.candidates[idx].query_span_fraction))
             .collect();
         writeln!(
             out,
             "{}\tcos\t{}\t{:.9}\t{:.3}\t{:.3}\t{:.6}\t{:.6}\t{}\t{}\t{}\t{}",
             rank + 1,
-            config.ploidy,
-            result.similarity,
-            result.qv,
-            result.dot,
-            result.sample_norm,
-            result.genotype_norm,
+            result.ploidy,
+            genotype_result.similarity,
+            genotype_result.qv,
+            genotype_result.dot,
+            genotype_result.sample_norm,
+            genotype_result.genotype_norm,
             haplotypes.join(","),
             regions.join(","),
             anchors.join(","),

--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -489,8 +489,11 @@ pub fn run_syng_cosigt<W: Write>(out: &mut W, config: &SyngCosigtConfig<'_>) -> 
         config.max_combinations,
     )?;
 
-    writeln!(out, "#impg genotype cosigt")?;
+    writeln!(out, "#impg genotype cos")?;
     writeln!(out, "#region\t{}", region_name)?;
+    writeln!(out, "#method\tcos")?;
+    writeln!(out, "#metric\tcosine")?;
+    writeln!(out, "#alias\tcosigt")?;
     writeln!(out, "#feature_space\tsyng-syncmer-node")?;
     writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
     writeln!(out, "#ploidy\t{}", config.ploidy)?;
@@ -533,7 +536,7 @@ pub fn run_syng_cosigt<W: Write>(out: &mut W, config: &SyngCosigtConfig<'_>) -> 
             .collect();
         writeln!(
             out,
-            "{}\tcosigt\t{}\t{:.9}\t{:.3}\t{:.3}\t{:.6}\t{:.6}\t{}\t{}\t{}\t{}",
+            "{}\tcos\t{}\t{:.9}\t{:.3}\t{:.3}\t{:.6}\t{:.6}\t{}\t{}\t{}\t{}",
             rank + 1,
             config.ploidy,
             result.similarity,

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -1,0 +1,342 @@
+use log::info;
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::commands::{genotype, graph, partition};
+use crate::pack;
+use crate::syng;
+use crate::{EngineOpts, GfaEngine, SyngImpgWrapper};
+
+#[derive(Debug, Clone)]
+pub struct InferTarget {
+    pub partition: String,
+    pub chrom: String,
+    pub start: i32,
+    pub end: i32,
+    pub name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionDiscoveryConfig<'a> {
+    pub window_size: usize,
+    pub merge_distance: i32,
+    pub starting_sequences_file: Option<&'a str>,
+    pub selection_mode: &'a str,
+    pub min_missing_size: i32,
+    pub min_boundary_distance: i32,
+    pub syng_padding: u64,
+    pub syng_min_chain_anchors: usize,
+    pub syng_min_chain_fraction: f64,
+    pub rehome_singletons: bool,
+}
+
+pub struct InferConfig<'a> {
+    pub syng_prefix: &'a str,
+    pub pack_path: &'a str,
+    pub targets: Vec<InferTarget>,
+    pub discovery: Option<PartitionDiscoveryConfig<'a>>,
+    pub candidate_mode: genotype::CandidateMode,
+    pub ploidy: usize,
+    pub top_n: usize,
+    pub candidate_top_k: usize,
+    pub max_combinations: u64,
+    pub syng_padding: u64,
+    pub syng_extension: u64,
+    pub min_anchors: usize,
+    pub min_span_fraction: f64,
+}
+
+fn parse_bed_like(path: &str, group_partitions: bool) -> io::Result<Vec<InferTarget>> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut targets = Vec::new();
+    let mut first_by_partition: BTreeMap<String, InferTarget> = BTreeMap::new();
+
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 3 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("BED line {} has fewer than 3 fields", line_no + 1),
+            ));
+        }
+        let start = fields[1].parse::<i32>().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid BED start on line {}: {}", line_no + 1, e),
+            )
+        })?;
+        let end = fields[2].parse::<i32>().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid BED end on line {}: {}", line_no + 1, e),
+            )
+        })?;
+        if start < 0 || end <= start {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "invalid BED range on line {}: {}-{}",
+                    line_no + 1,
+                    start,
+                    end
+                ),
+            ));
+        }
+        let name = fields
+            .get(3)
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty() && *s != ".")
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("{}:{}-{}", fields[0], start, end));
+        let partition = if group_partitions {
+            name.clone()
+        } else {
+            format!("{}", targets.len())
+        };
+        let target = InferTarget {
+            partition: partition.clone(),
+            chrom: fields[0].to_string(),
+            start,
+            end,
+            name,
+        };
+        if group_partitions {
+            first_by_partition.entry(partition).or_insert(target);
+        } else {
+            targets.push(target);
+        }
+    }
+
+    if group_partitions {
+        targets.extend(first_by_partition.into_values());
+    }
+    Ok(targets)
+}
+
+pub fn parse_target_range(target_range: &str) -> io::Result<InferTarget> {
+    let (chrom, (start, end), name) = partition::parse_target_range(target_range)?;
+    Ok(InferTarget {
+        partition: "0".to_string(),
+        chrom,
+        start,
+        end,
+        name,
+    })
+}
+
+pub fn parse_target_bed(path: &str) -> io::Result<Vec<InferTarget>> {
+    parse_bed_like(path, false)
+}
+
+pub fn parse_partitions(path: &str) -> io::Result<Vec<InferTarget>> {
+    parse_bed_like(path, true)
+}
+
+fn temp_partition_dir() -> io::Result<PathBuf> {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "impg-infer-partitions-{}-{stamp}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn discover_partitions(
+    syng_prefix: &str,
+    discovery: &PartitionDiscoveryConfig<'_>,
+) -> io::Result<Vec<InferTarget>> {
+    let temp_dir = temp_partition_dir()?;
+    let temp_dir_str = temp_dir.to_string_lossy().to_string();
+    let syng_index = syng::SyngIndex::load(syng_prefix, syng::SyncmerParams::default())?;
+    let seq_index = syng_index.build_seq_index();
+    let wrapper = {
+        let base = SyngImpgWrapper::new(syng_index, seq_index, discovery.syng_padding);
+        if discovery.syng_min_chain_anchors > 0 {
+            base.with_chain_filter(
+                discovery.syng_min_chain_anchors,
+                discovery.syng_min_chain_fraction,
+            )
+        } else {
+            base
+        }
+    };
+    let engine_config = EngineOpts {
+        engine: GfaEngine::Poa,
+        pipeline: graph::GraphBuildConfig::default(),
+        target_poa_lengths: vec![700, 1100],
+        max_node_length: 100,
+        poa_padding_fraction: 0.001,
+        partition_size: None,
+    };
+
+    info!(
+        "Discovering inference partitions with window_size={} merge_distance={}",
+        discovery.window_size, discovery.merge_distance
+    );
+    partition::partition_alignments(
+        &wrapper,
+        discovery.window_size,
+        discovery.starting_sequences_file,
+        discovery.selection_mode,
+        discovery.merge_distance,
+        None,
+        discovery.min_missing_size,
+        discovery.min_boundary_distance,
+        false,
+        1,
+        0,
+        0,
+        "bed",
+        Some(&temp_dir_str),
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        &engine_config,
+        discovery.rehome_singletons,
+    )?;
+
+    let partitions_path = temp_dir.join("partitions.bed");
+    let result = parse_partitions(partitions_path.to_str().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "temporary path is not UTF-8")
+    })?);
+    fs::remove_dir_all(&temp_dir).ok();
+    result
+}
+
+fn target_range_string(target: &InferTarget) -> String {
+    format!("{}:{}-{}", target.chrom, target.start, target.end)
+}
+
+fn candidate_region(candidate: &genotype::HaplotypeCandidate) -> String {
+    format!(
+        "{}:{}-{}({})",
+        candidate.path_name, candidate.start, candidate.end, candidate.strand
+    )
+}
+
+pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> io::Result<()> {
+    let targets = if config.targets.is_empty() {
+        let discovery = config.discovery.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "infer requires --target-range, --target-bed, --partitions, or discovery settings",
+            )
+        })?;
+        discover_partitions(config.syng_prefix, discovery)?
+    } else {
+        config.targets.clone()
+    };
+
+    if targets.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "no inference targets were found",
+        ));
+    }
+
+    info!("Loading syng index from prefix: {}", config.syng_prefix);
+    let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
+    info!("Loading sample pack coverage from {}", config.pack_path);
+    let coverage = pack::read(config.pack_path)?;
+
+    writeln!(out, "#impg infer")?;
+    writeln!(out, "#evidence_backend\tpack")?;
+    writeln!(out, "#score\tcos")?;
+    writeln!(out, "#feature_space\tsyng-syncmer-node")?;
+    writeln!(out, "#targets\t{}", targets.len())?;
+    writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
+    writeln!(out, "#ploidy\t{}", config.ploidy)?;
+    writeln!(
+        out,
+        "#rank\tpartition\tchrom\tstart\tend\tmethod\tploidy\tsimilarity\tqv\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions\tstatus"
+    )?;
+
+    for target in &targets {
+        let target_range = target_range_string(target);
+        let query = genotype::SyngCosigtQuery {
+            target_range: &target_range,
+            candidate_mode: config.candidate_mode,
+            ploidy: config.ploidy,
+            top_n: config.top_n,
+            candidate_top_k: config.candidate_top_k,
+            max_combinations: config.max_combinations,
+            syng_padding: config.syng_padding,
+            syng_extension: config.syng_extension,
+            min_anchors: config.min_anchors,
+            min_span_fraction: config.min_span_fraction,
+        };
+
+        match genotype::compute_syng_cosigt(&syng_index, &coverage, &query) {
+            Ok(result) => {
+                for (rank, genotype_result) in result.results.iter().enumerate() {
+                    let haplotypes: Vec<&str> = genotype_result
+                        .combination
+                        .iter()
+                        .map(|&idx| result.candidates[idx].path_name.as_str())
+                        .collect();
+                    let regions: Vec<String> = genotype_result
+                        .combination
+                        .iter()
+                        .map(|&idx| candidate_region(&result.candidates[idx]))
+                        .collect();
+                    let anchors: Vec<String> = genotype_result
+                        .combination
+                        .iter()
+                        .map(|&idx| result.candidates[idx].anchors.to_string())
+                        .collect();
+                    let spans: Vec<String> = genotype_result
+                        .combination
+                        .iter()
+                        .map(|&idx| format!("{:.6}", result.candidates[idx].query_span_fraction))
+                        .collect();
+                    writeln!(
+                        out,
+                        "{}\t{}\t{}\t{}\t{}\tcos\t{}\t{:.9}\t{:.3}\t{}\t{}\t{}\t{}\tPASS",
+                        rank + 1,
+                        target.partition,
+                        target.chrom,
+                        target.start,
+                        target.end,
+                        result.ploidy,
+                        genotype_result.similarity,
+                        genotype_result.qv,
+                        haplotypes.join(","),
+                        regions.join(","),
+                        anchors.join(","),
+                        spans.join(","),
+                    )?;
+                }
+            }
+            Err(e) => {
+                writeln!(
+                    out,
+                    "1\t{}\t{}\t{}\t{}\tcos\t{}\t0.000000000\t0.000\t.\t.\t.\t.\tNO_CALL:{}",
+                    target.partition,
+                    target.chrom,
+                    target.start,
+                    target.end,
+                    config.ploidy,
+                    e.to_string().replace('\t', " ")
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod align;
+pub mod genotype;
 pub mod graph;
 pub mod lace;
 pub mod partition;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod align;
 pub mod genotype;
 pub mod graph;
+pub mod infer;
 pub mod lace;
 pub mod partition;
 pub mod refine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod impg;
 pub mod impg_index;
 pub mod multi_impg;
 pub mod onealn;
+pub mod pack;
 pub mod paf;
 pub mod seqidx;
 pub mod sequence_index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 use coitrees::{Interval, IntervalTree};
 use crossbeam_channel as channel;
 use impg::alignment_record::{AlignmentFormat, AlignmentRecord, Strand};
-use impg::commands::{genotype, graph, lace, partition, refine, similarity};
+use impg::commands::{genotype, graph, infer, lace, partition, refine, similarity};
 use impg::impg::{AdjustedInterval, CigarOp, Impg};
 use impg::impg_index::{ImpgIndex, ImpgWrapper};
 use impg::multi_impg::MultiImpg;
@@ -3065,6 +3065,116 @@ enum Args {
         command: GenotypeCommand,
     },
 
+    /// Infer allele calls across ranges or partitions from graph-derived evidence
+    Infer {
+        /// Syng index prefix or .1khash/.1gbwt/.spos/.pstep/.names/.meta path
+        #[clap(short = 'a', long, value_parser)]
+        index: String,
+
+        /// Sample evidence produced by `impg map -o pack` or `impg map -o packbin`
+        #[clap(short = 'p', long, value_parser)]
+        pack: String,
+
+        /// Type exactly one target range, in the format `seq_name:start-end`
+        #[clap(short = 'r', long, value_parser, conflicts_with_all = ["target_bed", "partitions"])]
+        target_range: Option<String>,
+
+        /// BED-like target ranges to type independently
+        #[clap(long, alias = "regions", value_parser, conflicts_with_all = ["target_range", "partitions"])]
+        target_bed: Option<String>,
+
+        /// BED-like partitions from `impg partition`; the first row per partition is used as the typed reference range
+        #[clap(long, value_parser, conflicts_with_all = ["target_range", "target_bed"])]
+        partitions: Option<String>,
+
+        /// Window size for internal partition discovery when no target input is provided
+        #[clap(short = 'w', long, value_parser, default_value_t = 1_000_000)]
+        window_size: usize,
+
+        /// Required for internal partition discovery. Merge query-gathered ranges separated by at most this many bp
+        #[clap(short = 'd', long, value_parser)]
+        merge_distance: Option<i32>,
+
+        /// Path to sequence names used to seed internal partition discovery
+        #[clap(long, value_parser)]
+        starting_sequences_file: Option<String>,
+
+        /// Selection mode for internal partition discovery
+        #[clap(long, value_parser, default_value = "longest")]
+        selection_mode: String,
+
+        /// Minimum region size for missing regions during internal partition discovery
+        #[clap(long, value_parser, default_value_t = 3000)]
+        min_missing_size: i32,
+
+        /// Minimum distance from sequence start/end during internal partition discovery
+        #[clap(long, value_parser, default_value_t = 3000)]
+        min_boundary_distance: i32,
+
+        /// Boundary padding in bp for syng queries during internal partition discovery
+        #[clap(long, value_parser, default_value_t = 120)]
+        partition_syng_padding: u64,
+
+        /// Minimum anchor count for syng chains during internal partition discovery
+        #[clap(long, value_parser, default_value_t = 0)]
+        partition_syng_min_chain_anchors: usize,
+
+        /// Minimum query-span fraction for syng chains during internal partition discovery
+        #[clap(long, value_parser, default_value_t = 0.0)]
+        partition_syng_min_chain_fraction: f64,
+
+        /// Disable post-partition singleton sliver rehoming during internal partition discovery
+        #[clap(long, action)]
+        no_rehome_singletons: bool,
+
+        /// Scoring method
+        #[clap(long, value_parser, default_value = "cos")]
+        score: String,
+
+        /// Candidate extraction mode
+        #[clap(long, value_enum, default_value_t = genotype::CandidateMode::Spanning)]
+        candidate_mode: genotype::CandidateMode,
+
+        /// Ploidy for genotype combinations
+        #[clap(long, value_parser, default_value_t = 2)]
+        ploidy: usize,
+
+        /// Number of genotype combinations to emit per target
+        #[clap(long, value_parser, default_value_t = 1)]
+        top_n: usize,
+
+        /// Keep only the best N single-haplotype candidates before combination search (0 = keep all)
+        #[clap(long, value_parser, default_value_t = 200)]
+        candidate_top_k: usize,
+
+        /// Maximum haplotype combinations to score per target
+        #[clap(long, value_parser, default_value_t = 1_000_000)]
+        max_combinations: u64,
+
+        /// Target-side padding in bp for syng candidate discovery during local typing
+        #[clap(long, value_parser, default_value_t = 0)]
+        syng_padding: u64,
+
+        /// Source-side extension in bp for syng candidate discovery during local typing
+        #[clap(long, value_parser, default_value_t = 0)]
+        syng_extension: u64,
+
+        /// Minimum shared syncmer anchors required for a candidate
+        #[clap(long, value_parser, default_value_t = 2)]
+        min_anchors: usize,
+
+        /// For spanning mode, minimum fraction of the requested reference range covered by shared anchors
+        #[clap(long, value_parser, default_value_t = 0.8)]
+        min_span_fraction: f64,
+
+        /// Output file path (default: stdout; .zst/.zstd enables zstd compression)
+        #[clap(short = 'O', long, value_parser)]
+        output: Option<String>,
+
+        #[clap(flatten)]
+        common: CommonOpts,
+    },
+
     /// Print alignment statistics
     Stats {
         // --- Input ---
@@ -4925,6 +5035,137 @@ fn run() -> io::Result<()> {
                         stdout.write_all(&out)?;
                         stdout.flush()?;
                     }
+                }
+            }
+        },
+        Args::Infer {
+            index,
+            pack,
+            target_range,
+            target_bed,
+            partitions,
+            window_size,
+            merge_distance,
+            starting_sequences_file,
+            selection_mode,
+            min_missing_size,
+            min_boundary_distance,
+            partition_syng_padding,
+            partition_syng_min_chain_anchors,
+            partition_syng_min_chain_fraction,
+            no_rehome_singletons,
+            score,
+            candidate_mode,
+            ploidy,
+            top_n,
+            candidate_top_k,
+            max_combinations,
+            syng_padding,
+            syng_extension,
+            min_anchors,
+            min_span_fraction,
+            output,
+            common,
+        } => {
+            initialize_threads_and_log(&common);
+            if score != "cos" {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unsupported infer --score '{}'; currently only 'cos' is supported", score),
+                ));
+            }
+            if window_size == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--window-size must be greater than 0",
+                ));
+            }
+
+            let targets = if let Some(range) = target_range {
+                vec![infer::parse_target_range(&range)?]
+            } else if let Some(path) = target_bed {
+                infer::parse_target_bed(&path)?
+            } else if let Some(path) = partitions {
+                infer::parse_partitions(&path)?
+            } else {
+                Vec::new()
+            };
+
+            let discovery = if targets.is_empty() {
+                let merge_distance = merge_distance.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "impg infer discovery mode requires -d/--merge-distance; provide --target-range, --target-bed, or --partitions to type explicit ranges",
+                    )
+                })?;
+                if merge_distance < 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--merge-distance must be >= 0",
+                    ));
+                }
+                validate_selection_mode(&selection_mode)?;
+                Some(infer::PartitionDiscoveryConfig {
+                    window_size,
+                    merge_distance,
+                    starting_sequences_file: starting_sequences_file.as_deref(),
+                    selection_mode: &selection_mode,
+                    min_missing_size,
+                    min_boundary_distance,
+                    syng_padding: partition_syng_padding,
+                    syng_min_chain_anchors: partition_syng_min_chain_anchors,
+                    syng_min_chain_fraction: partition_syng_min_chain_fraction,
+                    rehome_singletons: !no_rehome_singletons,
+                })
+            } else {
+                None
+            };
+
+            let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+            let config = infer::InferConfig {
+                syng_prefix: &syng_prefix,
+                pack_path: &pack,
+                targets,
+                discovery,
+                candidate_mode,
+                ploidy,
+                top_n,
+                candidate_top_k,
+                max_combinations,
+                syng_padding,
+                syng_extension,
+                min_anchors,
+                min_span_fraction,
+            };
+
+            #[cfg(unix)]
+            let saved_stdout = silence_stdout_for_process()?;
+            #[cfg(not(unix))]
+            silence_stdout_for_process()?;
+
+            if let Some(path) = output {
+                let mut out = create_map_output_writer(&path)?;
+                infer::run_syng_pack_infer(&mut out, &config)?;
+                out.flush()?;
+                #[cfg(unix)]
+                unsafe {
+                    libc::close(saved_stdout);
+                }
+            } else {
+                let mut out = Vec::new();
+                infer::run_syng_pack_infer(&mut out, &config)?;
+                #[cfg(unix)]
+                {
+                    write_all_to_fd(saved_stdout, &out)?;
+                    unsafe {
+                        libc::close(saved_stdout);
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let mut stdout = io::stdout();
+                    stdout.write_all(&out)?;
+                    stdout.flush()?;
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 use coitrees::{Interval, IntervalTree};
 use crossbeam_channel as channel;
 use impg::alignment_record::{AlignmentFormat, AlignmentRecord, Strand};
@@ -20,7 +20,7 @@ use rustc_hash::FxHashMap;
 use std::collections::{hash_map::DefaultHasher, BTreeMap};
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::num::NonZeroUsize;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
@@ -1068,6 +1068,24 @@ fn write_u64_le<W: Write>(out: &mut W, value: u64) -> io::Result<()> {
     out.write_all(&value.to_le_bytes())
 }
 
+fn read_u32_le<R: Read>(input: &mut R) -> io::Result<u32> {
+    let mut bytes = [0u8; 4];
+    input.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_i32_le<R: Read>(input: &mut R) -> io::Result<i32> {
+    let mut bytes = [0u8; 4];
+    input.read_exact(&mut bytes)?;
+    Ok(i32::from_le_bytes(bytes))
+}
+
+fn read_u64_le<R: Read>(input: &mut R) -> io::Result<u64> {
+    let mut bytes = [0u8; 8];
+    input.read_exact(&mut bytes)?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
 fn build_syng_map_pack_chunk(
     syng_matcher: &mut impg::syng::SyngMatcherWorker<'_>,
     chunk: &SyngGafQueryChunk,
@@ -1389,6 +1407,690 @@ fn emit_syng_map_pack_binary<W: Write + Send>(
         compression_level,
         block_size
     );
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum GenotypeCandidateMode {
+    /// Keep path candidates whose shared anchors span the requested reference range.
+    Spanning,
+    /// Score every query-gathered candidate interval independently.
+    Overlapping,
+}
+
+#[derive(Debug)]
+struct SyngPackCoverage {
+    counts: FxHashMap<u32, u64>,
+    universe_nodes: Option<u64>,
+    nonzero_nodes: u64,
+    retained_reads: Option<u64>,
+    syncmer_anchors: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct SyngGenotypeCandidate {
+    path_name: String,
+    start: u64,
+    end: u64,
+    strand: char,
+    anchors: usize,
+    query_span_fraction: f64,
+    nodes: Vec<(u32, u64)>,
+    single_similarity: f64,
+}
+
+#[derive(Debug)]
+struct SyngGenotypeCandidateGroup {
+    start: u64,
+    end: u64,
+    anchors: Vec<impg::syng::Anchor>,
+}
+
+#[derive(Debug)]
+struct CosigtResult {
+    combination: Vec<usize>,
+    similarity: f64,
+    qv: f64,
+    dot: f64,
+    sample_norm: f64,
+    genotype_norm: f64,
+}
+
+fn read_syng_pack_counts(path: &str) -> io::Result<SyngPackCoverage> {
+    let mut file = File::open(path)?;
+    let mut magic = [0u8; 8];
+    let n = file.read(&mut magic)?;
+    if n == SYNG_PACK_BINARY_MAGIC.len() && &magic == SYNG_PACK_BINARY_MAGIC {
+        read_syng_pack_binary_counts(file)
+    } else {
+        read_syng_pack_tsv_counts(path)
+    }
+}
+
+fn read_syng_pack_tsv_counts(path: &str) -> io::Result<SyngPackCoverage> {
+    let reader = get_auto_reader(path)?;
+    let mut counts = FxHashMap::default();
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut fields = line.split('\t');
+        let node_id = fields
+            .next()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("pack TSV line {} is missing node_id", line_no + 1),
+                )
+            })?
+            .parse::<u32>()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid pack TSV node_id on line {}: {}", line_no + 1, e),
+                )
+            })?;
+        let count = fields
+            .next()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("pack TSV line {} is missing count", line_no + 1),
+                )
+            })?
+            .parse::<u64>()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid pack TSV count on line {}: {}", line_no + 1, e),
+                )
+            })?;
+        if count > 0 {
+            counts.insert(node_id, count);
+        }
+    }
+    Ok(SyngPackCoverage {
+        nonzero_nodes: counts.len() as u64,
+        counts,
+        universe_nodes: None,
+        retained_reads: None,
+        syncmer_anchors: None,
+    })
+}
+
+fn read_syng_pack_binary_counts(mut file: File) -> io::Result<SyngPackCoverage> {
+    let version = read_u32_le(&mut file)?;
+    if version != SYNG_PACK_BINARY_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported packbin version {}", version),
+        ));
+    }
+    let header_len = read_u32_le(&mut file)?;
+    if header_len != SYNG_PACK_BINARY_HEADER_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported packbin header length {}; expected {}",
+                header_len, SYNG_PACK_BINARY_HEADER_LEN
+            ),
+        ));
+    }
+    let universe_nodes = read_u64_le(&mut file)?;
+    let nonzero_nodes = read_u64_le(&mut file)?;
+    let retained_reads = read_u64_le(&mut file)?;
+    let syncmer_anchors = read_u64_le(&mut file)?;
+    let block_size = read_u32_le(&mut file)? as usize;
+    let _zstd_level = read_i32_le(&mut file)?;
+    let block_count = read_u64_le(&mut file)? as usize;
+    let overflow_count = read_u64_le(&mut file)? as usize;
+    let block_index_offset = read_u64_le(&mut file)?;
+    let overflow_offset = read_u64_le(&mut file)?;
+    let data_offset = read_u64_le(&mut file)?;
+
+    if block_size == 0 && universe_nodes > 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "packbin block size is zero",
+        ));
+    }
+
+    file.seek(SeekFrom::Start(block_index_offset))?;
+    let mut block_offsets = Vec::with_capacity(block_count + 1);
+    for _ in 0..=block_count {
+        block_offsets.push(read_u64_le(&mut file)?);
+    }
+
+    file.seek(SeekFrom::Start(overflow_offset))?;
+    let mut overflow = FxHashMap::default();
+    for _ in 0..overflow_count {
+        let node_id = read_u32_le(&mut file)?;
+        let count = read_u64_le(&mut file)?;
+        overflow.insert(node_id, count);
+    }
+
+    let mut counts = FxHashMap::default();
+    for block_idx in 0..block_count {
+        let start = block_offsets[block_idx];
+        let end = block_offsets[block_idx + 1];
+        if end < start {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "packbin block offsets are not monotonic",
+            ));
+        }
+        let compressed_len = (end - start) as usize;
+        file.seek(SeekFrom::Start(data_offset + start))?;
+        let mut compressed = vec![0u8; compressed_len];
+        file.read_exact(&mut compressed)?;
+        let remaining = (universe_nodes as usize).saturating_sub(block_idx * block_size);
+        let expected_len = remaining.min(block_size);
+        let block = zstd::bulk::decompress(&compressed, expected_len)?;
+        if block.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "packbin block decompressed to unexpected length",
+            ));
+        }
+        for (offset, &count) in block.iter().enumerate() {
+            if count == 0 {
+                continue;
+            }
+            let node_id = (block_idx * block_size + offset + 1) as u32;
+            counts.insert(node_id, u64::from(count));
+        }
+    }
+    for (node_id, count) in overflow {
+        counts.insert(node_id, count);
+    }
+
+    Ok(SyngPackCoverage {
+        counts,
+        universe_nodes: Some(universe_nodes),
+        nonzero_nodes,
+        retained_reads: Some(retained_reads),
+        syncmer_anchors: Some(syncmer_anchors),
+    })
+}
+
+fn syng_anchor_span_fraction(
+    anchors: &[impg::syng::Anchor],
+    region_start: u64,
+    region_end: u64,
+    syncmer_len: u64,
+) -> f64 {
+    if anchors.is_empty() || region_end <= region_start {
+        return 0.0;
+    }
+    let anchor_start = anchors.iter().map(|a| a.query_pos).min().unwrap_or(region_start);
+    let anchor_end = anchors
+        .iter()
+        .map(|a| a.query_pos.saturating_add(syncmer_len))
+        .max()
+        .unwrap_or(anchor_start);
+    let clipped_start = anchor_start.max(region_start);
+    let clipped_end = anchor_end.min(region_end);
+    if clipped_end <= clipped_start {
+        return 0.0;
+    }
+    (clipped_end - clipped_start) as f64 / (region_end - region_start) as f64
+}
+
+fn syng_candidate_node_counts(
+    syng_index: &impg::syng::SyngIndex,
+    path_name: &str,
+    start: u64,
+    end: u64,
+) -> io::Result<Vec<(u32, u64)>> {
+    let path_idx = syng_index
+        .name_map
+        .name_to_path
+        .get(path_name)
+        .copied()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("candidate path '{}' is missing from syng name map", path_name),
+            )
+        })? as usize;
+    let mut counts: FxHashMap<u32, u64> = FxHashMap::default();
+    for (signed_node, _) in syng_index.walk_path_range(path_idx, start, end)? {
+        *counts.entry(signed_node.unsigned_abs()).or_insert(0) += 1;
+    }
+    let mut nodes: Vec<(u32, u64)> = counts.into_iter().collect();
+    nodes.sort_unstable_by_key(|&(node_id, _)| node_id);
+    Ok(nodes)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_syng_genotype_candidates(
+    syng_index: &impg::syng::SyngIndex,
+    target_name: &str,
+    region_start: u64,
+    region_end: u64,
+    padding: u64,
+    extension: u64,
+    mode: GenotypeCandidateMode,
+    min_anchors: usize,
+    min_span_fraction: f64,
+) -> io::Result<Vec<SyngGenotypeCandidate>> {
+    let syncmer_len = syng_index.syncmer_length_bp() as u64;
+    let hits = syng_index.query_region_with_anchors_ext(
+        target_name,
+        region_start,
+        region_end,
+        padding,
+        extension,
+    )?;
+    let mut candidates = Vec::new();
+
+    match mode {
+        GenotypeCandidateMode::Overlapping => {
+            for hit in hits {
+                if hit.anchors.len() < min_anchors || hit.end <= hit.start {
+                    continue;
+                }
+                let query_span_fraction =
+                    syng_anchor_span_fraction(&hit.anchors, region_start, region_end, syncmer_len);
+                let nodes =
+                    syng_candidate_node_counts(syng_index, &hit.genome, hit.start, hit.end)?;
+                if nodes.is_empty() {
+                    continue;
+                }
+                candidates.push(SyngGenotypeCandidate {
+                    path_name: hit.genome,
+                    start: hit.start,
+                    end: hit.end,
+                    strand: hit.strand,
+                    anchors: hit.anchors.len(),
+                    query_span_fraction,
+                    nodes,
+                    single_similarity: 0.0,
+                });
+            }
+        }
+        GenotypeCandidateMode::Spanning => {
+            let mut groups: BTreeMap<(String, char), SyngGenotypeCandidateGroup> = BTreeMap::new();
+            for hit in hits {
+                if hit.end <= hit.start {
+                    continue;
+                }
+                let entry = groups
+                    .entry((hit.genome, hit.strand))
+                    .or_insert_with(|| SyngGenotypeCandidateGroup {
+                        start: u64::MAX,
+                        end: 0,
+                        anchors: Vec::new(),
+                    });
+                entry.start = entry.start.min(hit.start);
+                entry.end = entry.end.max(hit.end);
+                entry.anchors.extend(hit.anchors);
+            }
+
+            for ((path_name, strand), mut group) in groups {
+                group.anchors.sort_by(|a, b| {
+                    a.query_pos
+                        .cmp(&b.query_pos)
+                        .then(a.target_pos.cmp(&b.target_pos))
+                });
+                group.anchors.dedup_by(|a, b| {
+                    a.query_pos == b.query_pos
+                        && a.target_pos == b.target_pos
+                        && a.node_id == b.node_id
+                });
+                let query_span_fraction = syng_anchor_span_fraction(
+                    &group.anchors,
+                    region_start,
+                    region_end,
+                    syncmer_len,
+                );
+                if group.anchors.len() < min_anchors || query_span_fraction < min_span_fraction {
+                    continue;
+                }
+                let nodes =
+                    syng_candidate_node_counts(syng_index, &path_name, group.start, group.end)?;
+                if nodes.is_empty() {
+                    continue;
+                }
+                candidates.push(SyngGenotypeCandidate {
+                    path_name,
+                    start: group.start,
+                    end: group.end,
+                    strand,
+                    anchors: group.anchors.len(),
+                    query_span_fraction,
+                    nodes,
+                    single_similarity: 0.0,
+                });
+            }
+        }
+    }
+
+    candidates.sort_by(|a, b| {
+        a.path_name
+            .cmp(&b.path_name)
+            .then(a.strand.cmp(&b.strand))
+            .then(a.start.cmp(&b.start))
+            .then(a.end.cmp(&b.end))
+    });
+    Ok(candidates)
+}
+
+fn syng_locus_nodes(candidates: &[SyngGenotypeCandidate]) -> Vec<u32> {
+    let mut seen: FxHashMap<u32, ()> = FxHashMap::default();
+    for candidate in candidates {
+        for &(node_id, _) in &candidate.nodes {
+            seen.insert(node_id, ());
+        }
+    }
+    let mut nodes: Vec<u32> = seen.into_keys().collect();
+    nodes.sort_unstable();
+    nodes
+}
+
+fn sample_norm_sq_for_nodes(sample_counts: &FxHashMap<u32, u64>, locus_nodes: &[u32]) -> f64 {
+    locus_nodes
+        .iter()
+        .map(|node_id| sample_counts.get(node_id).copied().unwrap_or(0) as f64)
+        .map(|v| v * v)
+        .sum()
+}
+
+fn cosine_for_candidate_nodes(
+    candidate_nodes: &[(u32, u64)],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+) -> f64 {
+    if sample_norm_sq == 0.0 {
+        return 0.0;
+    }
+    let mut dot = 0.0;
+    let mut genotype_norm_sq = 0.0;
+    for &(node_id, count) in candidate_nodes {
+        let g = count as f64;
+        genotype_norm_sq += g * g;
+        dot += g * sample_counts.get(&node_id).copied().unwrap_or(0) as f64;
+    }
+    if genotype_norm_sq == 0.0 {
+        0.0
+    } else {
+        dot / (sample_norm_sq.sqrt() * genotype_norm_sq.sqrt())
+    }
+}
+
+fn score_cosigt_combination(
+    combination: &[usize],
+    candidates: &[SyngGenotypeCandidate],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+) -> CosigtResult {
+    let mut genotype_counts: FxHashMap<u32, u64> = FxHashMap::default();
+    for &idx in combination {
+        for &(node_id, count) in &candidates[idx].nodes {
+            *genotype_counts.entry(node_id).or_insert(0) += count;
+        }
+    }
+
+    let mut dot = 0.0;
+    let mut genotype_norm_sq = 0.0;
+    for (node_id, count) in genotype_counts {
+        let g = count as f64;
+        genotype_norm_sq += g * g;
+        dot += g * sample_counts.get(&node_id).copied().unwrap_or(0) as f64;
+    }
+
+    let sample_norm = sample_norm_sq.sqrt();
+    let genotype_norm = genotype_norm_sq.sqrt();
+    let similarity = if sample_norm == 0.0 || genotype_norm == 0.0 {
+        0.0
+    } else {
+        dot / (sample_norm * genotype_norm)
+    };
+    let qv = if similarity >= 1.0 {
+        999.0
+    } else if similarity <= 0.0 {
+        0.0
+    } else {
+        -10.0 * (1.0 - similarity).log10()
+    };
+
+    CosigtResult {
+        combination: combination.to_vec(),
+        similarity,
+        qv,
+        dot,
+        sample_norm,
+        genotype_norm,
+    }
+}
+
+struct CosigtSearch<'a> {
+    candidates: &'a [SyngGenotypeCandidate],
+    sample_counts: &'a FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+    ploidy: usize,
+    max_combinations: u64,
+    visited: u64,
+    results: Vec<CosigtResult>,
+}
+
+impl CosigtSearch<'_> {
+    fn run(mut self) -> io::Result<Vec<CosigtResult>> {
+        let mut current = Vec::with_capacity(self.ploidy);
+        self.visit(0, &mut current)?;
+        self.results.sort_by(|a, b| {
+            b.similarity
+                .total_cmp(&a.similarity)
+                .then_with(|| b.dot.total_cmp(&a.dot))
+                .then_with(|| a.combination.cmp(&b.combination))
+        });
+        Ok(self.results)
+    }
+
+    fn visit(&mut self, start: usize, current: &mut Vec<usize>) -> io::Result<()> {
+        if current.len() == self.ploidy {
+            self.visited += 1;
+            if self.visited > self.max_combinations {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "genotype combination search exceeded --max-combinations ({})",
+                        self.max_combinations
+                    ),
+                ));
+            }
+            self.results.push(score_cosigt_combination(
+                current,
+                self.candidates,
+                self.sample_counts,
+                self.sample_norm_sq,
+            ));
+            return Ok(());
+        }
+
+        for idx in start..self.candidates.len() {
+            current.push(idx);
+            self.visit(idx, current)?;
+            current.pop();
+        }
+        Ok(())
+    }
+}
+
+fn format_genotype_candidate_region(candidate: &SyngGenotypeCandidate) -> String {
+    format!(
+        "{}:{}-{}({})",
+        candidate.path_name, candidate.start, candidate.end, candidate.strand
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_syng_genotype_cosigt<W: Write>(
+    out: &mut W,
+    syng_prefix: &str,
+    pack_path: &str,
+    target_range: &str,
+    candidate_mode: GenotypeCandidateMode,
+    ploidy: usize,
+    top_n: usize,
+    candidate_top_k: usize,
+    max_combinations: u64,
+    syng_padding: u64,
+    syng_extension: u64,
+    min_anchors: usize,
+    min_span_fraction: f64,
+) -> io::Result<()> {
+    if ploidy == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--ploidy must be greater than 0",
+        ));
+    }
+    if top_n == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--top-n must be greater than 0",
+        ));
+    }
+    if !(0.0..=1.0).contains(&min_span_fraction) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--min-span-fraction must be between 0 and 1",
+        ));
+    }
+
+    let (target_name, (range_start, range_end), region_name) =
+        partition::parse_target_range(target_range)?;
+    if range_start < 0 || range_end <= range_start {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("target range must be non-empty with non-negative coordinates: {target_range}"),
+        ));
+    }
+    let region_start = range_start as u64;
+    let region_end = range_end as u64;
+
+    info!("Loading syng index from prefix: {}", syng_prefix);
+    let syng_index = impg::syng::SyngIndex::load(syng_prefix, impg::syng::SyncmerParams::default())?;
+    info!("Loading sample pack coverage from {}", pack_path);
+    let pack = read_syng_pack_counts(pack_path)?;
+
+    let mut candidates = collect_syng_genotype_candidates(
+        &syng_index,
+        &target_name,
+        region_start,
+        region_end,
+        syng_padding,
+        syng_extension,
+        candidate_mode,
+        min_anchors,
+        min_span_fraction,
+    )?;
+    if candidates.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "no syng genotype candidates were found for the requested range",
+        ));
+    }
+
+    let all_locus_nodes = syng_locus_nodes(&candidates);
+    let all_sample_norm_sq = sample_norm_sq_for_nodes(&pack.counts, &all_locus_nodes);
+    for candidate in &mut candidates {
+        candidate.single_similarity =
+            cosine_for_candidate_nodes(&candidate.nodes, &pack.counts, all_sample_norm_sq);
+    }
+    candidates.sort_by(|a, b| {
+        b.single_similarity
+            .total_cmp(&a.single_similarity)
+            .then(b.anchors.cmp(&a.anchors))
+            .then(a.path_name.cmp(&b.path_name))
+            .then(a.start.cmp(&b.start))
+    });
+    if candidate_top_k > 0 && candidates.len() > candidate_top_k {
+        candidates.truncate(candidate_top_k);
+    }
+
+    let locus_nodes = syng_locus_nodes(&candidates);
+    let sample_norm_sq = sample_norm_sq_for_nodes(&pack.counts, &locus_nodes);
+    if sample_norm_sq == 0.0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "sample pack has zero coverage over candidate syng nodes",
+        ));
+    }
+
+    let search = CosigtSearch {
+        candidates: &candidates,
+        sample_counts: &pack.counts,
+        sample_norm_sq,
+        ploidy,
+        max_combinations,
+        visited: 0,
+        results: Vec::new(),
+    };
+    let mut results = search.run()?;
+    results.truncate(top_n);
+
+    writeln!(out, "#impg genotype cosigt")?;
+    writeln!(out, "#region\t{}", region_name)?;
+    writeln!(out, "#candidate_mode\t{:?}", candidate_mode)?;
+    writeln!(out, "#ploidy\t{}", ploidy)?;
+    writeln!(out, "#candidates\t{}", candidates.len())?;
+    writeln!(out, "#locus_nodes\t{}", locus_nodes.len())?;
+    writeln!(out, "#pack_nonzero_nodes\t{}", pack.nonzero_nodes)?;
+    if let Some(universe_nodes) = pack.universe_nodes {
+        writeln!(out, "#pack_universe_nodes\t{}", universe_nodes)?;
+    }
+    if let Some(retained_reads) = pack.retained_reads {
+        writeln!(out, "#pack_retained_reads\t{}", retained_reads)?;
+    }
+    if let Some(syncmer_anchors) = pack.syncmer_anchors {
+        writeln!(out, "#pack_syncmer_anchors\t{}", syncmer_anchors)?;
+    }
+    writeln!(
+        out,
+        "#rank\tmethod\tploidy\tsimilarity\tqv\tdot\tsample_norm\tgenotype_norm\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions"
+    )?;
+    for (rank, result) in results.iter().enumerate() {
+        let haplotypes: Vec<&str> = result
+            .combination
+            .iter()
+            .map(|&idx| candidates[idx].path_name.as_str())
+            .collect();
+        let regions: Vec<String> = result
+            .combination
+            .iter()
+            .map(|&idx| format_genotype_candidate_region(&candidates[idx]))
+            .collect();
+        let anchors: Vec<String> = result
+            .combination
+            .iter()
+            .map(|&idx| candidates[idx].anchors.to_string())
+            .collect();
+        let spans: Vec<String> = result
+            .combination
+            .iter()
+            .map(|&idx| format!("{:.6}", candidates[idx].query_span_fraction))
+            .collect();
+        writeln!(
+            out,
+            "{}\tcosigt\t{}\t{:.9}\t{:.3}\t{:.3}\t{:.6}\t{:.6}\t{}\t{}\t{}\t{}",
+            rank + 1,
+            ploidy,
+            result.similarity,
+            result.qv,
+            result.dot,
+            result.sample_norm,
+            result.genotype_norm,
+            haplotypes.join(","),
+            regions.join(","),
+            anchors.join(","),
+            spans.join(","),
+        )?;
+    }
+
     Ok(())
 }
 
@@ -2629,6 +3331,68 @@ impl RefineOpts {
     }
 }
 
+#[derive(Subcommand, Debug)]
+enum GenotypeCommand {
+    /// Genotype a syng locus by COSIGT cosine similarity over pack coverage
+    Cosigt {
+        /// Syng index prefix or .1khash/.1gbwt/.spos/.pstep/.names/.meta path
+        #[clap(short = 'a', long, value_parser)]
+        index: String,
+
+        /// Sample coverage produced by `impg map -o pack` or `impg map -o packbin`
+        #[clap(short = 'p', long, value_parser)]
+        pack: String,
+
+        /// Reference path range to genotype, in the format `seq_name:start-end`
+        #[clap(short = 'r', long, value_parser)]
+        target_range: String,
+
+        /// Candidate extraction mode
+        #[clap(long, value_enum, default_value_t = GenotypeCandidateMode::Spanning)]
+        candidate_mode: GenotypeCandidateMode,
+
+        /// Ploidy for genotype combinations
+        #[clap(long, value_parser, default_value_t = 2)]
+        ploidy: usize,
+
+        /// Number of genotype combinations to emit
+        #[clap(long, value_parser, default_value_t = 20)]
+        top_n: usize,
+
+        /// Keep only the best N single-haplotype candidates before combination search (0 = keep all)
+        #[clap(long, value_parser, default_value_t = 200)]
+        candidate_top_k: usize,
+
+        /// Maximum haplotype combinations to score
+        #[clap(long, value_parser, default_value_t = 1_000_000)]
+        max_combinations: u64,
+
+        /// Target-side padding in bp for syng candidate discovery
+        #[clap(long, value_parser, default_value_t = 0)]
+        syng_padding: u64,
+
+        /// Source-side extension in bp for syng candidate discovery
+        #[clap(long, value_parser, default_value_t = 0)]
+        syng_extension: u64,
+
+        /// Minimum shared syncmer anchors required for a candidate
+        #[clap(long, value_parser, default_value_t = 2)]
+        min_anchors: usize,
+
+        /// For spanning mode, minimum fraction of the requested reference range covered by shared anchors
+        #[clap(long, value_parser, default_value_t = 0.8)]
+        min_span_fraction: f64,
+
+        /// Output file path (default: stdout; .zst/.zstd enables zstd compression)
+        #[clap(short = 'O', long, value_parser)]
+        output: Option<String>,
+
+        // --- General ---
+        #[clap(flatten)]
+        common: CommonOpts,
+    },
+}
+
 /// Parse sequence name to extract subsequence coordinates and original sequence name
 /// Format: `seq_name:start-end` -> (original_seq_name, start_offset)
 /// Detect whether a path points to a syng index. Returns the syng
@@ -3106,6 +3870,13 @@ enum Args {
         // --- General ---
         #[clap(flatten)]
         common: CommonOpts,
+    },
+
+    /// Genotype a locus from graph-derived sample evidence
+    #[command(alias = "gt")]
+    Genotype {
+        #[command(subcommand)]
+        command: GenotypeCommand,
     },
 
     /// Print alignment statistics
@@ -4905,6 +5676,86 @@ fn run() -> io::Result<()> {
                 polarize_guide_samples.as_deref(),
             )?;
         }
+        Args::Genotype { command } => match command {
+            GenotypeCommand::Cosigt {
+                index,
+                pack,
+                target_range,
+                candidate_mode,
+                ploidy,
+                top_n,
+                candidate_top_k,
+                max_combinations,
+                syng_padding,
+                syng_extension,
+                min_anchors,
+                min_span_fraction,
+                output,
+                common,
+            } => {
+                initialize_threads_and_log(&common);
+                let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+
+                #[cfg(unix)]
+                let saved_stdout = silence_stdout_for_process()?;
+                #[cfg(not(unix))]
+                silence_stdout_for_process()?;
+
+                if let Some(path) = output {
+                    let mut out = create_map_output_writer(&path)?;
+                    emit_syng_genotype_cosigt(
+                        &mut out,
+                        &syng_prefix,
+                        &pack,
+                        &target_range,
+                        candidate_mode,
+                        ploidy,
+                        top_n,
+                        candidate_top_k,
+                        max_combinations,
+                        syng_padding,
+                        syng_extension,
+                        min_anchors,
+                        min_span_fraction,
+                    )?;
+                    out.flush()?;
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::close(saved_stdout);
+                    }
+                } else {
+                    let mut out = Vec::new();
+                    emit_syng_genotype_cosigt(
+                        &mut out,
+                        &syng_prefix,
+                        &pack,
+                        &target_range,
+                        candidate_mode,
+                        ploidy,
+                        top_n,
+                        candidate_top_k,
+                        max_combinations,
+                        syng_padding,
+                        syng_extension,
+                        min_anchors,
+                        min_span_fraction,
+                    )?;
+                    #[cfg(unix)]
+                    {
+                        write_all_to_fd(saved_stdout, &out)?;
+                        unsafe {
+                            libc::close(saved_stdout);
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        let mut stdout = io::stdout();
+                        stdout.write_all(&out)?;
+                        stdout.flush()?;
+                    }
+                }
+            }
+        },
         Args::Stats {
             common,
             alignment,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2518,8 +2518,9 @@ impl RefineOpts {
 
 #[derive(Subcommand, Debug)]
 enum GenotypeCommand {
-    /// Genotype a syng locus by COSIGT cosine similarity over pack coverage
-    Cosigt {
+    /// Genotype a locus by cosine similarity over graph-feature coverage
+    #[command(alias = "cosigt")]
+    Cos {
         /// Syng index prefix or .1khash/.1gbwt/.spos/.pstep/.names/.meta path
         #[clap(short = 'a', long, value_parser)]
         index: String,
@@ -4862,7 +4863,7 @@ fn run() -> io::Result<()> {
             )?;
         }
         Args::Genotype { command } => match command {
-            GenotypeCommand::Cosigt {
+            GenotypeCommand::Cos {
                 index,
                 pack,
                 target_range,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use coitrees::{Interval, IntervalTree};
 use crossbeam_channel as channel;
 use impg::alignment_record::{AlignmentFormat, AlignmentRecord, Strand};
-use impg::commands::{graph, lace, partition, refine, similarity};
+use impg::commands::{genotype, graph, lace, partition, refine, similarity};
 use impg::impg::{AdjustedInterval, CigarOp, Impg};
 use impg::impg_index::{ImpgIndex, ImpgWrapper};
 use impg::multi_impg::MultiImpg;
@@ -20,7 +20,7 @@ use rustc_hash::FxHashMap;
 use std::collections::{hash_map::DefaultHasher, BTreeMap};
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{self, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::num::NonZeroUsize;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
@@ -1047,45 +1047,6 @@ struct SyngPackMapStats {
     anchors: usize,
 }
 
-const SYNG_PACK_BINARY_MAGIC: &[u8; 8] = b"IMPGPKB1";
-const SYNG_PACK_BINARY_VERSION: u32 = 1;
-const SYNG_PACK_BINARY_HEADER_LEN: u32 = 96;
-const DEFAULT_PACK_BINARY_BLOCK_SIZE: usize = 1 << 20;
-
-fn is_pack_binary_format(output_format: &str) -> bool {
-    matches!(output_format, "packbin" | "pack-bin" | "bpack")
-}
-
-fn write_u32_le<W: Write>(out: &mut W, value: u32) -> io::Result<()> {
-    out.write_all(&value.to_le_bytes())
-}
-
-fn write_i32_le<W: Write>(out: &mut W, value: i32) -> io::Result<()> {
-    out.write_all(&value.to_le_bytes())
-}
-
-fn write_u64_le<W: Write>(out: &mut W, value: u64) -> io::Result<()> {
-    out.write_all(&value.to_le_bytes())
-}
-
-fn read_u32_le<R: Read>(input: &mut R) -> io::Result<u32> {
-    let mut bytes = [0u8; 4];
-    input.read_exact(&mut bytes)?;
-    Ok(u32::from_le_bytes(bytes))
-}
-
-fn read_i32_le<R: Read>(input: &mut R) -> io::Result<i32> {
-    let mut bytes = [0u8; 4];
-    input.read_exact(&mut bytes)?;
-    Ok(i32::from_le_bytes(bytes))
-}
-
-fn read_u64_le<R: Read>(input: &mut R) -> io::Result<u64> {
-    let mut bytes = [0u8; 8];
-    input.read_exact(&mut bytes)?;
-    Ok(u64::from_le_bytes(bytes))
-}
-
 fn build_syng_map_pack_chunk(
     syng_matcher: &mut impg::syng::SyngMatcherWorker<'_>,
     chunk: &SyngGafQueryChunk,
@@ -1131,13 +1092,7 @@ fn merge_syng_pack_counts(dst: &mut FxHashMap<u32, u64>, src: FxHashMap<u32, u64
 }
 
 fn write_syng_map_pack<W: Write>(out: &mut W, counts: FxHashMap<u32, u64>) -> io::Result<usize> {
-    writeln!(out, "#node_id\tcount")?;
-    let mut rows: Vec<(u32, u64)> = counts.into_iter().collect();
-    rows.sort_unstable_by_key(|&(node_id, _)| node_id);
-    for (node_id, count) in &rows {
-        writeln!(out, "{node_id}\t{count}")?;
-    }
-    Ok(rows.len())
+    impg::pack::write_tsv(out, counts)
 }
 
 fn write_syng_map_pack_binary<W: Write>(
@@ -1148,103 +1103,17 @@ fn write_syng_map_pack_binary<W: Write>(
     compression_level: i32,
     block_size: usize,
 ) -> io::Result<usize> {
-    if !(1..=22).contains(&compression_level) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("--pack-compression-level must be in 1..=22, got {compression_level}"),
-        ));
-    }
-    if block_size == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "--pack-block-size must be greater than 0",
-        ));
-    }
-    if block_size > u32::MAX as usize {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "--pack-block-size must fit in u32",
-        ));
-    }
-    if universe_nodes > u32::MAX as usize {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "packbin currently supports at most 2^32 syncmer nodes",
-        ));
-    }
-
-    let mut dense = vec![0u8; universe_nodes];
-    let mut overflow = Vec::new();
-    for (&node_id, &count) in &counts {
-        if node_id == 0 || node_id as usize > universe_nodes {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("pack count node {node_id} is outside 1..={universe_nodes}"),
-            ));
-        }
-        dense[(node_id - 1) as usize] = count.min(255) as u8;
-        if count > 255 {
-            overflow.push((node_id, count));
-        }
-    }
-    overflow.sort_unstable_by_key(|&(node_id, _)| node_id);
-
-    let block_count = dense.len().div_ceil(block_size);
-    let mut block_offsets = Vec::with_capacity(block_count + 1);
-    let mut compressed_blocks = Vec::with_capacity(block_count);
-    let mut compressed_offset = 0u64;
-    block_offsets.push(compressed_offset);
-    for block in dense.chunks(block_size) {
-        let compressed = zstd::bulk::compress(block, compression_level)?;
-        compressed_offset = compressed_offset
-            .checked_add(compressed.len() as u64)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin offset overflow"))?;
-        block_offsets.push(compressed_offset);
-        compressed_blocks.push(compressed);
-    }
-
-    let header_len = u64::from(SYNG_PACK_BINARY_HEADER_LEN);
-    let block_index_offset = header_len;
-    let block_index_bytes = (block_offsets.len() as u64)
-        .checked_mul(8)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin index overflow"))?;
-    let overflow_offset = block_index_offset
-        .checked_add(block_index_bytes)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin offset overflow"))?;
-    let overflow_bytes = (overflow.len() as u64)
-        .checked_mul(12)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin overflow overflow"))?;
-    let data_offset = overflow_offset
-        .checked_add(overflow_bytes)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin data offset overflow"))?;
-
-    out.write_all(SYNG_PACK_BINARY_MAGIC)?;
-    write_u32_le(out, SYNG_PACK_BINARY_VERSION)?;
-    write_u32_le(out, SYNG_PACK_BINARY_HEADER_LEN)?;
-    write_u64_le(out, universe_nodes as u64)?;
-    write_u64_le(out, counts.len() as u64)?;
-    write_u64_le(out, stats.records as u64)?;
-    write_u64_le(out, stats.anchors as u64)?;
-    write_u32_le(out, block_size as u32)?;
-    write_i32_le(out, compression_level)?;
-    write_u64_le(out, block_count as u64)?;
-    write_u64_le(out, overflow.len() as u64)?;
-    write_u64_le(out, block_index_offset)?;
-    write_u64_le(out, overflow_offset)?;
-    write_u64_le(out, data_offset)?;
-
-    for offset in block_offsets {
-        write_u64_le(out, offset)?;
-    }
-    for (node_id, count) in overflow {
-        write_u32_le(out, node_id)?;
-        write_u64_le(out, count)?;
-    }
-    for block in compressed_blocks {
-        out.write_all(&block)?;
-    }
-
-    Ok(counts.len())
+    impg::pack::write_binary(
+        out,
+        &counts,
+        impg::pack::WriteStats {
+            retained_records: stats.records as u64,
+            syncmer_anchors: stats.anchors as u64,
+        },
+        universe_nodes,
+        compression_level,
+        block_size,
+    )
 }
 
 fn collect_syng_map_pack_counts_sequential(
@@ -1407,690 +1276,6 @@ fn emit_syng_map_pack_binary<W: Write + Send>(
         compression_level,
         block_size
     );
-    Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum GenotypeCandidateMode {
-    /// Keep path candidates whose shared anchors span the requested reference range.
-    Spanning,
-    /// Score every query-gathered candidate interval independently.
-    Overlapping,
-}
-
-#[derive(Debug)]
-struct SyngPackCoverage {
-    counts: FxHashMap<u32, u64>,
-    universe_nodes: Option<u64>,
-    nonzero_nodes: u64,
-    retained_reads: Option<u64>,
-    syncmer_anchors: Option<u64>,
-}
-
-#[derive(Debug, Clone)]
-struct SyngGenotypeCandidate {
-    path_name: String,
-    start: u64,
-    end: u64,
-    strand: char,
-    anchors: usize,
-    query_span_fraction: f64,
-    nodes: Vec<(u32, u64)>,
-    single_similarity: f64,
-}
-
-#[derive(Debug)]
-struct SyngGenotypeCandidateGroup {
-    start: u64,
-    end: u64,
-    anchors: Vec<impg::syng::Anchor>,
-}
-
-#[derive(Debug)]
-struct CosigtResult {
-    combination: Vec<usize>,
-    similarity: f64,
-    qv: f64,
-    dot: f64,
-    sample_norm: f64,
-    genotype_norm: f64,
-}
-
-fn read_syng_pack_counts(path: &str) -> io::Result<SyngPackCoverage> {
-    let mut file = File::open(path)?;
-    let mut magic = [0u8; 8];
-    let n = file.read(&mut magic)?;
-    if n == SYNG_PACK_BINARY_MAGIC.len() && &magic == SYNG_PACK_BINARY_MAGIC {
-        read_syng_pack_binary_counts(file)
-    } else {
-        read_syng_pack_tsv_counts(path)
-    }
-}
-
-fn read_syng_pack_tsv_counts(path: &str) -> io::Result<SyngPackCoverage> {
-    let reader = get_auto_reader(path)?;
-    let mut counts = FxHashMap::default();
-    for (line_no, line) in reader.lines().enumerate() {
-        let line = line?;
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        let mut fields = line.split('\t');
-        let node_id = fields
-            .next()
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("pack TSV line {} is missing node_id", line_no + 1),
-                )
-            })?
-            .parse::<u32>()
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("invalid pack TSV node_id on line {}: {}", line_no + 1, e),
-                )
-            })?;
-        let count = fields
-            .next()
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("pack TSV line {} is missing count", line_no + 1),
-                )
-            })?
-            .parse::<u64>()
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("invalid pack TSV count on line {}: {}", line_no + 1, e),
-                )
-            })?;
-        if count > 0 {
-            counts.insert(node_id, count);
-        }
-    }
-    Ok(SyngPackCoverage {
-        nonzero_nodes: counts.len() as u64,
-        counts,
-        universe_nodes: None,
-        retained_reads: None,
-        syncmer_anchors: None,
-    })
-}
-
-fn read_syng_pack_binary_counts(mut file: File) -> io::Result<SyngPackCoverage> {
-    let version = read_u32_le(&mut file)?;
-    if version != SYNG_PACK_BINARY_VERSION {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("unsupported packbin version {}", version),
-        ));
-    }
-    let header_len = read_u32_le(&mut file)?;
-    if header_len != SYNG_PACK_BINARY_HEADER_LEN {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "unsupported packbin header length {}; expected {}",
-                header_len, SYNG_PACK_BINARY_HEADER_LEN
-            ),
-        ));
-    }
-    let universe_nodes = read_u64_le(&mut file)?;
-    let nonzero_nodes = read_u64_le(&mut file)?;
-    let retained_reads = read_u64_le(&mut file)?;
-    let syncmer_anchors = read_u64_le(&mut file)?;
-    let block_size = read_u32_le(&mut file)? as usize;
-    let _zstd_level = read_i32_le(&mut file)?;
-    let block_count = read_u64_le(&mut file)? as usize;
-    let overflow_count = read_u64_le(&mut file)? as usize;
-    let block_index_offset = read_u64_le(&mut file)?;
-    let overflow_offset = read_u64_le(&mut file)?;
-    let data_offset = read_u64_le(&mut file)?;
-
-    if block_size == 0 && universe_nodes > 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "packbin block size is zero",
-        ));
-    }
-
-    file.seek(SeekFrom::Start(block_index_offset))?;
-    let mut block_offsets = Vec::with_capacity(block_count + 1);
-    for _ in 0..=block_count {
-        block_offsets.push(read_u64_le(&mut file)?);
-    }
-
-    file.seek(SeekFrom::Start(overflow_offset))?;
-    let mut overflow = FxHashMap::default();
-    for _ in 0..overflow_count {
-        let node_id = read_u32_le(&mut file)?;
-        let count = read_u64_le(&mut file)?;
-        overflow.insert(node_id, count);
-    }
-
-    let mut counts = FxHashMap::default();
-    for block_idx in 0..block_count {
-        let start = block_offsets[block_idx];
-        let end = block_offsets[block_idx + 1];
-        if end < start {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "packbin block offsets are not monotonic",
-            ));
-        }
-        let compressed_len = (end - start) as usize;
-        file.seek(SeekFrom::Start(data_offset + start))?;
-        let mut compressed = vec![0u8; compressed_len];
-        file.read_exact(&mut compressed)?;
-        let remaining = (universe_nodes as usize).saturating_sub(block_idx * block_size);
-        let expected_len = remaining.min(block_size);
-        let block = zstd::bulk::decompress(&compressed, expected_len)?;
-        if block.len() != expected_len {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "packbin block decompressed to unexpected length",
-            ));
-        }
-        for (offset, &count) in block.iter().enumerate() {
-            if count == 0 {
-                continue;
-            }
-            let node_id = (block_idx * block_size + offset + 1) as u32;
-            counts.insert(node_id, u64::from(count));
-        }
-    }
-    for (node_id, count) in overflow {
-        counts.insert(node_id, count);
-    }
-
-    Ok(SyngPackCoverage {
-        counts,
-        universe_nodes: Some(universe_nodes),
-        nonzero_nodes,
-        retained_reads: Some(retained_reads),
-        syncmer_anchors: Some(syncmer_anchors),
-    })
-}
-
-fn syng_anchor_span_fraction(
-    anchors: &[impg::syng::Anchor],
-    region_start: u64,
-    region_end: u64,
-    syncmer_len: u64,
-) -> f64 {
-    if anchors.is_empty() || region_end <= region_start {
-        return 0.0;
-    }
-    let anchor_start = anchors.iter().map(|a| a.query_pos).min().unwrap_or(region_start);
-    let anchor_end = anchors
-        .iter()
-        .map(|a| a.query_pos.saturating_add(syncmer_len))
-        .max()
-        .unwrap_or(anchor_start);
-    let clipped_start = anchor_start.max(region_start);
-    let clipped_end = anchor_end.min(region_end);
-    if clipped_end <= clipped_start {
-        return 0.0;
-    }
-    (clipped_end - clipped_start) as f64 / (region_end - region_start) as f64
-}
-
-fn syng_candidate_node_counts(
-    syng_index: &impg::syng::SyngIndex,
-    path_name: &str,
-    start: u64,
-    end: u64,
-) -> io::Result<Vec<(u32, u64)>> {
-    let path_idx = syng_index
-        .name_map
-        .name_to_path
-        .get(path_name)
-        .copied()
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("candidate path '{}' is missing from syng name map", path_name),
-            )
-        })? as usize;
-    let mut counts: FxHashMap<u32, u64> = FxHashMap::default();
-    for (signed_node, _) in syng_index.walk_path_range(path_idx, start, end)? {
-        *counts.entry(signed_node.unsigned_abs()).or_insert(0) += 1;
-    }
-    let mut nodes: Vec<(u32, u64)> = counts.into_iter().collect();
-    nodes.sort_unstable_by_key(|&(node_id, _)| node_id);
-    Ok(nodes)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn collect_syng_genotype_candidates(
-    syng_index: &impg::syng::SyngIndex,
-    target_name: &str,
-    region_start: u64,
-    region_end: u64,
-    padding: u64,
-    extension: u64,
-    mode: GenotypeCandidateMode,
-    min_anchors: usize,
-    min_span_fraction: f64,
-) -> io::Result<Vec<SyngGenotypeCandidate>> {
-    let syncmer_len = syng_index.syncmer_length_bp() as u64;
-    let hits = syng_index.query_region_with_anchors_ext(
-        target_name,
-        region_start,
-        region_end,
-        padding,
-        extension,
-    )?;
-    let mut candidates = Vec::new();
-
-    match mode {
-        GenotypeCandidateMode::Overlapping => {
-            for hit in hits {
-                if hit.anchors.len() < min_anchors || hit.end <= hit.start {
-                    continue;
-                }
-                let query_span_fraction =
-                    syng_anchor_span_fraction(&hit.anchors, region_start, region_end, syncmer_len);
-                let nodes =
-                    syng_candidate_node_counts(syng_index, &hit.genome, hit.start, hit.end)?;
-                if nodes.is_empty() {
-                    continue;
-                }
-                candidates.push(SyngGenotypeCandidate {
-                    path_name: hit.genome,
-                    start: hit.start,
-                    end: hit.end,
-                    strand: hit.strand,
-                    anchors: hit.anchors.len(),
-                    query_span_fraction,
-                    nodes,
-                    single_similarity: 0.0,
-                });
-            }
-        }
-        GenotypeCandidateMode::Spanning => {
-            let mut groups: BTreeMap<(String, char), SyngGenotypeCandidateGroup> = BTreeMap::new();
-            for hit in hits {
-                if hit.end <= hit.start {
-                    continue;
-                }
-                let entry = groups
-                    .entry((hit.genome, hit.strand))
-                    .or_insert_with(|| SyngGenotypeCandidateGroup {
-                        start: u64::MAX,
-                        end: 0,
-                        anchors: Vec::new(),
-                    });
-                entry.start = entry.start.min(hit.start);
-                entry.end = entry.end.max(hit.end);
-                entry.anchors.extend(hit.anchors);
-            }
-
-            for ((path_name, strand), mut group) in groups {
-                group.anchors.sort_by(|a, b| {
-                    a.query_pos
-                        .cmp(&b.query_pos)
-                        .then(a.target_pos.cmp(&b.target_pos))
-                });
-                group.anchors.dedup_by(|a, b| {
-                    a.query_pos == b.query_pos
-                        && a.target_pos == b.target_pos
-                        && a.node_id == b.node_id
-                });
-                let query_span_fraction = syng_anchor_span_fraction(
-                    &group.anchors,
-                    region_start,
-                    region_end,
-                    syncmer_len,
-                );
-                if group.anchors.len() < min_anchors || query_span_fraction < min_span_fraction {
-                    continue;
-                }
-                let nodes =
-                    syng_candidate_node_counts(syng_index, &path_name, group.start, group.end)?;
-                if nodes.is_empty() {
-                    continue;
-                }
-                candidates.push(SyngGenotypeCandidate {
-                    path_name,
-                    start: group.start,
-                    end: group.end,
-                    strand,
-                    anchors: group.anchors.len(),
-                    query_span_fraction,
-                    nodes,
-                    single_similarity: 0.0,
-                });
-            }
-        }
-    }
-
-    candidates.sort_by(|a, b| {
-        a.path_name
-            .cmp(&b.path_name)
-            .then(a.strand.cmp(&b.strand))
-            .then(a.start.cmp(&b.start))
-            .then(a.end.cmp(&b.end))
-    });
-    Ok(candidates)
-}
-
-fn syng_locus_nodes(candidates: &[SyngGenotypeCandidate]) -> Vec<u32> {
-    let mut seen: FxHashMap<u32, ()> = FxHashMap::default();
-    for candidate in candidates {
-        for &(node_id, _) in &candidate.nodes {
-            seen.insert(node_id, ());
-        }
-    }
-    let mut nodes: Vec<u32> = seen.into_keys().collect();
-    nodes.sort_unstable();
-    nodes
-}
-
-fn sample_norm_sq_for_nodes(sample_counts: &FxHashMap<u32, u64>, locus_nodes: &[u32]) -> f64 {
-    locus_nodes
-        .iter()
-        .map(|node_id| sample_counts.get(node_id).copied().unwrap_or(0) as f64)
-        .map(|v| v * v)
-        .sum()
-}
-
-fn cosine_for_candidate_nodes(
-    candidate_nodes: &[(u32, u64)],
-    sample_counts: &FxHashMap<u32, u64>,
-    sample_norm_sq: f64,
-) -> f64 {
-    if sample_norm_sq == 0.0 {
-        return 0.0;
-    }
-    let mut dot = 0.0;
-    let mut genotype_norm_sq = 0.0;
-    for &(node_id, count) in candidate_nodes {
-        let g = count as f64;
-        genotype_norm_sq += g * g;
-        dot += g * sample_counts.get(&node_id).copied().unwrap_or(0) as f64;
-    }
-    if genotype_norm_sq == 0.0 {
-        0.0
-    } else {
-        dot / (sample_norm_sq.sqrt() * genotype_norm_sq.sqrt())
-    }
-}
-
-fn score_cosigt_combination(
-    combination: &[usize],
-    candidates: &[SyngGenotypeCandidate],
-    sample_counts: &FxHashMap<u32, u64>,
-    sample_norm_sq: f64,
-) -> CosigtResult {
-    let mut genotype_counts: FxHashMap<u32, u64> = FxHashMap::default();
-    for &idx in combination {
-        for &(node_id, count) in &candidates[idx].nodes {
-            *genotype_counts.entry(node_id).or_insert(0) += count;
-        }
-    }
-
-    let mut dot = 0.0;
-    let mut genotype_norm_sq = 0.0;
-    for (node_id, count) in genotype_counts {
-        let g = count as f64;
-        genotype_norm_sq += g * g;
-        dot += g * sample_counts.get(&node_id).copied().unwrap_or(0) as f64;
-    }
-
-    let sample_norm = sample_norm_sq.sqrt();
-    let genotype_norm = genotype_norm_sq.sqrt();
-    let similarity = if sample_norm == 0.0 || genotype_norm == 0.0 {
-        0.0
-    } else {
-        dot / (sample_norm * genotype_norm)
-    };
-    let qv = if similarity >= 1.0 {
-        999.0
-    } else if similarity <= 0.0 {
-        0.0
-    } else {
-        -10.0 * (1.0 - similarity).log10()
-    };
-
-    CosigtResult {
-        combination: combination.to_vec(),
-        similarity,
-        qv,
-        dot,
-        sample_norm,
-        genotype_norm,
-    }
-}
-
-struct CosigtSearch<'a> {
-    candidates: &'a [SyngGenotypeCandidate],
-    sample_counts: &'a FxHashMap<u32, u64>,
-    sample_norm_sq: f64,
-    ploidy: usize,
-    max_combinations: u64,
-    visited: u64,
-    results: Vec<CosigtResult>,
-}
-
-impl CosigtSearch<'_> {
-    fn run(mut self) -> io::Result<Vec<CosigtResult>> {
-        let mut current = Vec::with_capacity(self.ploidy);
-        self.visit(0, &mut current)?;
-        self.results.sort_by(|a, b| {
-            b.similarity
-                .total_cmp(&a.similarity)
-                .then_with(|| b.dot.total_cmp(&a.dot))
-                .then_with(|| a.combination.cmp(&b.combination))
-        });
-        Ok(self.results)
-    }
-
-    fn visit(&mut self, start: usize, current: &mut Vec<usize>) -> io::Result<()> {
-        if current.len() == self.ploidy {
-            self.visited += 1;
-            if self.visited > self.max_combinations {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!(
-                        "genotype combination search exceeded --max-combinations ({})",
-                        self.max_combinations
-                    ),
-                ));
-            }
-            self.results.push(score_cosigt_combination(
-                current,
-                self.candidates,
-                self.sample_counts,
-                self.sample_norm_sq,
-            ));
-            return Ok(());
-        }
-
-        for idx in start..self.candidates.len() {
-            current.push(idx);
-            self.visit(idx, current)?;
-            current.pop();
-        }
-        Ok(())
-    }
-}
-
-fn format_genotype_candidate_region(candidate: &SyngGenotypeCandidate) -> String {
-    format!(
-        "{}:{}-{}({})",
-        candidate.path_name, candidate.start, candidate.end, candidate.strand
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn emit_syng_genotype_cosigt<W: Write>(
-    out: &mut W,
-    syng_prefix: &str,
-    pack_path: &str,
-    target_range: &str,
-    candidate_mode: GenotypeCandidateMode,
-    ploidy: usize,
-    top_n: usize,
-    candidate_top_k: usize,
-    max_combinations: u64,
-    syng_padding: u64,
-    syng_extension: u64,
-    min_anchors: usize,
-    min_span_fraction: f64,
-) -> io::Result<()> {
-    if ploidy == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "--ploidy must be greater than 0",
-        ));
-    }
-    if top_n == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "--top-n must be greater than 0",
-        ));
-    }
-    if !(0.0..=1.0).contains(&min_span_fraction) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "--min-span-fraction must be between 0 and 1",
-        ));
-    }
-
-    let (target_name, (range_start, range_end), region_name) =
-        partition::parse_target_range(target_range)?;
-    if range_start < 0 || range_end <= range_start {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("target range must be non-empty with non-negative coordinates: {target_range}"),
-        ));
-    }
-    let region_start = range_start as u64;
-    let region_end = range_end as u64;
-
-    info!("Loading syng index from prefix: {}", syng_prefix);
-    let syng_index = impg::syng::SyngIndex::load(syng_prefix, impg::syng::SyncmerParams::default())?;
-    info!("Loading sample pack coverage from {}", pack_path);
-    let pack = read_syng_pack_counts(pack_path)?;
-
-    let mut candidates = collect_syng_genotype_candidates(
-        &syng_index,
-        &target_name,
-        region_start,
-        region_end,
-        syng_padding,
-        syng_extension,
-        candidate_mode,
-        min_anchors,
-        min_span_fraction,
-    )?;
-    if candidates.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "no syng genotype candidates were found for the requested range",
-        ));
-    }
-
-    let all_locus_nodes = syng_locus_nodes(&candidates);
-    let all_sample_norm_sq = sample_norm_sq_for_nodes(&pack.counts, &all_locus_nodes);
-    for candidate in &mut candidates {
-        candidate.single_similarity =
-            cosine_for_candidate_nodes(&candidate.nodes, &pack.counts, all_sample_norm_sq);
-    }
-    candidates.sort_by(|a, b| {
-        b.single_similarity
-            .total_cmp(&a.single_similarity)
-            .then(b.anchors.cmp(&a.anchors))
-            .then(a.path_name.cmp(&b.path_name))
-            .then(a.start.cmp(&b.start))
-    });
-    if candidate_top_k > 0 && candidates.len() > candidate_top_k {
-        candidates.truncate(candidate_top_k);
-    }
-
-    let locus_nodes = syng_locus_nodes(&candidates);
-    let sample_norm_sq = sample_norm_sq_for_nodes(&pack.counts, &locus_nodes);
-    if sample_norm_sq == 0.0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "sample pack has zero coverage over candidate syng nodes",
-        ));
-    }
-
-    let search = CosigtSearch {
-        candidates: &candidates,
-        sample_counts: &pack.counts,
-        sample_norm_sq,
-        ploidy,
-        max_combinations,
-        visited: 0,
-        results: Vec::new(),
-    };
-    let mut results = search.run()?;
-    results.truncate(top_n);
-
-    writeln!(out, "#impg genotype cosigt")?;
-    writeln!(out, "#region\t{}", region_name)?;
-    writeln!(out, "#candidate_mode\t{:?}", candidate_mode)?;
-    writeln!(out, "#ploidy\t{}", ploidy)?;
-    writeln!(out, "#candidates\t{}", candidates.len())?;
-    writeln!(out, "#locus_nodes\t{}", locus_nodes.len())?;
-    writeln!(out, "#pack_nonzero_nodes\t{}", pack.nonzero_nodes)?;
-    if let Some(universe_nodes) = pack.universe_nodes {
-        writeln!(out, "#pack_universe_nodes\t{}", universe_nodes)?;
-    }
-    if let Some(retained_reads) = pack.retained_reads {
-        writeln!(out, "#pack_retained_reads\t{}", retained_reads)?;
-    }
-    if let Some(syncmer_anchors) = pack.syncmer_anchors {
-        writeln!(out, "#pack_syncmer_anchors\t{}", syncmer_anchors)?;
-    }
-    writeln!(
-        out,
-        "#rank\tmethod\tploidy\tsimilarity\tqv\tdot\tsample_norm\tgenotype_norm\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions"
-    )?;
-    for (rank, result) in results.iter().enumerate() {
-        let haplotypes: Vec<&str> = result
-            .combination
-            .iter()
-            .map(|&idx| candidates[idx].path_name.as_str())
-            .collect();
-        let regions: Vec<String> = result
-            .combination
-            .iter()
-            .map(|&idx| format_genotype_candidate_region(&candidates[idx]))
-            .collect();
-        let anchors: Vec<String> = result
-            .combination
-            .iter()
-            .map(|&idx| candidates[idx].anchors.to_string())
-            .collect();
-        let spans: Vec<String> = result
-            .combination
-            .iter()
-            .map(|&idx| format!("{:.6}", candidates[idx].query_span_fraction))
-            .collect();
-        writeln!(
-            out,
-            "{}\tcosigt\t{}\t{:.9}\t{:.3}\t{:.3}\t{:.6}\t{:.6}\t{}\t{}\t{}\t{}",
-            rank + 1,
-            ploidy,
-            result.similarity,
-            result.qv,
-            result.dot,
-            result.sample_norm,
-            result.genotype_norm,
-            haplotypes.join(","),
-            regions.join(","),
-            anchors.join(","),
-            spans.join(","),
-        )?;
-    }
-
     Ok(())
 }
 
@@ -3348,8 +2533,8 @@ enum GenotypeCommand {
         target_range: String,
 
         /// Candidate extraction mode
-        #[clap(long, value_enum, default_value_t = GenotypeCandidateMode::Spanning)]
-        candidate_mode: GenotypeCandidateMode,
+        #[clap(long, value_enum, default_value_t = genotype::CandidateMode::Spanning)]
+        candidate_mode: genotype::CandidateMode,
 
         /// Ploidy for genotype combinations
         #[clap(long, value_parser, default_value_t = 2)]
@@ -3992,7 +3177,7 @@ enum Args {
         pack_compression_level: i32,
 
         /// Dense node-count block size for binary pack random access
-        #[clap(long, value_parser, default_value_t = DEFAULT_PACK_BINARY_BLOCK_SIZE)]
+        #[clap(long, value_parser, default_value_t = impg::pack::DEFAULT_BINARY_BLOCK_SIZE)]
         pack_block_size: usize,
 
         // --- General ---
@@ -5695,6 +4880,20 @@ fn run() -> io::Result<()> {
             } => {
                 initialize_threads_and_log(&common);
                 let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+                let config = genotype::SyngCosigtConfig {
+                    syng_prefix: &syng_prefix,
+                    pack_path: &pack,
+                    target_range: &target_range,
+                    candidate_mode,
+                    ploidy,
+                    top_n,
+                    candidate_top_k,
+                    max_combinations,
+                    syng_padding,
+                    syng_extension,
+                    min_anchors,
+                    min_span_fraction,
+                };
 
                 #[cfg(unix)]
                 let saved_stdout = silence_stdout_for_process()?;
@@ -5703,21 +4902,7 @@ fn run() -> io::Result<()> {
 
                 if let Some(path) = output {
                     let mut out = create_map_output_writer(&path)?;
-                    emit_syng_genotype_cosigt(
-                        &mut out,
-                        &syng_prefix,
-                        &pack,
-                        &target_range,
-                        candidate_mode,
-                        ploidy,
-                        top_n,
-                        candidate_top_k,
-                        max_combinations,
-                        syng_padding,
-                        syng_extension,
-                        min_anchors,
-                        min_span_fraction,
-                    )?;
+                    genotype::run_syng_cosigt(&mut out, &config)?;
                     out.flush()?;
                     #[cfg(unix)]
                     unsafe {
@@ -5725,21 +4910,7 @@ fn run() -> io::Result<()> {
                     }
                 } else {
                     let mut out = Vec::new();
-                    emit_syng_genotype_cosigt(
-                        &mut out,
-                        &syng_prefix,
-                        &pack,
-                        &target_range,
-                        candidate_mode,
-                        ploidy,
-                        top_n,
-                        candidate_top_k,
-                        max_combinations,
-                        syng_padding,
-                        syng_extension,
-                        min_anchors,
-                        min_span_fraction,
-                    )?;
+                    genotype::run_syng_cosigt(&mut out, &config)?;
                     #[cfg(unix)]
                     {
                         write_all_to_fd(saved_stdout, &out)?;
@@ -6025,7 +5196,7 @@ fn run() -> io::Result<()> {
 
             let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
             if !matches!(output_format.as_str(), "gaf" | "paf" | "pack")
-                && !is_pack_binary_format(&output_format)
+                && !impg::pack::is_binary_format(&output_format)
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -6035,7 +5206,7 @@ fn run() -> io::Result<()> {
                     ),
                 ));
             }
-            if is_pack_binary_format(&output_format) {
+            if impg::pack::is_binary_format(&output_format) {
                 if !(1..=22).contains(&pack_compression_level) {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
@@ -6058,7 +5229,7 @@ fn run() -> io::Result<()> {
             silence_stdout_for_process()?;
 
             if let Some(path) = output {
-                let mut out = if is_pack_binary_format(&output_format) {
+                let mut out = if impg::pack::is_binary_format(&output_format) {
                     create_plain_map_output_writer(&path)?
                 } else {
                     create_map_output_writer(&path)?
@@ -6080,7 +5251,7 @@ fn run() -> io::Result<()> {
                         )?;
                         emit_syng_map_pack(&mut out, &syng_matcher, &query, min_anchors)?;
                     }
-                    format if is_pack_binary_format(format) => {
+                    format if impg::pack::is_binary_format(format) => {
                         info!("Loading syng syncmer dictionary from prefix: {}", syng_prefix);
                         let syng_matcher = impg::syng::SyngMatcher::load(
                             &syng_prefix,
@@ -6138,7 +5309,7 @@ fn run() -> io::Result<()> {
                         )?;
                         emit_syng_map_pack(&mut out, &syng_matcher, &query, min_anchors)?;
                     }
-                    format if is_pack_binary_format(format) => {
+                    format if impg::pack::is_binary_format(format) => {
                         info!("Loading syng syncmer dictionary from prefix: {}", syng_prefix);
                         let syng_matcher = impg::syng::SyngMatcher::load(
                             &syng_prefix,

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,0 +1,340 @@
+use rustc_hash::FxHashMap;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write};
+
+pub const BINARY_MAGIC: &[u8; 8] = b"IMPGPKB1";
+pub const BINARY_VERSION: u32 = 1;
+pub const BINARY_HEADER_LEN: u32 = 96;
+pub const DEFAULT_BINARY_BLOCK_SIZE: usize = 1 << 20;
+
+#[derive(Debug, Clone, Copy)]
+pub struct WriteStats {
+    pub retained_records: u64,
+    pub syncmer_anchors: u64,
+}
+
+#[derive(Debug)]
+pub struct Coverage {
+    pub counts: FxHashMap<u32, u64>,
+    pub universe_nodes: Option<u64>,
+    pub nonzero_nodes: u64,
+    pub retained_records: Option<u64>,
+    pub syncmer_anchors: Option<u64>,
+}
+
+pub fn is_binary_format(output_format: &str) -> bool {
+    matches!(output_format, "packbin" | "pack-bin" | "bpack")
+}
+
+fn write_u32_le<W: Write>(out: &mut W, value: u32) -> io::Result<()> {
+    out.write_all(&value.to_le_bytes())
+}
+
+fn write_i32_le<W: Write>(out: &mut W, value: i32) -> io::Result<()> {
+    out.write_all(&value.to_le_bytes())
+}
+
+fn write_u64_le<W: Write>(out: &mut W, value: u64) -> io::Result<()> {
+    out.write_all(&value.to_le_bytes())
+}
+
+fn read_u32_le<R: Read>(input: &mut R) -> io::Result<u32> {
+    let mut bytes = [0u8; 4];
+    input.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_i32_le<R: Read>(input: &mut R) -> io::Result<i32> {
+    let mut bytes = [0u8; 4];
+    input.read_exact(&mut bytes)?;
+    Ok(i32::from_le_bytes(bytes))
+}
+
+fn read_u64_le<R: Read>(input: &mut R) -> io::Result<u64> {
+    let mut bytes = [0u8; 8];
+    input.read_exact(&mut bytes)?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+pub fn write_tsv<W: Write>(out: &mut W, counts: FxHashMap<u32, u64>) -> io::Result<usize> {
+    writeln!(out, "#node_id\tcount")?;
+    let mut rows: Vec<(u32, u64)> = counts.into_iter().collect();
+    rows.sort_unstable_by_key(|&(node_id, _)| node_id);
+    for (node_id, count) in &rows {
+        writeln!(out, "{node_id}\t{count}")?;
+    }
+    Ok(rows.len())
+}
+
+pub fn write_binary<W: Write>(
+    out: &mut W,
+    counts: &FxHashMap<u32, u64>,
+    stats: WriteStats,
+    universe_nodes: usize,
+    compression_level: i32,
+    block_size: usize,
+) -> io::Result<usize> {
+    if !(1..=22).contains(&compression_level) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("--pack-compression-level must be in 1..=22, got {compression_level}"),
+        ));
+    }
+    if block_size == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--pack-block-size must be greater than 0",
+        ));
+    }
+    if block_size > u32::MAX as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--pack-block-size must fit in u32",
+        ));
+    }
+    if universe_nodes > u32::MAX as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "packbin currently supports at most 2^32 graph features",
+        ));
+    }
+
+    let mut dense = vec![0u8; universe_nodes];
+    let mut overflow = Vec::new();
+    for (&node_id, &count) in counts {
+        if node_id == 0 || node_id as usize > universe_nodes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("pack count node {node_id} is outside 1..={universe_nodes}"),
+            ));
+        }
+        dense[(node_id - 1) as usize] = count.min(255) as u8;
+        if count > 255 {
+            overflow.push((node_id, count));
+        }
+    }
+    overflow.sort_unstable_by_key(|&(node_id, _)| node_id);
+
+    let block_count = dense.len().div_ceil(block_size);
+    let mut block_offsets = Vec::with_capacity(block_count + 1);
+    let mut compressed_blocks = Vec::with_capacity(block_count);
+    let mut compressed_offset = 0u64;
+    block_offsets.push(compressed_offset);
+    for block in dense.chunks(block_size) {
+        let compressed = zstd::bulk::compress(block, compression_level)?;
+        compressed_offset = compressed_offset
+            .checked_add(compressed.len() as u64)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin offset overflow"))?;
+        block_offsets.push(compressed_offset);
+        compressed_blocks.push(compressed);
+    }
+
+    let header_len = u64::from(BINARY_HEADER_LEN);
+    let block_index_offset = header_len;
+    let block_index_bytes = (block_offsets.len() as u64)
+        .checked_mul(8)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin index overflow"))?;
+    let overflow_offset = block_index_offset
+        .checked_add(block_index_bytes)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin offset overflow"))?;
+    let overflow_bytes = (overflow.len() as u64)
+        .checked_mul(12)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "packbin overflow overflow"))?;
+    let data_offset = overflow_offset.checked_add(overflow_bytes).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "packbin data offset overflow")
+    })?;
+
+    out.write_all(BINARY_MAGIC)?;
+    write_u32_le(out, BINARY_VERSION)?;
+    write_u32_le(out, BINARY_HEADER_LEN)?;
+    write_u64_le(out, universe_nodes as u64)?;
+    write_u64_le(out, counts.len() as u64)?;
+    write_u64_le(out, stats.retained_records)?;
+    write_u64_le(out, stats.syncmer_anchors)?;
+    write_u32_le(out, block_size as u32)?;
+    write_i32_le(out, compression_level)?;
+    write_u64_le(out, block_count as u64)?;
+    write_u64_le(out, overflow.len() as u64)?;
+    write_u64_le(out, block_index_offset)?;
+    write_u64_le(out, overflow_offset)?;
+    write_u64_le(out, data_offset)?;
+
+    for offset in block_offsets {
+        write_u64_le(out, offset)?;
+    }
+    for (node_id, count) in overflow {
+        write_u32_le(out, node_id)?;
+        write_u64_le(out, count)?;
+    }
+    for block in compressed_blocks {
+        out.write_all(&block)?;
+    }
+
+    Ok(counts.len())
+}
+
+pub fn read(path: &str) -> io::Result<Coverage> {
+    let mut file = File::open(path)?;
+    let mut magic = [0u8; 8];
+    let n = file.read(&mut magic)?;
+    if n == BINARY_MAGIC.len() && &magic == BINARY_MAGIC {
+        read_binary(file)
+    } else {
+        read_tsv(path)
+    }
+}
+
+fn read_tsv(path: &str) -> io::Result<Coverage> {
+    let reader = auto_reader(path)?;
+    let mut counts = FxHashMap::default();
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut fields = line.split('\t');
+        let node_id = fields
+            .next()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("pack TSV line {} is missing node_id", line_no + 1),
+                )
+            })?
+            .parse::<u32>()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid pack TSV node_id on line {}: {}", line_no + 1, e),
+                )
+            })?;
+        let count = fields
+            .next()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("pack TSV line {} is missing count", line_no + 1),
+                )
+            })?
+            .parse::<u64>()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid pack TSV count on line {}: {}", line_no + 1, e),
+                )
+            })?;
+        if count > 0 {
+            counts.insert(node_id, count);
+        }
+    }
+    Ok(Coverage {
+        nonzero_nodes: counts.len() as u64,
+        counts,
+        universe_nodes: None,
+        retained_records: None,
+        syncmer_anchors: None,
+    })
+}
+
+fn read_binary(mut file: File) -> io::Result<Coverage> {
+    let version = read_u32_le(&mut file)?;
+    if version != BINARY_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported packbin version {}", version),
+        ));
+    }
+    let header_len = read_u32_le(&mut file)?;
+    if header_len != BINARY_HEADER_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported packbin header length {}; expected {}",
+                header_len, BINARY_HEADER_LEN
+            ),
+        ));
+    }
+    let universe_nodes = read_u64_le(&mut file)?;
+    let nonzero_nodes = read_u64_le(&mut file)?;
+    let retained_records = read_u64_le(&mut file)?;
+    let syncmer_anchors = read_u64_le(&mut file)?;
+    let block_size = read_u32_le(&mut file)? as usize;
+    let _zstd_level = read_i32_le(&mut file)?;
+    let block_count = read_u64_le(&mut file)? as usize;
+    let overflow_count = read_u64_le(&mut file)? as usize;
+    let block_index_offset = read_u64_le(&mut file)?;
+    let overflow_offset = read_u64_le(&mut file)?;
+    let data_offset = read_u64_le(&mut file)?;
+
+    if block_size == 0 && universe_nodes > 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "packbin block size is zero",
+        ));
+    }
+
+    file.seek(SeekFrom::Start(block_index_offset))?;
+    let mut block_offsets = Vec::with_capacity(block_count + 1);
+    for _ in 0..=block_count {
+        block_offsets.push(read_u64_le(&mut file)?);
+    }
+
+    file.seek(SeekFrom::Start(overflow_offset))?;
+    let mut overflow = FxHashMap::default();
+    for _ in 0..overflow_count {
+        let node_id = read_u32_le(&mut file)?;
+        let count = read_u64_le(&mut file)?;
+        overflow.insert(node_id, count);
+    }
+
+    let mut counts = FxHashMap::default();
+    for block_idx in 0..block_count {
+        let start = block_offsets[block_idx];
+        let end = block_offsets[block_idx + 1];
+        if end < start {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "packbin block offsets are not monotonic",
+            ));
+        }
+        let compressed_len = (end - start) as usize;
+        file.seek(SeekFrom::Start(data_offset + start))?;
+        let mut compressed = vec![0u8; compressed_len];
+        file.read_exact(&mut compressed)?;
+        let remaining = (universe_nodes as usize).saturating_sub(block_idx * block_size);
+        let expected_len = remaining.min(block_size);
+        let block = zstd::bulk::decompress(&compressed, expected_len)?;
+        if block.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "packbin block decompressed to unexpected length",
+            ));
+        }
+        for (offset, &count) in block.iter().enumerate() {
+            if count == 0 {
+                continue;
+            }
+            let node_id = (block_idx * block_size + offset + 1) as u32;
+            counts.insert(node_id, u64::from(count));
+        }
+    }
+    for (node_id, count) in overflow {
+        counts.insert(node_id, count);
+    }
+
+    Ok(Coverage {
+        counts,
+        universe_nodes: Some(universe_nodes),
+        nonzero_nodes,
+        retained_records: Some(retained_records),
+        syncmer_anchors: Some(syncmer_anchors),
+    })
+}
+
+fn auto_reader(path: &str) -> io::Result<Box<dyn BufRead>> {
+    let file = File::open(path)?;
+    let (reader, _format) = niffler::get_reader(Box::new(file))
+        .map_err(|e| io::Error::other(format!("Failed to open reader for '{}': {}", path, e)))?;
+    Ok(Box::new(BufReader::new(reader)))
+}

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -2593,6 +2593,23 @@ impl SyngIndex {
         }))
     }
 
+    /// Walk a bp interval on an indexed forward path using sampled path-step
+    /// checkpoints, returning every syncmer step overlapping `[start, end)`.
+    pub fn walk_path_range(
+        &self,
+        path_idx: usize,
+        start: u64,
+        end: u64,
+    ) -> io::Result<Vec<(i32, u64)>> {
+        if path_idx >= self.name_map.path_to_name.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("path index {} is outside the syng name map", path_idx),
+            ));
+        }
+        self.walk_path_range_from_sampled_steps(path_idx, start, end)
+    }
+
     /// Rebuild both sampled positional sidecars by walking existing GBWT paths.
     ///
     /// This repairs indexes that already have `.1gbwt`, `.1khash`, `.names`, and

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -1651,6 +1651,323 @@ fn test_syng_genotype_cos_short_read_simulation_calls_heterozygote() {
 }
 
 #[test]
+fn test_syng_infer_pack_partitions_and_discovery() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_infer_pack");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let left = numeric_to_ascii(&make_sequence_numeric(900, 41));
+    let allele_a = numeric_to_ascii(&make_sequence_numeric(900, 42));
+    let allele_b = numeric_to_ascii(&make_sequence_numeric(900, 43));
+    let allele_c = numeric_to_ascii(&make_sequence_numeric(900, 44));
+    let right = numeric_to_ascii(&make_sequence_numeric(900, 45));
+
+    let mut hap_a = Vec::new();
+    hap_a.extend_from_slice(&left);
+    hap_a.extend_from_slice(&allele_a);
+    hap_a.extend_from_slice(&right);
+    let mut hap_b = Vec::new();
+    hap_b.extend_from_slice(&left);
+    hap_b.extend_from_slice(&allele_b);
+    hap_b.extend_from_slice(&right);
+    let mut hap_c = Vec::new();
+    hap_c.extend_from_slice(&left);
+    hap_c.extend_from_slice(&allele_c);
+    hap_c.extend_from_slice(&right);
+
+    let fasta_path = dir.join("index.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        writeln!(f, ">sampleA#0#chr1").unwrap();
+        f.write_all(&hap_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#0#chr1").unwrap();
+        f.write_all(&hap_b).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleC#0#chr1").unwrap();
+        f.write_all(&hap_c).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let idx_prefix = dir.join("idx");
+    let build = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "-o",
+            idx_prefix.to_str().unwrap(),
+            "--position-sample-rate",
+            "1",
+        ])
+        .output()
+        .expect("failed to run impg syng");
+    assert!(
+        build.status.success(),
+        "impg syng failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let reads_path = dir.join("simulated_reads.fq");
+    {
+        let mut f = std::fs::File::create(&reads_path).unwrap();
+        write_tiled_fastq(&mut f, "hapA", &hap_a, 250, 25).unwrap();
+        write_tiled_fastq(&mut f, "hapB", &hap_b, 250, 25).unwrap();
+    }
+
+    let packbin_path = dir.join("sample.packbin");
+    let map = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-q",
+            reads_path.to_str().unwrap(),
+            "-o",
+            "packbin",
+            "-O",
+            packbin_path.to_str().unwrap(),
+            "--pack-compression-level",
+            "3",
+            "--pack-block-size",
+            "64",
+            "--min-anchors",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg map -o packbin");
+    assert!(
+        map.status.success(),
+        "impg map -o packbin failed: {}",
+        String::from_utf8_lossy(&map.stderr)
+    );
+
+    let target_range = format!("sampleA#0#chr1:0-{}", hap_a.len());
+    let infer_range = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "-r",
+            &target_range,
+            "--top-n",
+            "2",
+            "--candidate-top-k",
+            "10",
+            "--min-span-fraction",
+            "0.8",
+        ])
+        .output()
+        .expect("failed to run impg infer -r");
+    assert!(
+        infer_range.status.success(),
+        "impg infer -r failed: {}",
+        String::from_utf8_lossy(&infer_range.stderr)
+    );
+    let infer_stdout = String::from_utf8_lossy(&infer_range.stdout);
+    assert!(infer_stdout.contains("#impg infer"), "{}", infer_stdout);
+    assert!(infer_stdout.contains("#score\tcos"), "{}", infer_stdout);
+    let first = infer_stdout
+        .lines()
+        .find(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .expect("expected infer result row");
+    let fields: Vec<&str> = first.split('\t').collect();
+    assert!(
+        fields.len() >= 14,
+        "infer row should have at least 14 fields: {}",
+        first
+    );
+    assert_eq!(fields[0], "1");
+    assert_eq!(fields[5], "cos");
+    assert_eq!(fields[6], "2");
+    assert_eq!(fields[13], "PASS");
+    assert!(
+        fields[9].contains("sampleA#0#chr1") && fields[9].contains("sampleB#0#chr1"),
+        "infer should call the simulated A/B diploid, got:\n{}",
+        infer_stdout
+    );
+    assert!(
+        !fields[9].contains("sampleC#0#chr1"),
+        "infer top call should not include the unsampled decoy, got:\n{}",
+        infer_stdout
+    );
+
+    let target_bed = dir.join("targets.bed");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&target_bed).unwrap();
+        writeln!(f, "sampleA#0#chr1\t0\t{}\twhole", hap_a.len()).unwrap();
+        writeln!(f, "sampleA#0#chr1\t900\t1800\tallele").unwrap();
+    }
+    let infer_bed_zst = dir.join("infer.bed.tsv.zst");
+    let infer_bed = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "--target-bed",
+            target_bed.to_str().unwrap(),
+            "--top-n",
+            "1",
+            "--candidate-top-k",
+            "10",
+            "--min-span-fraction",
+            "0.7",
+            "-O",
+            infer_bed_zst.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run impg infer --target-bed");
+    assert!(
+        infer_bed.status.success(),
+        "impg infer --target-bed failed: {}",
+        String::from_utf8_lossy(&infer_bed.stderr)
+    );
+    assert!(
+        infer_bed.stdout.is_empty(),
+        "infer -O should write result rows to the file"
+    );
+    let mut decoder =
+        zstd::stream::read::Decoder::new(std::fs::File::open(&infer_bed_zst).unwrap()).unwrap();
+    let mut decoded = String::new();
+    {
+        use std::io::Read;
+        decoder.read_to_string(&mut decoded).unwrap();
+    }
+    let bed_rows: Vec<&str> = decoded
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .collect();
+    assert_eq!(bed_rows.len(), 2, "target BED top-n 1 should emit two rows");
+    assert!(bed_rows.iter().all(|row| row.ends_with("\tPASS")), "{}", decoded);
+
+    let partitions_path = dir.join("partitions.bed");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&partitions_path).unwrap();
+        writeln!(f, "sampleA#0#chr1\t0\t{}\tp0", hap_a.len()).unwrap();
+        writeln!(f, "sampleB#0#chr1\t0\t{}\tp0", hap_b.len()).unwrap();
+        writeln!(f, "sampleA#0#chr1\t900\t1800\tp1").unwrap();
+        writeln!(f, "sampleB#0#chr1\t900\t1800\tp1").unwrap();
+    }
+    let infer_partitions = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "--partitions",
+            partitions_path.to_str().unwrap(),
+            "--top-n",
+            "1",
+            "--candidate-top-k",
+            "10",
+            "--min-span-fraction",
+            "0.7",
+        ])
+        .output()
+        .expect("failed to run impg infer --partitions");
+    assert!(
+        infer_partitions.status.success(),
+        "impg infer --partitions failed: {}",
+        String::from_utf8_lossy(&infer_partitions.stderr)
+    );
+    let partition_stdout = String::from_utf8_lossy(&infer_partitions.stdout);
+    let partition_rows: Vec<&str> = partition_stdout
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .collect();
+    assert_eq!(
+        partition_rows.len(),
+        2,
+        "ready partition BED should emit one top row per partition"
+    );
+    assert!(
+        partition_rows.iter().any(|row| row.split('\t').nth(1) == Some("p0")),
+        "{}",
+        partition_stdout
+    );
+    assert!(
+        partition_rows.iter().any(|row| row.split('\t').nth(1) == Some("p1")),
+        "{}",
+        partition_stdout
+    );
+
+    let no_d = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run impg infer without target inputs");
+    assert!(
+        !no_d.status.success(),
+        "infer discovery without -d should fail"
+    );
+    assert!(
+        String::from_utf8_lossy(&no_d.stderr).contains("requires -d/--merge-distance"),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&no_d.stderr)
+    );
+
+    let infer_discovery = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "-w",
+            "1500",
+            "-d",
+            "100",
+            "--min-missing-size",
+            "100",
+            "--min-boundary-distance",
+            "100",
+            "--top-n",
+            "1",
+            "--candidate-top-k",
+            "10",
+            "--min-span-fraction",
+            "0.7",
+        ])
+        .output()
+        .expect("failed to run impg infer discovery");
+    assert!(
+        infer_discovery.status.success(),
+        "impg infer discovery failed: {}",
+        String::from_utf8_lossy(&infer_discovery.stderr)
+    );
+    let discovery_stdout = String::from_utf8_lossy(&infer_discovery.stdout);
+    assert!(discovery_stdout.contains("#impg infer"), "{}", discovery_stdout);
+    assert!(
+        discovery_stdout
+            .lines()
+            .any(|line| !line.starts_with('#') && line.ends_with("\tPASS")),
+        "discovery infer should emit at least one PASS row:\n{}",
+        discovery_stdout
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_syng_map_cli_sampled_positions_paf() {
     let _guard = lock_syng();
     let Some(bin) = impg_binary() else {

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -967,6 +967,186 @@ fn test_syng_map_cli_gaf_and_paf() {
 }
 
 #[test]
+fn test_syng_genotype_cosigt_packbin_heterozygote() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_genotype_cosigt");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let left = numeric_to_ascii(&make_sequence_numeric(700, 11));
+    let allele_a = numeric_to_ascii(&make_sequence_numeric(700, 12));
+    let allele_b = numeric_to_ascii(&make_sequence_numeric(700, 13));
+    let right = numeric_to_ascii(&make_sequence_numeric(700, 14));
+    let mut hap_a = Vec::new();
+    hap_a.extend_from_slice(&left);
+    hap_a.extend_from_slice(&allele_a);
+    hap_a.extend_from_slice(&right);
+    let mut hap_b = Vec::new();
+    hap_b.extend_from_slice(&left);
+    hap_b.extend_from_slice(&allele_b);
+    hap_b.extend_from_slice(&right);
+
+    let fasta_path = dir.join("index.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        writeln!(f, ">sampleA#0#chr1").unwrap();
+        f.write_all(&hap_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#0#chr1").unwrap();
+        f.write_all(&hap_b).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let idx_prefix = dir.join("idx");
+    let build = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "-o",
+            idx_prefix.to_str().unwrap(),
+            "--position-sample-rate",
+            "1",
+        ])
+        .output()
+        .expect("failed to run impg syng");
+    assert!(
+        build.status.success(),
+        "impg syng failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let reads_path = dir.join("reads.fq");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&reads_path).unwrap();
+        writeln!(f, "@read_a").unwrap();
+        f.write_all(&hap_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "+").unwrap();
+        writeln!(f, "{}", "I".repeat(hap_a.len())).unwrap();
+        writeln!(f, "@read_b").unwrap();
+        f.write_all(&hap_b).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "+").unwrap();
+        writeln!(f, "{}", "I".repeat(hap_b.len())).unwrap();
+    }
+
+    let packbin_path = dir.join("sample.packbin");
+    let map = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-q",
+            reads_path.to_str().unwrap(),
+            "-o",
+            "packbin",
+            "-O",
+            packbin_path.to_str().unwrap(),
+            "--pack-compression-level",
+            "3",
+            "--pack-block-size",
+            "64",
+            "--min-anchors",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg map -o packbin");
+    assert!(
+        map.status.success(),
+        "impg map -o packbin failed: {}",
+        String::from_utf8_lossy(&map.stderr)
+    );
+
+    let gt = Command::new(&bin)
+        .args([
+            "genotype",
+            "cosigt",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "-r",
+            "sampleA#0#chr1:0-2100",
+            "--top-n",
+            "3",
+            "--candidate-top-k",
+            "10",
+            "--min-anchors",
+            "2",
+            "--min-span-fraction",
+            "0.7",
+        ])
+        .output()
+        .expect("failed to run impg genotype cosigt");
+    assert!(
+        gt.status.success(),
+        "impg genotype cosigt failed: {}",
+        String::from_utf8_lossy(&gt.stderr)
+    );
+    let gt_stdout = String::from_utf8_lossy(&gt.stdout);
+    let top = gt_stdout
+        .lines()
+        .find(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .expect("expected at least one COSIGT result row");
+    let fields: Vec<&str> = top.split('\t').collect();
+    assert!(
+        fields.len() >= 12,
+        "COSIGT row should have at least 12 fields: {}",
+        top
+    );
+    assert_eq!(fields[0], "1");
+    assert_eq!(fields[1], "cosigt");
+    assert_eq!(fields[2], "2");
+    let similarity = fields[3].parse::<f64>().unwrap();
+    assert!(
+        similarity > 0.99,
+        "expected near-perfect heterozygous COSIGT score, got {}\n{}",
+        similarity,
+        gt_stdout
+    );
+    assert!(
+        fields[8].contains("sampleA#0#chr1") && fields[8].contains("sampleB#0#chr1"),
+        "top COSIGT haplotypes should contain both haplotypes, got:\n{}",
+        gt_stdout
+    );
+
+    let gt_alias = Command::new(&bin)
+        .args([
+            "gt",
+            "cosigt",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "-r",
+            "sampleA#0#chr1:0-2100",
+            "--top-n",
+            "1",
+            "--candidate-top-k",
+            "10",
+            "--min-span-fraction",
+            "0.7",
+        ])
+        .output()
+        .expect("failed to run impg gt cosigt");
+    assert!(
+        gt_alias.status.success(),
+        "impg gt cosigt alias failed: {}",
+        String::from_utf8_lossy(&gt_alias.stderr)
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_syng_map_cli_sampled_positions_paf() {
     let _guard = lock_syng();
     let Some(bin) = impg_binary() else {

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -967,14 +967,14 @@ fn test_syng_map_cli_gaf_and_paf() {
 }
 
 #[test]
-fn test_syng_genotype_cosigt_packbin_heterozygote() {
+fn test_syng_genotype_cos_packbin_heterozygote() {
     let _guard = lock_syng();
     let Some(bin) = impg_binary() else {
         eprintln!("Skipping: impg binary not built");
         return;
     };
 
-    let dir = std::env::temp_dir().join("impg_test_syng_genotype_cosigt");
+    let dir = std::env::temp_dir().join("impg_test_syng_genotype_cos");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -1068,7 +1068,7 @@ fn test_syng_genotype_cosigt_packbin_heterozygote() {
     let gt = Command::new(&bin)
         .args([
             "genotype",
-            "cosigt",
+            "cos",
             "-a",
             idx_prefix.to_str().unwrap(),
             "-p",
@@ -1085,10 +1085,10 @@ fn test_syng_genotype_cosigt_packbin_heterozygote() {
             "0.7",
         ])
         .output()
-        .expect("failed to run impg genotype cosigt");
+        .expect("failed to run impg genotype cos");
     assert!(
         gt.status.success(),
-        "impg genotype cosigt failed: {}",
+        "impg genotype cos failed: {}",
         String::from_utf8_lossy(&gt.stderr)
     );
     let gt_stdout = String::from_utf8_lossy(&gt.stdout);
@@ -1103,7 +1103,7 @@ fn test_syng_genotype_cosigt_packbin_heterozygote() {
         top
     );
     assert_eq!(fields[0], "1");
-    assert_eq!(fields[1], "cosigt");
+    assert_eq!(fields[1], "cos");
     assert_eq!(fields[2], "2");
     let similarity = fields[3].parse::<f64>().unwrap();
     assert!(

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -47,6 +47,39 @@ fn numeric_to_ascii(numeric: &[u8]) -> Vec<u8> {
         .collect()
 }
 
+fn write_tiled_fastq<W: std::io::Write>(
+    writer: &mut W,
+    prefix: &str,
+    seq: &[u8],
+    read_len: usize,
+    step: usize,
+) -> std::io::Result<usize> {
+    assert!(read_len > 0);
+    assert!(step > 0);
+    assert!(seq.len() >= read_len);
+
+    let mut starts = Vec::new();
+    let mut start = 0usize;
+    while start + read_len <= seq.len() {
+        starts.push(start);
+        start += step;
+    }
+    let terminal_start = seq.len() - read_len;
+    if starts.last().copied() != Some(terminal_start) {
+        starts.push(terminal_start);
+    }
+
+    for (read_idx, start) in starts.iter().enumerate() {
+        let end = start + read_len;
+        writeln!(writer, "@{}_{}", prefix, read_idx)?;
+        writer.write_all(&seq[*start..end])?;
+        writeln!(writer)?;
+        writeln!(writer, "+")?;
+        writeln!(writer, "{}", "I".repeat(read_len))?;
+    }
+    Ok(starts.len())
+}
+
 /// Build a small test AGC archive with multiple samples sharing a backbone.
 fn create_test_agc(path: &str) {
     let config = StreamingQueueConfig {
@@ -1239,6 +1272,175 @@ fn test_syng_genotype_cos_cli_permutations() {
         }
     }
     assert_eq!(checked, 16, "expected to exercise the full genotype CLI matrix");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_syng_genotype_cos_short_read_simulation_calls_heterozygote() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_genotype_short_read_sim");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let left = numeric_to_ascii(&make_sequence_numeric(900, 31));
+    let allele_a = numeric_to_ascii(&make_sequence_numeric(900, 32));
+    let allele_b = numeric_to_ascii(&make_sequence_numeric(900, 33));
+    let allele_c = numeric_to_ascii(&make_sequence_numeric(900, 34));
+    let right = numeric_to_ascii(&make_sequence_numeric(900, 35));
+
+    let mut hap_a = Vec::new();
+    hap_a.extend_from_slice(&left);
+    hap_a.extend_from_slice(&allele_a);
+    hap_a.extend_from_slice(&right);
+    let mut hap_b = Vec::new();
+    hap_b.extend_from_slice(&left);
+    hap_b.extend_from_slice(&allele_b);
+    hap_b.extend_from_slice(&right);
+    let mut hap_c = Vec::new();
+    hap_c.extend_from_slice(&left);
+    hap_c.extend_from_slice(&allele_c);
+    hap_c.extend_from_slice(&right);
+    assert_eq!(hap_a.len(), hap_b.len());
+    assert_eq!(hap_a.len(), hap_c.len());
+
+    let fasta_path = dir.join("index.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        writeln!(f, ">sampleA#0#chr1").unwrap();
+        f.write_all(&hap_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#0#chr1").unwrap();
+        f.write_all(&hap_b).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleC#0#chr1").unwrap();
+        f.write_all(&hap_c).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let idx_prefix = dir.join("idx");
+    let build = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "-o",
+            idx_prefix.to_str().unwrap(),
+            "--position-sample-rate",
+            "1",
+        ])
+        .output()
+        .expect("failed to run impg syng");
+    assert!(
+        build.status.success(),
+        "impg syng failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let reads_path = dir.join("simulated_reads.fq");
+    let read_count = {
+        let mut f = std::fs::File::create(&reads_path).unwrap();
+        let a = write_tiled_fastq(&mut f, "hapA", &hap_a, 250, 25).unwrap();
+        let b = write_tiled_fastq(&mut f, "hapB", &hap_b, 250, 25).unwrap();
+        a + b
+    };
+    assert!(
+        read_count >= 190,
+        "expected dense tiled short-read simulation, got {} reads",
+        read_count
+    );
+
+    let packbin_path = dir.join("simulated.packbin");
+    let map = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-q",
+            reads_path.to_str().unwrap(),
+            "-o",
+            "packbin",
+            "-O",
+            packbin_path.to_str().unwrap(),
+            "--pack-compression-level",
+            "3",
+            "--pack-block-size",
+            "64",
+            "--min-anchors",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg map -o packbin");
+    assert!(
+        map.status.success(),
+        "impg map -o packbin failed: {}",
+        String::from_utf8_lossy(&map.stderr)
+    );
+
+    let target_range = format!("sampleA#0#chr1:0-{}", hap_a.len());
+    let gt = Command::new(&bin)
+        .args([
+            "genotype",
+            "cos",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-p",
+            packbin_path.to_str().unwrap(),
+            "-r",
+            &target_range,
+            "--top-n",
+            "5",
+            "--candidate-top-k",
+            "10",
+            "--min-anchors",
+            "2",
+            "--min-span-fraction",
+            "0.8",
+        ])
+        .output()
+        .expect("failed to run impg genotype cos");
+    assert!(
+        gt.status.success(),
+        "impg genotype cos failed: {}",
+        String::from_utf8_lossy(&gt.stderr)
+    );
+    let gt_stdout = String::from_utf8_lossy(&gt.stdout);
+    let top = gt_stdout
+        .lines()
+        .find(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .expect("expected at least one cosine genotype result row");
+    let fields: Vec<&str> = top.split('\t').collect();
+    assert!(
+        fields.len() >= 12,
+        "cos genotype row should have at least 12 fields: {}",
+        top
+    );
+    assert_eq!(fields[0], "1");
+    assert_eq!(fields[1], "cos");
+    assert_eq!(fields[2], "2");
+    let similarity = fields[3].parse::<f64>().unwrap();
+    assert!(
+        similarity > 0.90,
+        "expected strong short-read heterozygous cosine score, got {}\n{}",
+        similarity,
+        gt_stdout
+    );
+    assert!(
+        fields[8].contains("sampleA#0#chr1") && fields[8].contains("sampleB#0#chr1"),
+        "top genotype should call the simulated A/B diploid, got:\n{}",
+        gt_stdout
+    );
+    assert!(
+        !fields[8].contains("sampleC#0#chr1"),
+        "top genotype should not include the unsampled decoy haplotype, got:\n{}",
+        gt_stdout
+    );
 
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -1121,6 +1121,34 @@ fn test_syng_genotype_cos_cli_permutations() {
         String::from_utf8_lossy(&map_pack.stderr)
     );
 
+    let pack_zst_path = dir.join("sample.pack.tsv.zst");
+    let map_pack_zst = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-q",
+            reads_path.to_str().unwrap(),
+            "-o",
+            "pack",
+            "-O",
+            pack_zst_path.to_str().unwrap(),
+            "--min-anchors",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg map -o pack -O sample.pack.tsv.zst");
+    assert!(
+        map_pack_zst.status.success(),
+        "impg map -o pack -O sample.pack.tsv.zst failed: {}",
+        String::from_utf8_lossy(&map_pack_zst.stderr)
+    );
+    let compressed_pack = std::fs::read(&pack_zst_path).unwrap();
+    assert!(
+        compressed_pack.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]),
+        "compressed pack should have zstd magic bytes"
+    );
+
     let genotype_help = Command::new(&bin)
         .args(["genotype", "--help"])
         .output()
@@ -1159,8 +1187,9 @@ fn test_syng_genotype_cos_cli_permutations() {
     let methods = ["cos", "cosigt"];
     let candidate_modes = ["spanning", "overlapping"];
     let packs = [
-        ("pack", pack_path.as_path()),
-        ("packbin", packbin_path.as_path()),
+        ("pack", "pack", pack_path.as_path()),
+        ("pack.zst", "pack", pack_zst_path.as_path()),
+        ("packbin", "packbin", packbin_path.as_path()),
     ];
     let mut expected_by_pack_mode: std::collections::BTreeMap<(String, String), String> =
         std::collections::BTreeMap::new();
@@ -1168,7 +1197,7 @@ fn test_syng_genotype_cos_cli_permutations() {
 
     for root in command_roots {
         for method in methods {
-            for (pack_label, pack_path) in packs {
+            for (pack_label, compare_label, pack_path) in packs {
                 for candidate_mode in candidate_modes {
                     checked += 1;
                     let output = Command::new(&bin)
@@ -1257,7 +1286,7 @@ fn test_syng_genotype_cos_cli_permutations() {
                         );
                     }
 
-                    let key = (pack_label.to_string(), candidate_mode.to_string());
+                    let key = (compare_label.to_string(), candidate_mode.to_string());
                     if let Some(expected) = expected_by_pack_mode.get(&key) {
                         assert_eq!(
                             &stdout, expected,
@@ -1271,7 +1300,183 @@ fn test_syng_genotype_cos_cli_permutations() {
             }
         }
     }
-    assert_eq!(checked, 16, "expected to exercise the full genotype CLI matrix");
+    assert_eq!(checked, 24, "expected to exercise the full genotype CLI matrix");
+
+    let idx_prefix_str = idx_prefix.to_str().unwrap();
+    let packbin_str = packbin_path.to_str().unwrap();
+    let target_range = "sampleA#0#chr1:0-2100";
+    let run_gt = |extra: &[&str]| {
+        let mut args = vec![
+            "genotype",
+            "cos",
+            "-a",
+            idx_prefix_str,
+            "-p",
+            packbin_str,
+            "-r",
+            target_range,
+        ];
+        args.extend_from_slice(extra);
+        Command::new(&bin)
+            .args(args)
+            .output()
+            .expect("failed to run impg genotype cos")
+    };
+
+    let custom = run_gt(&[
+        "--ploidy",
+        "1",
+        "--top-n",
+        "1",
+        "--candidate-top-k",
+        "0",
+        "--syng-padding",
+        "12",
+        "--syng-extension",
+        "12",
+        "--min-anchors",
+        "1",
+        "--min-span-fraction",
+        "0.5",
+    ]);
+    assert!(
+        custom.status.success(),
+        "non-default genotype options failed: {}",
+        String::from_utf8_lossy(&custom.stderr)
+    );
+    let custom_stdout = String::from_utf8_lossy(&custom.stdout);
+    assert!(custom_stdout.contains("#ploidy\t1"), "{}", custom_stdout);
+    let custom_rows: Vec<&str> = custom_stdout
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .collect();
+    assert_eq!(custom_rows.len(), 1, "top-n 1 should emit one row");
+    assert_eq!(custom_rows[0].split('\t').nth(2), Some("1"));
+
+    let ploidy3 = run_gt(&[
+        "--ploidy",
+        "3",
+        "--top-n",
+        "2",
+        "--candidate-top-k",
+        "0",
+        "--min-span-fraction",
+        "0.7",
+    ]);
+    assert!(
+        ploidy3.status.success(),
+        "ploidy 3 genotype options failed: {}",
+        String::from_utf8_lossy(&ploidy3.stderr)
+    );
+    let ploidy3_stdout = String::from_utf8_lossy(&ploidy3.stdout);
+    assert!(ploidy3_stdout.contains("#ploidy\t3"), "{}", ploidy3_stdout);
+    let ploidy3_rows: Vec<&str> = ploidy3_stdout
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .collect();
+    assert_eq!(ploidy3_rows.len(), 2, "top-n 2 should emit two rows");
+    assert!(ploidy3_rows
+        .iter()
+        .all(|row| row.split('\t').nth(2) == Some("3")));
+
+    let stdout_for_output = run_gt(&["--top-n", "2", "--candidate-top-k", "10"]);
+    assert!(
+        stdout_for_output.status.success(),
+        "stdout genotype baseline failed: {}",
+        String::from_utf8_lossy(&stdout_for_output.stderr)
+    );
+    let output_zst_path = dir.join("genotype.tsv.zst");
+    let output_to_file = Command::new(&bin)
+        .args([
+            "genotype",
+            "cos",
+            "-a",
+            idx_prefix_str,
+            "-p",
+            packbin_str,
+            "-r",
+            target_range,
+            "--top-n",
+            "2",
+            "--candidate-top-k",
+            "10",
+            "-O",
+            output_zst_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run impg genotype cos -O genotype.tsv.zst");
+    assert!(
+        output_to_file.status.success(),
+        "compressed genotype output failed: {}",
+        String::from_utf8_lossy(&output_to_file.stderr)
+    );
+    assert!(
+        output_to_file.stdout.is_empty(),
+        "genotype -O should not write result rows to stdout"
+    );
+    let compressed_output = std::fs::read(&output_zst_path).unwrap();
+    assert!(
+        compressed_output.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]),
+        "genotype .zst output should have zstd magic bytes"
+    );
+    let mut decoder =
+        zstd::stream::read::Decoder::new(std::fs::File::open(&output_zst_path).unwrap()).unwrap();
+    let mut decoded_output = String::new();
+    {
+        use std::io::Read;
+        decoder.read_to_string(&mut decoded_output).unwrap();
+    }
+    assert_eq!(
+        decoded_output,
+        String::from_utf8_lossy(&stdout_for_output.stdout),
+        "compressed genotype output should match stdout output"
+    );
+
+    for (label, extra, expected) in [
+        (
+            "ploidy zero",
+            &["--ploidy", "0"][..],
+            "--ploidy must be greater than 0",
+        ),
+        (
+            "top-n zero",
+            &["--top-n", "0"][..],
+            "--top-n must be greater than 0",
+        ),
+        (
+            "bad min-span-fraction",
+            &["--min-span-fraction", "1.1"][..],
+            "--min-span-fraction must be between 0 and 1",
+        ),
+        (
+            "search budget",
+            &[
+                "--candidate-top-k",
+                "10",
+                "--max-combinations",
+                "1",
+                "--min-span-fraction",
+                "0.7",
+            ][..],
+            "genotype combination search exceeded --max-combinations",
+        ),
+    ] {
+        let failed = run_gt(extra);
+        assert!(
+            !failed.status.success(),
+            "{} should fail but succeeded with stdout:\n{}",
+            label,
+            String::from_utf8_lossy(&failed.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&failed.stderr);
+        assert!(
+            stderr.contains(expected),
+            "{} should report '{}', got:\n{}",
+            label,
+            expected,
+            stderr
+        );
+    }
 
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -967,14 +967,14 @@ fn test_syng_map_cli_gaf_and_paf() {
 }
 
 #[test]
-fn test_syng_genotype_cos_packbin_heterozygote() {
+fn test_syng_genotype_cos_cli_permutations() {
     let _guard = lock_syng();
     let Some(bin) = impg_binary() else {
         eprintln!("Skipping: impg binary not built");
         return;
     };
 
-    let dir = std::env::temp_dir().join("impg_test_syng_genotype_cos");
+    let dir = std::env::temp_dir().join("impg_test_syng_genotype_cos_permutations");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -1065,83 +1065,180 @@ fn test_syng_genotype_cos_packbin_heterozygote() {
         String::from_utf8_lossy(&map.stderr)
     );
 
-    let gt = Command::new(&bin)
+    let pack_path = dir.join("sample.pack.tsv");
+    let map_pack = Command::new(&bin)
         .args([
-            "genotype",
-            "cos",
+            "map",
             "-a",
             idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
-            "-r",
-            "sampleA#0#chr1:0-2100",
-            "--top-n",
-            "3",
-            "--candidate-top-k",
-            "10",
+            "-q",
+            reads_path.to_str().unwrap(),
+            "-o",
+            "pack",
+            "-O",
+            pack_path.to_str().unwrap(),
             "--min-anchors",
             "2",
-            "--min-span-fraction",
-            "0.7",
         ])
         .output()
-        .expect("failed to run impg genotype cos");
+        .expect("failed to run impg map -o pack");
     assert!(
-        gt.status.success(),
-        "impg genotype cos failed: {}",
-        String::from_utf8_lossy(&gt.stderr)
-    );
-    let gt_stdout = String::from_utf8_lossy(&gt.stdout);
-    let top = gt_stdout
-        .lines()
-        .find(|line| !line.starts_with('#') && !line.trim().is_empty())
-        .expect("expected at least one COSIGT result row");
-    let fields: Vec<&str> = top.split('\t').collect();
-    assert!(
-        fields.len() >= 12,
-        "COSIGT row should have at least 12 fields: {}",
-        top
-    );
-    assert_eq!(fields[0], "1");
-    assert_eq!(fields[1], "cos");
-    assert_eq!(fields[2], "2");
-    let similarity = fields[3].parse::<f64>().unwrap();
-    assert!(
-        similarity > 0.99,
-        "expected near-perfect heterozygous COSIGT score, got {}\n{}",
-        similarity,
-        gt_stdout
-    );
-    assert!(
-        fields[8].contains("sampleA#0#chr1") && fields[8].contains("sampleB#0#chr1"),
-        "top COSIGT haplotypes should contain both haplotypes, got:\n{}",
-        gt_stdout
+        map_pack.status.success(),
+        "impg map -o pack failed: {}",
+        String::from_utf8_lossy(&map_pack.stderr)
     );
 
-    let gt_alias = Command::new(&bin)
-        .args([
-            "gt",
-            "cosigt",
-            "-a",
-            idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
-            "-r",
-            "sampleA#0#chr1:0-2100",
-            "--top-n",
-            "1",
-            "--candidate-top-k",
-            "10",
-            "--min-span-fraction",
-            "0.7",
-        ])
+    let genotype_help = Command::new(&bin)
+        .args(["genotype", "--help"])
         .output()
-        .expect("failed to run impg gt cosigt");
+        .expect("failed to run impg genotype --help");
+    assert!(genotype_help.status.success());
+    let genotype_help_stdout = String::from_utf8_lossy(&genotype_help.stdout);
     assert!(
-        gt_alias.status.success(),
-        "impg gt cosigt alias failed: {}",
-        String::from_utf8_lossy(&gt_alias.stderr)
+        genotype_help_stdout.contains("  cos  "),
+        "genotype help should list cos:\n{}",
+        genotype_help_stdout
     );
+    assert!(
+        !genotype_help_stdout.contains("cosigt"),
+        "genotype help should not list the cosigt alias:\n{}",
+        genotype_help_stdout
+    );
+
+    let gt_help = Command::new(&bin)
+        .args(["gt", "--help"])
+        .output()
+        .expect("failed to run impg gt --help");
+    assert!(gt_help.status.success());
+    let gt_help_stdout = String::from_utf8_lossy(&gt_help.stdout);
+    assert!(
+        gt_help_stdout.contains("  cos  "),
+        "gt help should list cos:\n{}",
+        gt_help_stdout
+    );
+    assert!(
+        !gt_help_stdout.contains("cosigt"),
+        "gt help should not list the cosigt alias:\n{}",
+        gt_help_stdout
+    );
+
+    let command_roots = ["genotype", "gt"];
+    let methods = ["cos", "cosigt"];
+    let candidate_modes = ["spanning", "overlapping"];
+    let packs = [
+        ("pack", pack_path.as_path()),
+        ("packbin", packbin_path.as_path()),
+    ];
+    let mut expected_by_pack_mode: std::collections::BTreeMap<(String, String), String> =
+        std::collections::BTreeMap::new();
+    let mut checked = 0usize;
+
+    for root in command_roots {
+        for method in methods {
+            for (pack_label, pack_path) in packs {
+                for candidate_mode in candidate_modes {
+                    checked += 1;
+                    let output = Command::new(&bin)
+                        .args([
+                            root,
+                            method,
+                            "-a",
+                            idx_prefix.to_str().unwrap(),
+                            "-p",
+                            pack_path.to_str().unwrap(),
+                            "-r",
+                            "sampleA#0#chr1:0-2100",
+                            "--candidate-mode",
+                            candidate_mode,
+                            "--top-n",
+                            "3",
+                            "--candidate-top-k",
+                            "10",
+                            "--min-anchors",
+                            "2",
+                            "--min-span-fraction",
+                            "0.7",
+                        ])
+                        .output()
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "failed to run impg {} {} with {} {}: {}",
+                                root, method, pack_label, candidate_mode, e
+                            )
+                        });
+                    assert!(
+                        output.status.success(),
+                        "impg {} {} failed with {} {}: {}",
+                        root,
+                        method,
+                        pack_label,
+                        candidate_mode,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+
+                    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                    assert!(stdout.contains("#impg genotype cos"), "{}", stdout);
+                    assert!(stdout.contains("#method\tcos"), "{}", stdout);
+                    assert!(stdout.contains("#metric\tcosine"), "{}", stdout);
+                    assert!(stdout.contains("#alias\tcosigt"), "{}", stdout);
+                    assert!(
+                        stdout.contains(&format!(
+                            "#candidate_mode\t{}",
+                            if candidate_mode == "spanning" {
+                                "Spanning"
+                            } else {
+                                "Overlapping"
+                            }
+                        )),
+                        "{}",
+                        stdout
+                    );
+
+                    let top = stdout
+                        .lines()
+                        .find(|line| !line.starts_with('#') && !line.trim().is_empty())
+                        .expect("expected at least one cosine genotype result row");
+                    let fields: Vec<&str> = top.split('\t').collect();
+                    assert!(
+                        fields.len() >= 12,
+                        "cos genotype row should have at least 12 fields: {}",
+                        top
+                    );
+                    assert_eq!(fields[0], "1");
+                    assert_eq!(fields[1], "cos");
+                    assert_eq!(fields[2], "2");
+
+                    if candidate_mode == "spanning" {
+                        let similarity = fields[3].parse::<f64>().unwrap();
+                        assert!(
+                            similarity > 0.99,
+                            "expected near-perfect heterozygous cosine score, got {}\n{}",
+                            similarity,
+                            stdout
+                        );
+                        assert!(
+                            fields[8].contains("sampleA#0#chr1")
+                                && fields[8].contains("sampleB#0#chr1"),
+                            "top spanning genotype should contain both haplotypes, got:\n{}",
+                            stdout
+                        );
+                    }
+
+                    let key = (pack_label.to_string(), candidate_mode.to_string());
+                    if let Some(expected) = expected_by_pack_mode.get(&key) {
+                        assert_eq!(
+                            &stdout, expected,
+                            "{} {} should match the first {} {} output",
+                            root, method, pack_label, candidate_mode
+                        );
+                    } else {
+                        expected_by_pack_mode.insert(key, stdout);
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(checked, 16, "expected to exercise the full genotype CLI matrix");
 
     std::fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
## Summary
- add `impg genotype cos` with `cosigt` alias for pack/packbin evidence over syng query targets
- add pack architecture for syncmer-node coverage, including compact binary pack output and zstd output support
- add `impg infer` as the first genome-inference entry point: pack/packbin evidence over `--target-range`, `--target-bed`, `--partitions`, or internal `impg partition` discovery
- require `-d/--merge-distance` when `impg infer` discovers partitions internally, since it controls how queried ranges are merged and the largest one-hop SV scale represented by a partition
- document the inference roadmap in `docs/infer-design.md`

## Validation
- `cargo check`
- `cargo test`
- `cargo test --test test_syng_integration test_syng_infer_pack_partitions_and_discovery -- --nocapture`
- `rustfmt --check src/commands/genotype.rs src/commands/infer.rs`
- `git diff --check`
