### PR TITLE
Add projections and stitched infer mosaics

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ impg stats -a f1.paf f2.1aln
 
 Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid plus the terminal syncmer: `--position-sample-rate 256` samples steps `0, 256, 512, ...` and the final step on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
 
-`impg map` projects FASTA/FASTQ queries onto a syng index via shared syncmers. The default output is GAF (syncmer-node walk); pass `-o paf` for projected genome coordinates, `-o pack` for a TSV node coverage vector, or `-o packbin` for a compact binary node coverage vector. Text map output written with `-O` is compressed automatically when the filename ends in `.zst` or `.zstd`; `packbin` uses internal block zstd compression for random access by node ID.
+`impg map` projects FASTA/FASTQ queries onto a syng index via shared syncmers. The default output is GAF (per-read syncmer-node walks); pass `-o paf` for projected genome coordinates, `-o pack` for a compact binary node support vector, `-o pack-tsv` for a human-readable TSV support vector, or `-o proj` for a sample projection bundle containing both `sample.pack` and `reads.gaf.zst`. Text map output written with `-O` is compressed automatically when the filename ends in `.zst` or `.zstd`; `pack` uses internal block zstd compression for random access by node ID. `packbin` remains accepted as a compatibility alias for compact pack output.
 
 Use `impg syng-repair -a <prefix> --position-sample-rate <N> --force` to rebuild or resample `.syng.spos` and `.syng.pstep` from an existing `.1gbwt` / `.1khash` syng index without re-reading the original sequences.
 
@@ -320,29 +320,43 @@ impg query -a c4.syng -r "grch38#chr6:31972046-32055647:0-${LEN}" \
 samtools faidx chr6.C4.fa 'grch38#chr6:31972046-32055647:5000-7000' > probe.fa
 impg map -a c4.syng -q probe.fa | cut -f1-6 | head -1
 # grch38...:5000-7000  2001  16  1979  +  <264>265>266<267<268>...
-impg map -a c4.syng -q probe.fa -o pack | head
+impg map -a c4.syng -q probe.fa -o pack-tsv | head
 # #node_id  count
 # 264      1
 # 265      1
-impg map -a c4.syng -q probe.fa -o pack -O probe.pack.tsv.zst
-impg map -a c4.syng -q probe.fa -o packbin -O probe.packbin \
+impg map -a c4.syng -q probe.fa -o pack-tsv -O probe.pack.tsv.zst
+impg map -a c4.syng -q probe.fa -o pack -O probe.pack \
          --pack-compression-level 12
+impg map -a c4.syng -q probe.fa -o proj -O probe.proj
 impg map -a c4.syng -q probe.fa -o paf
 # grch38...:5000-7000  2001  1302  1833  +  HG02109#1#...  77232  6300  6831  126 531 0 an:i:2 sk:i:63
 ```
 
-`packbin` stores a dense u8 count vector over syng node IDs, zstd-compressed
+`pack` stores a dense u8 count vector over syng node IDs, zstd-compressed
 in independently addressable blocks, plus a small overflow table for node
 counts above 255. `--pack-compression-level` defaults to 12; level 19 is a
 compact cohort/archive setting that is slower to write but just as fast to
 read in practice.
+
+A `proj` directory is the richer sample projection object:
+
+```text
+sample.proj/
+  manifest.json
+  sample.pack
+  reads.gaf.zst
+```
+
+Use `pack` when aggregate graph support is enough or when storing many
+samples. Use `proj` when inference should also have read-walk linkage evidence
+available.
 
 `impg genotype` (`impg gt`) is the namespace for graph-based genotyping
 methods. The first listed method is `cos`: cosine genotyping over graph-feature
 coverage, following the COSIGT/LikeGT scoring model:
 
 ```bash
-impg genotype cos -a c4.syng -p sample.packbin \
+impg genotype cos -a c4.syng -p sample.pack \
   -r 'grch38#chr6:31972046-32055647:0-10000' \
   --ploidy 2 --top-n 20
 ```
@@ -350,7 +364,7 @@ impg genotype cos -a c4.syng -p sample.packbin \
 `cosigt` is accepted as an alias for `cos` to make the paper/tool lineage
 clear. `cos` extracts haplotype candidates from the requested reference path
 range, builds traversal-count vectors over the candidate syncmer nodes, and ranks
-ploidy-sized haplotype combinations against the sample `pack`/`packbin`
+ploidy-sized haplotype combinations against the sample `pack`
 coverage vector by cosine similarity. The default candidate mode is
 `spanning`: candidates must have shared anchors spanning the requested
 reference interval. Use `--candidate-mode overlapping` to score each gathered
@@ -361,16 +375,18 @@ graph-feature evidence model this is built around.
 emits allele calls over genomic intervals:
 
 ```bash
-impg infer -a hprc.syng -p sample.packbin \
+impg infer -a hprc.syng --proj sample.proj \
   --partitions partitions.bed --top-n 1 -O sample.infer.tsv.zst
 ```
 
 Inputs choose the operation mode: `-r/--target-range` types one range,
 `--target-bed` types a BED-like range list, `--partitions` consumes ready
 `impg partition` BED output, and omitting all three runs internal syng partition
-discovery, which requires `-d/--merge-distance`. The first evidence backend is
-native `pack`/`packbin` from `impg map`; the design intentionally keeps BWA/local
-realignment evidence as future pack-producing backends. See
+discovery, which requires `-d/--merge-distance`. `infer` can consume `--pack`
+for aggregate graph support or `--proj` for a bundle that also carries read
+walks. Add `--stitch beam --emit-mosaic out.tsv --emit-fasta haps.fa
+--emit-gfa diplotype.gfa --sequence-files panel.fa-or.agc` to stitch local
+calls into phased mosaic paths and materialize sequence. See
 `docs/infer-design.md`.
 
 `-r` splits on the **last** `:`. Path names from `odgi paths -f`

--- a/docs/genotype-architecture.md
+++ b/docs/genotype-architecture.md
@@ -25,7 +25,8 @@ score = cosine(S, G)
 The current backend is syng:
 
 - graph features are syng syncmer node IDs
-- sample evidence comes from `impg map -o pack` or `impg map -o packbin`
+- sample evidence comes from `impg map -o pack` or a projection bundle from
+  `impg map -o proj`
 - candidates are path intervals gathered by querying a reference path range
 - candidate vectors are syncmer-node traversal counts through those intervals
 
@@ -37,7 +38,8 @@ methods should be able to feed the same `pack` abstraction:
 - read alignment to extracted haplotypes for short or damaged ancient DNA
 - condensed graph or bubble-level features
 
-`packbin` is the binary coverage-vector format used by the current syng path,
-but the abstraction is feature coverage. Future versions should carry graph
-identity metadata so packs cannot be accidentally combined with the wrong graph
-or feature namespace.
+`pack` is the compact binary coverage-vector format used by the current syng
+path. `pack-tsv` is the human-readable export of the same abstraction, and
+`packbin` remains a compatibility alias for compact pack output. Projection
+bundles add metadata and read-walk evidence around the pack so packs cannot be
+accidentally combined with the wrong graph or feature namespace.

--- a/docs/infer-design.md
+++ b/docs/infer-design.md
@@ -25,7 +25,8 @@ reads / alignments
 For modern WGS, the first-class evidence path is native:
 
 ```text
-FASTQ + impg map -a panel.syng -o packbin -> sample.packbin
+FASTQ + impg map -a panel.syng -o pack -> sample.pack
+FASTQ + impg map -a panel.syng -o proj -> sample.proj/
 ```
 
 For ancient DNA or very short degraded reads, the intended path is:
@@ -54,8 +55,8 @@ mode if we add one later). This is the same biological knob as in
 `query`/`partition`: it defines the maximum internal gap/SV that one query hop
 can absorb into one typed range.
 
-The initial implementation supports pack-based evidence. BWA/local-realignment
-is a backend, not a separate genotyping model.
+The initial implementation supports pack-based evidence and projection bundles.
+BWA/local-realignment is a backend, not a separate genotyping model.
 
 ## Partitions
 
@@ -65,13 +66,13 @@ The first implementation reuses `impg partition` semantics:
 
 ```bash
 impg partition -a panel.syng -w 1000000 -d 10000 -o bed --output-folder parts
-impg infer -a panel.syng -p sample.packbin --partitions parts/partitions.bed
+impg infer -a panel.syng --proj sample.proj --partitions parts/partitions.bed
 ```
 
 `infer` may also run the partition step internally:
 
 ```bash
-impg infer -a panel.syng -p sample.packbin --window-size 1000000 -d 10000
+impg infer -a panel.syng -p sample.pack --window-size 1000000 -d 10000
 ```
 
 Internal partition discovery writes temporary partitions, parses them back, then
@@ -108,6 +109,23 @@ weighting / normalization
 The important invariant is compatibility: candidate allele vectors and sample
 evidence vectors must live in the same feature space.
 
+## Projections
+
+A projection is the native sample evidence object produced by `impg map -o
+proj`. The first directory-backed format contains:
+
+```text
+sample.proj/
+  manifest.json
+  sample.pack
+  reads.gaf.zst
+```
+
+`sample.pack` is the aggregate support vector. `reads.gaf.zst` is the per-read
+syncmer walk layer that can later supply linkage/phase evidence. Commands should
+prefer `--proj` when both layers are available, while still accepting `--pack`
+for large cohort-scale aggregate workflows.
+
 ## Scoring
 
 The first scoring method is `cos`, the same cosine scorer used by
@@ -127,7 +145,8 @@ likelihoods, learned scoring functions, or GBWT/panel-based imputers.
 
 ## Genome-Wide Inference
 
-The first implementation emits independent local calls per range/partition.
+The first implementation emits independent local calls per range/partition and
+can optionally stitch retained local states into a phased mosaic.
 
 The next layer should stitch those local calls into a haplotype mosaic:
 
@@ -140,6 +159,13 @@ best genome = argmax sum_j emission_j + transition_j
 
 This can start as beam search over the top local genotype states, then move to
 more principled HMM/Viterbi inference.
+
+Current stitching is the conservative first layer: retained local calls are
+expanded into ordered ploidy states, same-path continuation is cheap, and
+haplotype switches pay a configurable `--switch-penalty`. This is a panel
+copying prior over local calls, not yet a full read-link imputer. Projection GAF
+walks are carried through the interface so read-link transition evidence can be
+added without changing the user workflow.
 
 ## Output
 
@@ -156,6 +182,19 @@ The first output is a TSV of allele calls over ranges:
 Each row is a local genotype state. Adjacent rows with compatible inferred
 haplotypes can later be merged into longer genome segments.
 
+With `--stitch beam`, side outputs can be requested:
+
+```bash
+impg infer -a panel.syng --proj sample.proj --partitions parts/partitions.bed \
+  --stitch beam --emit-mosaic sample.mosaic.tsv \
+  --sequence-files panel.agc \
+  --emit-fasta sample.haps.fa --emit-gfa sample.diplotype.gfa
+```
+
+The FASTA writer concatenates phase tracks and inserts `N`s at uncertain joins
+unless `--strict-stitch` is set. The GFA writer emits one segment per selected
+haplotype interval and path lines for the inferred phases.
+
 ## Testing Strategy
 
 Tests should cover:
@@ -164,7 +203,7 @@ Tests should cover:
 - BED/range list input
 - ready partition BED input
 - internal partition discovery requiring `-d`
-- pack, compressed pack, and packbin evidence
+- pack, pack-tsv, compressed pack-tsv, compatibility packbin, and projection evidence
 - short-read simulation against a panel with a decoy haplotype
 - invalid CLI combinations
 - output compression and deterministic row shape

--- a/docs/read-syncmer-index-design.md
+++ b/docs/read-syncmer-index-design.md
@@ -185,7 +185,7 @@ The `.r2s` / future `.s2r` read-syncmer postings are working indexes for
 read retrieval and subgraph-to-read support queries. They are not the
 primary long-term cohort archive for per-sample coverage. For storage at
 tens of thousands of samples, the compact archive target is the
-node-coverage vector (`impg map -o packbin`): exact per-node counts,
+node-coverage vector (`impg map -o pack`): exact per-node counts,
 internally block-compressed with zstd, random-accessible by syncmer node
 ID, and cheap to regenerate from reads when a read-level support index is
 needed.

--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -73,6 +73,7 @@ pub struct SyngCosigtQuery<'a> {
     pub min_span_fraction: f64,
 }
 
+#[derive(Debug)]
 pub struct SyngCosigtOutput {
     pub region_name: String,
     pub candidate_mode: CandidateMode,

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -1,12 +1,15 @@
+use clap::ValueEnum;
 use log::info;
 use std::collections::BTreeMap;
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::commands::{genotype, graph, partition};
+use crate::graph::reverse_complement;
 use crate::pack;
+use crate::sequence_index::{SequenceIndex, UnifiedSequenceIndex};
 use crate::syng;
 use crate::{EngineOpts, GfaEngine, SyngImpgWrapper};
 
@@ -33,6 +36,14 @@ pub struct PartitionDiscoveryConfig<'a> {
     pub rehome_singletons: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum StitchMode {
+    /// Emit independent local calls only.
+    None,
+    /// Stitch retained local calls into phased mosaics with a beam search.
+    Beam,
+}
+
 pub struct InferConfig<'a> {
     pub syng_prefix: &'a str,
     pub pack_path: &'a str,
@@ -47,6 +58,63 @@ pub struct InferConfig<'a> {
     pub syng_extension: u64,
     pub min_anchors: usize,
     pub min_span_fraction: f64,
+    pub gaf_path: Option<&'a str>,
+    pub stitch: StitchMode,
+    pub stitch_beam: usize,
+    pub switch_penalty: f64,
+    pub stitch_gap: u64,
+    pub strict_stitch: bool,
+    pub emit_mosaic: Option<&'a str>,
+    pub emit_fasta: Option<&'a str>,
+    pub emit_gfa: Option<&'a str>,
+    pub sequence_index: Option<&'a UnifiedSequenceIndex>,
+}
+
+#[derive(Debug)]
+pub struct LocalCallSet {
+    pub target: InferTarget,
+    pub output: Option<genotype::SyngCosigtOutput>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct OrderedState {
+    result_idx: usize,
+    candidates: Vec<usize>,
+    emission: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TransitionKind {
+    Start,
+    Continue,
+    Recombine,
+    Uncertain,
+}
+
+impl TransitionKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            TransitionKind::Start => "start",
+            TransitionKind::Continue => "continue",
+            TransitionKind::Recombine => "recombine",
+            TransitionKind::Uncertain => "uncertain",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MosaicStep {
+    call_idx: usize,
+    state: OrderedState,
+    transition_kinds: Vec<TransitionKind>,
+    transition_cost: f64,
+}
+
+#[derive(Debug, Clone)]
+struct MosaicPath {
+    score: f64,
+    steps: Vec<MosaicStep>,
 }
 
 fn parse_bed_like(path: &str, group_partitions: bool) -> io::Result<Vec<InferTarget>> {
@@ -230,7 +298,7 @@ fn candidate_region(candidate: &genotype::HaplotypeCandidate) -> String {
     )
 }
 
-pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> io::Result<()> {
+fn resolve_targets(config: &InferConfig<'_>) -> io::Result<Vec<InferTarget>> {
     let targets = if config.targets.is_empty() {
         let discovery = config.discovery.as_ref().ok_or_else(|| {
             io::Error::new(
@@ -249,25 +317,17 @@ pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> i
             "no inference targets were found",
         ));
     }
+    Ok(targets)
+}
 
-    info!("Loading syng index from prefix: {}", config.syng_prefix);
-    let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
-    info!("Loading sample pack coverage from {}", config.pack_path);
-    let coverage = pack::read(config.pack_path)?;
-
-    writeln!(out, "#impg infer")?;
-    writeln!(out, "#evidence_backend\tpack")?;
-    writeln!(out, "#score\tcos")?;
-    writeln!(out, "#feature_space\tsyng-syncmer-node")?;
-    writeln!(out, "#targets\t{}", targets.len())?;
-    writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
-    writeln!(out, "#ploidy\t{}", config.ploidy)?;
-    writeln!(
-        out,
-        "#rank\tpartition\tchrom\tstart\tend\tmethod\tploidy\tsimilarity\tqv\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions\tstatus"
-    )?;
-
-    for target in &targets {
+fn compute_local_call_sets(
+    syng_index: &syng::SyngIndex,
+    coverage: &pack::Coverage,
+    targets: &[InferTarget],
+    config: &InferConfig<'_>,
+) -> Vec<LocalCallSet> {
+    let mut call_sets = Vec::with_capacity(targets.len());
+    for target in targets {
         let target_range = target_range_string(target);
         let query = genotype::SyngCosigtQuery {
             target_range: &target_range,
@@ -281,9 +341,46 @@ pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> i
             min_anchors: config.min_anchors,
             min_span_fraction: config.min_span_fraction,
         };
+        match genotype::compute_syng_cosigt(syng_index, coverage, &query) {
+            Ok(output) => call_sets.push(LocalCallSet {
+                target: target.clone(),
+                output: Some(output),
+                error: None,
+            }),
+            Err(e) => call_sets.push(LocalCallSet {
+                target: target.clone(),
+                output: None,
+                error: Some(e.to_string().replace('\t', " ")),
+            }),
+        }
+    }
+    call_sets
+}
 
-        match genotype::compute_syng_cosigt(&syng_index, &coverage, &query) {
-            Ok(result) => {
+fn write_local_infer_output<W: Write>(
+    out: &mut W,
+    call_sets: &[LocalCallSet],
+    config: &InferConfig<'_>,
+) -> io::Result<()> {
+    writeln!(out, "#impg infer")?;
+    writeln!(out, "#evidence_backend\tpack")?;
+    if config.gaf_path.is_some() {
+        writeln!(out, "#read_walks\tgaf")?;
+    }
+    writeln!(out, "#score\tcos")?;
+    writeln!(out, "#feature_space\tsyng-syncmer-node")?;
+    writeln!(out, "#targets\t{}", call_sets.len())?;
+    writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
+    writeln!(out, "#ploidy\t{}", config.ploidy)?;
+    writeln!(
+        out,
+        "#rank\tpartition\tchrom\tstart\tend\tmethod\tploidy\tsimilarity\tqv\thaplotypes\tregions\tcandidate_anchors\tcandidate_span_fractions\tstatus"
+    )?;
+
+    for call_set in call_sets {
+        let target = &call_set.target;
+        match &call_set.output {
+            Some(result) => {
                 for (rank, genotype_result) in result.results.iter().enumerate() {
                     let haplotypes: Vec<&str> = genotype_result
                         .combination
@@ -323,7 +420,7 @@ pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> i
                     )?;
                 }
             }
-            Err(e) => {
+            None => {
                 writeln!(
                     out,
                     "1\t{}\t{}\t{}\t{}\tcos\t{}\t0.000000000\t0.000\t.\t.\t.\t.\tNO_CALL:{}",
@@ -332,9 +429,418 @@ pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> i
                     target.start,
                     target.end,
                     config.ploidy,
-                    e.to_string().replace('\t', " ")
+                    call_set.error.as_deref().unwrap_or("unknown error")
                 )?;
             }
+        }
+    }
+
+    Ok(())
+}
+
+fn unique_ordered_permutations(values: &[usize]) -> Vec<Vec<usize>> {
+    fn visit(
+        values: &[usize],
+        used: &mut [bool],
+        current: &mut Vec<usize>,
+        out: &mut Vec<Vec<usize>>,
+    ) {
+        if current.len() == values.len() {
+            if !out.contains(current) {
+                out.push(current.clone());
+            }
+            return;
+        }
+        for idx in 0..values.len() {
+            if used[idx] {
+                continue;
+            }
+            used[idx] = true;
+            current.push(values[idx]);
+            visit(values, used, current, out);
+            current.pop();
+            used[idx] = false;
+        }
+    }
+
+    let mut out = Vec::new();
+    let mut used = vec![false; values.len()];
+    let mut current = Vec::with_capacity(values.len());
+    visit(values, &mut used, &mut current, &mut out);
+    out
+}
+
+fn ordered_states(call_set: &LocalCallSet) -> Vec<OrderedState> {
+    let Some(output) = &call_set.output else {
+        return Vec::new();
+    };
+    let mut states = Vec::new();
+    for (result_idx, result) in output.results.iter().enumerate() {
+        for candidates in unique_ordered_permutations(&result.combination) {
+            states.push(OrderedState {
+                result_idx,
+                candidates,
+                emission: result.qv,
+            });
+        }
+    }
+    states
+}
+
+fn phase_transition(
+    prev: &genotype::HaplotypeCandidate,
+    curr: &genotype::HaplotypeCandidate,
+    switch_penalty: f64,
+    stitch_gap: u64,
+) -> (TransitionKind, f64) {
+    if prev.path_name == curr.path_name && prev.strand == curr.strand {
+        let gap = if curr.start >= prev.end {
+            curr.start - prev.end
+        } else {
+            prev.start.saturating_sub(curr.end)
+        };
+        if gap <= stitch_gap || curr.start <= prev.end {
+            return (TransitionKind::Continue, 0.0);
+        }
+        return (TransitionKind::Uncertain, switch_penalty * 0.5);
+    }
+    (TransitionKind::Recombine, switch_penalty)
+}
+
+fn transition_between(
+    prev_call: &LocalCallSet,
+    prev_state: &OrderedState,
+    curr_call: &LocalCallSet,
+    curr_state: &OrderedState,
+    config: &InferConfig<'_>,
+) -> (Vec<TransitionKind>, f64) {
+    let Some(prev_output) = &prev_call.output else {
+        return (Vec::new(), 0.0);
+    };
+    let Some(curr_output) = &curr_call.output else {
+        return (Vec::new(), 0.0);
+    };
+    let mut kinds = Vec::with_capacity(prev_state.candidates.len());
+    let mut cost = 0.0;
+    for (&prev_idx, &curr_idx) in prev_state
+        .candidates
+        .iter()
+        .zip(curr_state.candidates.iter())
+    {
+        let (kind, phase_cost) = phase_transition(
+            &prev_output.candidates[prev_idx],
+            &curr_output.candidates[curr_idx],
+            config.switch_penalty,
+            config.stitch_gap,
+        );
+        kinds.push(kind);
+        cost += phase_cost;
+    }
+    (kinds, cost)
+}
+
+fn stitch_mosaic(
+    call_sets: &[LocalCallSet],
+    config: &InferConfig<'_>,
+) -> io::Result<Option<MosaicPath>> {
+    let indexed_states: Vec<(usize, Vec<OrderedState>)> = call_sets
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, call_set)| {
+            let states = ordered_states(call_set);
+            if states.is_empty() {
+                None
+            } else {
+                Some((idx, states))
+            }
+        })
+        .collect();
+    if indexed_states.is_empty() {
+        return Ok(None);
+    }
+
+    let (first_idx, first_states) = &indexed_states[0];
+    let mut beam: Vec<MosaicPath> = first_states
+        .iter()
+        .map(|state| MosaicPath {
+            score: state.emission,
+            steps: vec![MosaicStep {
+                call_idx: *first_idx,
+                state: state.clone(),
+                transition_kinds: vec![TransitionKind::Start; state.candidates.len()],
+                transition_cost: 0.0,
+            }],
+        })
+        .collect();
+    beam.sort_by(|a, b| b.score.total_cmp(&a.score));
+    beam.truncate(config.stitch_beam);
+
+    for (call_idx, states) in indexed_states.iter().skip(1) {
+        let mut next = Vec::new();
+        for path in &beam {
+            let prev_step = path.steps.last().expect("beam path has at least one step");
+            let prev_call = &call_sets[prev_step.call_idx];
+            for state in states {
+                let (kinds, transition_cost) = transition_between(
+                    prev_call,
+                    &prev_step.state,
+                    &call_sets[*call_idx],
+                    state,
+                    config,
+                );
+                let mut candidate = path.clone();
+                candidate.score += state.emission - transition_cost;
+                candidate.steps.push(MosaicStep {
+                    call_idx: *call_idx,
+                    state: state.clone(),
+                    transition_kinds: kinds,
+                    transition_cost,
+                });
+                next.push(candidate);
+            }
+        }
+        next.sort_by(|a, b| b.score.total_cmp(&a.score));
+        next.truncate(config.stitch_beam);
+        beam = next;
+    }
+
+    Ok(beam.into_iter().max_by(|a, b| a.score.total_cmp(&b.score)))
+}
+
+fn write_mosaic_tsv(path: &str, mosaic: &MosaicPath, call_sets: &[LocalCallSet]) -> io::Result<()> {
+    let mut out = BufWriter::new(File::create(path)?);
+    writeln!(out, "#impg infer mosaic")?;
+    writeln!(out, "#score\t{:.6}", mosaic.score)?;
+    writeln!(
+        out,
+        "#phase\tpartition\tchrom\tstart\tend\tpath\tpath_start\tpath_end\tstrand\tlocal_rank\tlocal_similarity\tlocal_qv\ttransition_kind\ttransition_cost"
+    )?;
+    for step in &mosaic.steps {
+        let call_set = &call_sets[step.call_idx];
+        let output = call_set.output.as_ref().expect("mosaic step has output");
+        let result = &output.results[step.state.result_idx];
+        for (phase, &candidate_idx) in step.state.candidates.iter().enumerate() {
+            let candidate = &output.candidates[candidate_idx];
+            writeln!(
+                out,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.9}\t{:.3}\t{}\t{:.3}",
+                phase,
+                call_set.target.partition,
+                call_set.target.chrom,
+                call_set.target.start,
+                call_set.target.end,
+                candidate.path_name,
+                candidate.start,
+                candidate.end,
+                candidate.strand,
+                step.state.result_idx + 1,
+                result.similarity,
+                result.qv,
+                step.transition_kinds
+                    .get(phase)
+                    .copied()
+                    .unwrap_or(TransitionKind::Uncertain)
+                    .as_str(),
+                step.transition_cost,
+            )?;
+        }
+    }
+    out.flush()
+}
+
+fn fetch_candidate_sequence(
+    sequence_index: &UnifiedSequenceIndex,
+    candidate: &genotype::HaplotypeCandidate,
+) -> io::Result<Vec<u8>> {
+    let mut seq = sequence_index.fetch_sequence(
+        &candidate.path_name,
+        candidate.start as i32,
+        candidate.end as i32,
+    )?;
+    if candidate.strand == '-' {
+        seq = reverse_complement(&seq);
+    }
+    Ok(seq)
+}
+
+fn write_wrapped_fasta<W: Write>(out: &mut W, name: &str, seq: &[u8]) -> io::Result<()> {
+    writeln!(out, ">{name}")?;
+    for chunk in seq.chunks(80) {
+        out.write_all(chunk)?;
+        out.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+fn write_mosaic_fasta(
+    path: &str,
+    mosaic: &MosaicPath,
+    call_sets: &[LocalCallSet],
+    sequence_index: &UnifiedSequenceIndex,
+    strict: bool,
+) -> io::Result<()> {
+    let ploidy = mosaic
+        .steps
+        .first()
+        .map(|step| step.state.candidates.len())
+        .unwrap_or(0);
+    let mut phase_sequences = vec![Vec::<u8>::new(); ploidy];
+    for step in &mosaic.steps {
+        let call_set = &call_sets[step.call_idx];
+        let output = call_set.output.as_ref().expect("mosaic step has output");
+        for (phase, &candidate_idx) in step.state.candidates.iter().enumerate() {
+            let kind = step
+                .transition_kinds
+                .get(phase)
+                .copied()
+                .unwrap_or(TransitionKind::Uncertain);
+            if matches!(kind, TransitionKind::Recombine | TransitionKind::Uncertain)
+                && !phase_sequences[phase].is_empty()
+            {
+                if strict {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "strict stitch rejected {} join in partition {}",
+                            kind.as_str(),
+                            call_set.target.partition
+                        ),
+                    ));
+                }
+                phase_sequences[phase].extend_from_slice(b"NNNNNNNNNN");
+            }
+            let seq = fetch_candidate_sequence(sequence_index, &output.candidates[candidate_idx])?;
+            phase_sequences[phase].extend_from_slice(&seq);
+        }
+    }
+    let mut out = BufWriter::new(File::create(path)?);
+    for (phase, seq) in phase_sequences.iter().enumerate() {
+        write_wrapped_fasta(&mut out, &format!("impg_phase_{phase}"), seq)?;
+    }
+    out.flush()
+}
+
+fn write_mosaic_gfa(
+    path: &str,
+    mosaic: &MosaicPath,
+    call_sets: &[LocalCallSet],
+    sequence_index: &UnifiedSequenceIndex,
+    strict: bool,
+) -> io::Result<()> {
+    let ploidy = mosaic
+        .steps
+        .first()
+        .map(|step| step.state.candidates.len())
+        .unwrap_or(0);
+    let mut out = BufWriter::new(File::create(path)?);
+    writeln!(out, "H\tVN:Z:1.0")?;
+    let mut phase_segments: Vec<Vec<String>> = vec![Vec::new(); ploidy];
+    for (step_idx, step) in mosaic.steps.iter().enumerate() {
+        let call_set = &call_sets[step.call_idx];
+        let output = call_set.output.as_ref().expect("mosaic step has output");
+        for (phase, &candidate_idx) in step.state.candidates.iter().enumerate() {
+            let kind = step
+                .transition_kinds
+                .get(phase)
+                .copied()
+                .unwrap_or(TransitionKind::Uncertain);
+            if strict
+                && matches!(kind, TransitionKind::Recombine | TransitionKind::Uncertain)
+                && !phase_segments[phase].is_empty()
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "strict stitch rejected {} join in partition {}",
+                        kind.as_str(),
+                        call_set.target.partition
+                    ),
+                ));
+            }
+            let candidate = &output.candidates[candidate_idx];
+            let segment = format!("phase{phase}_{step_idx}");
+            let seq = fetch_candidate_sequence(sequence_index, candidate)?;
+            writeln!(out, "S\t{}\t{}", segment, String::from_utf8_lossy(&seq))?;
+            if let Some(prev) = phase_segments[phase].last() {
+                writeln!(
+                    out,
+                    "L\t{}\t+\t{}\t+\t0M\tTK:Z:{}",
+                    prev,
+                    segment,
+                    kind.as_str()
+                )?;
+            }
+            phase_segments[phase].push(segment);
+        }
+    }
+    for (phase, segments) in phase_segments.iter().enumerate() {
+        let walk = segments
+            .iter()
+            .map(|seg| format!("{seg}+"))
+            .collect::<Vec<_>>()
+            .join(",");
+        writeln!(out, "P\timpg_phase_{phase}\t{}\t*", walk)?;
+    }
+    out.flush()
+}
+
+pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> io::Result<()> {
+    let targets = resolve_targets(config)?;
+
+    info!("Loading syng index from prefix: {}", config.syng_prefix);
+    let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
+    info!("Loading sample pack coverage from {}", config.pack_path);
+    let coverage = pack::read(config.pack_path)?;
+    if let Some(gaf_path) = config.gaf_path {
+        info!("Using read-walk projection from {}", gaf_path);
+    }
+
+    let call_sets = compute_local_call_sets(&syng_index, &coverage, &targets, config);
+    write_local_infer_output(out, &call_sets, config)?;
+
+    let wants_stitch = config.stitch == StitchMode::Beam
+        || config.emit_mosaic.is_some()
+        || config.emit_fasta.is_some()
+        || config.emit_gfa.is_some();
+    if wants_stitch {
+        let mosaic = stitch_mosaic(&call_sets, config)?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no PASS local calls available to stitch into a mosaic",
+            )
+        })?;
+        if let Some(path) = config.emit_mosaic {
+            write_mosaic_tsv(path, &mosaic, &call_sets)?;
+        }
+        if let Some(path) = config.emit_fasta {
+            let sequence_index = config.sequence_index.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--emit-fasta requires --sequence-files or --sequence-list",
+                )
+            })?;
+            write_mosaic_fasta(
+                path,
+                &mosaic,
+                &call_sets,
+                sequence_index,
+                config.strict_stitch,
+            )?;
+        }
+        if let Some(path) = config.emit_gfa {
+            let sequence_index = config.sequence_index.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--emit-gfa requires --sequence-files or --sequence-list",
+                )
+            })?;
+            write_mosaic_gfa(
+                path,
+                &mosaic,
+                &call_sets,
+                sequence_index,
+                config.strict_stitch,
+            )?;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod multi_impg;
 pub mod onealn;
 pub mod pack;
 pub mod paf;
+pub mod projection;
 pub mod seqidx;
 pub mod sequence_index;
 pub mod smooth;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::num::NonZeroUsize;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicU64, AtomicUsize, Ordering},
     Arc,
@@ -1279,6 +1279,59 @@ fn emit_syng_map_pack_binary<W: Write + Send>(
     Ok(())
 }
 
+fn emit_syng_map_projection(
+    output_dir: &str,
+    syng_prefix: &str,
+    syng_matcher: &impg::syng::SyngMatcher,
+    query_path: &str,
+    min_anchors: usize,
+    compression_level: i32,
+    block_size: usize,
+) -> io::Result<()> {
+    let root = PathBuf::from(output_dir);
+    std::fs::create_dir_all(&root)?;
+    let pack_name = "sample.pack";
+    let gaf_name = "reads.gaf.zst";
+    let pack_path = root.join(pack_name);
+    let gaf_path = root.join(gaf_name);
+
+    info!(
+        "Writing sample projection to {} (pack + GAF walks)",
+        root.display()
+    );
+    {
+        let mut pack_out = create_plain_map_output_writer(
+            pack_path
+                .to_str()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "projection pack path is not UTF-8")
+                })?,
+        )?;
+        emit_syng_map_pack_binary(
+            &mut pack_out,
+            syng_matcher,
+            query_path,
+            min_anchors,
+            compression_level,
+            block_size,
+        )?;
+        pack_out.flush()?;
+    }
+    {
+        let mut gaf_out = create_map_output_writer(
+            gaf_path
+                .to_str()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "projection GAF path is not UTF-8")
+                })?,
+        )?;
+        emit_syng_map_gaf(&mut gaf_out, syng_matcher, query_path, min_anchors)?;
+        gaf_out.flush()?;
+    }
+    impg::projection::write_manifest(&root, syng_prefix, pack_name, Some(gaf_name))?;
+    Ok(())
+}
+
 const READ_SYNCMER_INDEX_VERSION: u32 = 1;
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -2525,9 +2578,13 @@ enum GenotypeCommand {
         #[clap(short = 'a', long, value_parser)]
         index: String,
 
-        /// Sample coverage produced by `impg map -o pack` or `impg map -o packbin`
+        /// Sample support vector produced by `impg map -o pack`
         #[clap(short = 'p', long, value_parser)]
-        pack: String,
+        pack: Option<String>,
+
+        /// Sample projection bundle produced by `impg map -o proj`
+        #[clap(long, value_parser, conflicts_with = "pack")]
+        proj: Option<String>,
 
         /// Reference path range to genotype, in the format `seq_name:start-end`
         #[clap(short = 'r', long, value_parser)]
@@ -3071,9 +3128,17 @@ enum Args {
         #[clap(short = 'a', long, value_parser)]
         index: String,
 
-        /// Sample evidence produced by `impg map -o pack` or `impg map -o packbin`
+        /// Sample support vector produced by `impg map -o pack`
         #[clap(short = 'p', long, value_parser)]
-        pack: String,
+        pack: Option<String>,
+
+        /// Sample projection bundle produced by `impg map -o proj`
+        #[clap(long, value_parser, conflicts_with = "pack")]
+        proj: Option<String>,
+
+        /// Per-read GAF syncmer walks produced by `impg map -o gaf`
+        #[clap(long, value_parser)]
+        gaf: Option<String>,
 
         /// Type exactly one target range, in the format `seq_name:start-end`
         #[clap(short = 'r', long, value_parser, conflicts_with_all = ["target_bed", "partitions"])]
@@ -3171,6 +3236,41 @@ enum Args {
         #[clap(short = 'O', long, value_parser)]
         output: Option<String>,
 
+        /// Stitch local calls into phased mosaic paths
+        #[clap(long, value_enum, default_value_t = infer::StitchMode::None)]
+        stitch: infer::StitchMode,
+
+        /// Number of partial mosaics retained during beam stitching
+        #[clap(long, value_parser, default_value_t = 200)]
+        stitch_beam: usize,
+
+        /// Cost of switching panel haplotypes in the stitched mosaic
+        #[clap(long, value_parser, default_value_t = 20.0)]
+        switch_penalty: f64,
+
+        /// Maximum same-path adjacency gap before marking a stitch uncertain
+        #[clap(long, value_parser, default_value_t = 1000)]
+        stitch_gap: u64,
+
+        /// Reject uncertain FASTA/GFA sequence joins instead of labeling or padding them
+        #[clap(long, action)]
+        strict_stitch: bool,
+
+        /// Write stitched mosaic segments as TSV
+        #[clap(long, value_parser)]
+        emit_mosaic: Option<String>,
+
+        /// Write inferred haplotype sequences as FASTA; requires --sequence-files or --sequence-list
+        #[clap(long, value_parser)]
+        emit_fasta: Option<String>,
+
+        /// Write inferred haplotype paths as GFA; requires --sequence-files or --sequence-list
+        #[clap(long, value_parser)]
+        emit_gfa: Option<String>,
+
+        #[clap(flatten)]
+        sequence: SequenceOpts,
+
         #[clap(flatten)]
         common: CommonOpts,
     },
@@ -3263,7 +3363,7 @@ enum Args {
         #[clap(short = 'q', long, value_parser)]
         query: String,
 
-        /// Output format: gaf (syncmer-node support), paf (projected genome coordinates), pack (TSV node coverage), or packbin (binary node coverage)
+        /// Output format: gaf (read syncmer walks), paf (projected coordinates), pack (compact support vector), pack-tsv (text support vector), or proj (projection bundle)
         #[clap(short = 'o', long, value_parser, default_value = "gaf")]
         output_format: String,
 
@@ -4976,6 +5076,7 @@ fn run() -> io::Result<()> {
             GenotypeCommand::Cos {
                 index,
                 pack,
+                proj,
                 target_range,
                 candidate_mode,
                 ploidy,
@@ -4991,9 +5092,32 @@ fn run() -> io::Result<()> {
             } => {
                 initialize_threads_and_log(&common);
                 let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+                let projection = if let Some(path) = proj.as_deref() {
+                    Some(impg::projection::load(path)?)
+                } else {
+                    None
+                };
+                if let Some(projection) = &projection {
+                    if projection.syng_prefix != syng_prefix {
+                        warn!(
+                            "Projection was built against syng prefix '{}', current index is '{}'",
+                            projection.syng_prefix, syng_prefix
+                        );
+                    }
+                }
+                let pack_path = if let Some(pack) = pack.as_deref() {
+                    pack.to_string()
+                } else if let Some(projection) = &projection {
+                    projection.pack_path.to_string_lossy().to_string()
+                } else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "impg genotype cos requires --pack or --proj",
+                    ));
+                };
                 let config = genotype::SyngCosigtConfig {
                     syng_prefix: &syng_prefix,
-                    pack_path: &pack,
+                    pack_path: &pack_path,
                     target_range: &target_range,
                     candidate_mode,
                     ploidy,
@@ -5041,6 +5165,8 @@ fn run() -> io::Result<()> {
         Args::Infer {
             index,
             pack,
+            proj,
+            gaf,
             target_range,
             target_bed,
             partitions,
@@ -5065,6 +5191,15 @@ fn run() -> io::Result<()> {
             min_anchors,
             min_span_fraction,
             output,
+            stitch,
+            stitch_beam,
+            switch_penalty,
+            stitch_gap,
+            strict_stitch,
+            emit_mosaic,
+            emit_fasta,
+            emit_gfa,
+            sequence,
             common,
         } => {
             initialize_threads_and_log(&common);
@@ -5122,9 +5257,60 @@ fn run() -> io::Result<()> {
             };
 
             let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+            let projection = if let Some(path) = proj.as_deref() {
+                Some(impg::projection::load(path)?)
+            } else {
+                None
+            };
+            if let Some(projection) = &projection {
+                if projection.syng_prefix != syng_prefix {
+                    warn!(
+                        "Projection was built against syng prefix '{}', current index is '{}'",
+                        projection.syng_prefix, syng_prefix
+                    );
+                }
+            }
+            let pack_path = if let Some(pack) = pack.as_deref() {
+                pack.to_string()
+            } else if let Some(projection) = &projection {
+                projection.pack_path.to_string_lossy().to_string()
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "impg infer requires --pack or --proj",
+                ));
+            };
+            let gaf_path = gaf.or_else(|| {
+                projection
+                    .as_ref()
+                    .and_then(|projection| projection.gaf_path.as_ref())
+                    .map(|path| path.to_string_lossy().to_string())
+            });
+            if stitch_beam == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--stitch-beam must be greater than 0",
+                ));
+            }
+            if switch_penalty < 0.0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--switch-penalty must be >= 0",
+                ));
+            }
+            let sequence_index = if emit_fasta.is_some() || emit_gfa.is_some() {
+                Some(sequence.build_sequence_index()?.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--emit-fasta/--emit-gfa require --sequence-files or --sequence-list",
+                    )
+                })?)
+            } else {
+                None
+            };
             let config = infer::InferConfig {
                 syng_prefix: &syng_prefix,
-                pack_path: &pack,
+                pack_path: &pack_path,
                 targets,
                 discovery,
                 candidate_mode,
@@ -5136,6 +5322,16 @@ fn run() -> io::Result<()> {
                 syng_extension,
                 min_anchors,
                 min_span_fraction,
+                gaf_path: gaf_path.as_deref(),
+                stitch,
+                stitch_beam,
+                switch_penalty,
+                stitch_gap,
+                strict_stitch,
+                emit_mosaic: emit_mosaic.as_deref(),
+                emit_fasta: emit_fasta.as_deref(),
+                emit_gfa: emit_gfa.as_deref(),
+                sequence_index: sequence_index.as_ref(),
             };
 
             #[cfg(unix)]
@@ -5437,18 +5633,25 @@ fn run() -> io::Result<()> {
             initialize_threads_and_log(&common);
 
             let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
-            if !matches!(output_format.as_str(), "gaf" | "paf" | "pack")
+            if !matches!(output_format.as_str(), "gaf" | "paf" | "proj")
                 && !impg::pack::is_binary_format(&output_format)
+                && !impg::pack::is_tsv_format(&output_format)
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
-                        "unsupported map output format '{}'; expected 'gaf', 'paf', 'pack', or 'packbin'",
+                        "unsupported map output format '{}'; expected 'gaf', 'paf', 'pack', 'pack-tsv', or 'proj'",
                         output_format
                     ),
                 ));
             }
-            if impg::pack::is_binary_format(&output_format) {
+            if output_format == "proj" && output.is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "impg map -o proj requires -O/--output with a projection directory path",
+                ));
+            }
+            if impg::pack::is_binary_format(&output_format) || output_format == "proj" {
                 if !(1..=22).contains(&pack_compression_level) {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
@@ -5473,6 +5676,8 @@ fn run() -> io::Result<()> {
             if let Some(path) = output {
                 let mut out = if impg::pack::is_binary_format(&output_format) {
                     create_plain_map_output_writer(&path)?
+                } else if output_format == "proj" {
+                    Box::new(io::sink()) as Box<dyn Write + Send>
                 } else {
                     create_map_output_writer(&path)?
                 };
@@ -5485,7 +5690,7 @@ fn run() -> io::Result<()> {
                         )?;
                         emit_syng_map_gaf(&mut out, &syng_matcher, &query, min_anchors)?;
                     }
-                    "pack" => {
+                    format if impg::pack::is_tsv_format(format) => {
                         info!("Loading syng syncmer dictionary from prefix: {}", syng_prefix);
                         let syng_matcher = impg::syng::SyngMatcher::load(
                             &syng_prefix,
@@ -5501,6 +5706,22 @@ fn run() -> io::Result<()> {
                         )?;
                         emit_syng_map_pack_binary(
                             &mut out,
+                            &syng_matcher,
+                            &query,
+                            min_anchors,
+                            pack_compression_level,
+                            pack_block_size,
+                        )?;
+                    }
+                    "proj" => {
+                        info!("Loading syng syncmer dictionary from prefix: {}", syng_prefix);
+                        let syng_matcher = impg::syng::SyngMatcher::load(
+                            &syng_prefix,
+                            impg::syng::SyncmerParams::default(),
+                        )?;
+                        emit_syng_map_projection(
+                            &path,
+                            &syng_prefix,
                             &syng_matcher,
                             &query,
                             min_anchors,
@@ -5543,7 +5764,7 @@ fn run() -> io::Result<()> {
                         )?;
                         emit_syng_map_gaf(&mut out, &syng_matcher, &query, min_anchors)?;
                     }
-                    "pack" => {
+                    format if impg::pack::is_tsv_format(format) => {
                         info!("Loading syng syncmer dictionary from prefix: {}", syng_prefix);
                         let syng_matcher = impg::syng::SyngMatcher::load(
                             &syng_prefix,

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -23,7 +23,11 @@ pub struct Coverage {
 }
 
 pub fn is_binary_format(output_format: &str) -> bool {
-    matches!(output_format, "packbin" | "pack-bin" | "bpack")
+    matches!(output_format, "pack" | "packbin" | "pack-bin" | "bpack")
+}
+
+pub fn is_tsv_format(output_format: &str) -> bool {
+    matches!(output_format, "pack-tsv" | "pack-text" | "packtsv")
 }
 
 fn write_u32_le<W: Write>(out: &mut W, value: u32) -> io::Result<()> {

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub const PROJECTION_FORMAT: &str = "impg-projection";
+pub const PROJECTION_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectionManifest {
+    pub format: String,
+    pub version: u32,
+    pub syng_prefix: String,
+    pub pack: String,
+    pub gaf: Option<String>,
+    pub feature_space: String,
+    pub read_space: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectionPaths {
+    pub root: PathBuf,
+    pub syng_prefix: String,
+    pub pack_path: PathBuf,
+    pub gaf_path: Option<PathBuf>,
+}
+
+fn resolve_relative(root: &Path, path: &str) -> PathBuf {
+    let p = Path::new(path);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        root.join(p)
+    }
+}
+
+pub fn write_manifest(
+    root: &Path,
+    syng_prefix: &str,
+    pack: &str,
+    gaf: Option<&str>,
+) -> io::Result<()> {
+    fs::create_dir_all(root)?;
+    let manifest = ProjectionManifest {
+        format: PROJECTION_FORMAT.to_string(),
+        version: PROJECTION_VERSION,
+        syng_prefix: syng_prefix.to_string(),
+        pack: pack.to_string(),
+        gaf: gaf.map(str::to_string),
+        feature_space: "syng-syncmer-node".to_string(),
+        read_space: gaf.map(|_| "syng-gaf-walk".to_string()),
+    };
+    let manifest_path = root.join("manifest.json");
+    let file = fs::File::create(manifest_path)?;
+    serde_json::to_writer_pretty(file, &manifest).map_err(io::Error::other)?;
+    Ok(())
+}
+
+pub fn load(path: impl AsRef<Path>) -> io::Result<ProjectionPaths> {
+    let root = path.as_ref();
+    let manifest_path = root.join("manifest.json");
+    let file = fs::File::open(&manifest_path).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!(
+                "failed to open projection manifest '{}': {}",
+                manifest_path.display(),
+                e
+            ),
+        )
+    })?;
+    let manifest: ProjectionManifest = serde_json::from_reader(file).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "failed to parse projection manifest '{}': {}",
+                manifest_path.display(),
+                e
+            ),
+        )
+    })?;
+    if manifest.format != PROJECTION_FORMAT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "projection manifest has format '{}', expected '{}'",
+                manifest.format, PROJECTION_FORMAT
+            ),
+        ));
+    }
+    if manifest.version != PROJECTION_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported projection version {}; expected {}",
+                manifest.version, PROJECTION_VERSION
+            ),
+        ));
+    }
+    let parent = manifest_path.parent().unwrap_or(root);
+    let pack_path = resolve_relative(parent, &manifest.pack);
+    let gaf_path = manifest
+        .gaf
+        .as_deref()
+        .map(|gaf| resolve_relative(parent, gaf));
+    Ok(ProjectionPaths {
+        root: root.to_path_buf(),
+        syng_prefix: manifest.syng_prefix,
+        pack_path,
+        gaf_path,
+    })
+}

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -636,7 +636,7 @@ fn test_syng_map_cli_gaf_and_paf() {
         "impg map should default to GAF output"
     );
 
-    let pack = Command::new(&bin)
+    let pack_tsv = Command::new(&bin)
         .args([
             "map",
             "-a",
@@ -644,29 +644,29 @@ fn test_syng_map_cli_gaf_and_paf() {
             "-q",
             query_path.to_str().unwrap(),
             "-o",
-            "pack",
+            "pack-tsv",
             "--min-anchors",
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o pack");
+        .expect("failed to run impg map -o pack-tsv");
     assert!(
-        pack.status.success(),
-        "impg map -o pack failed: {}",
-        String::from_utf8_lossy(&pack.stderr)
+        pack_tsv.status.success(),
+        "impg map -o pack-tsv failed: {}",
+        String::from_utf8_lossy(&pack_tsv.stderr)
     );
-    let pack_stdout = String::from_utf8_lossy(&pack.stdout);
+    let pack_stdout = String::from_utf8_lossy(&pack_tsv.stdout);
     let pack_lines: Vec<&str> = pack_stdout.lines().collect();
     assert_eq!(
         pack_lines.first().copied(),
         Some("#node_id\tcount"),
-        "pack output should start with a TSV header, got:\n{}",
+        "pack-tsv output should start with a TSV header, got:\n{}",
         pack_stdout
     );
     assert_eq!(
         pack_lines.len().saturating_sub(1),
         expected_pack_nodes.len(),
-        "pack output should have one row per distinct GAF node"
+        "pack-tsv output should have one row per distinct GAF node"
     );
     for line in pack_lines.iter().skip(1) {
         let fields: Vec<&str> = line.split('\t').collect();
@@ -675,7 +675,7 @@ fn test_syng_map_cli_gaf_and_paf() {
         let count = fields[1].parse::<u64>().unwrap();
         assert!(
             expected_pack_nodes.contains(&node_id),
-            "pack emitted unexpected node {} in:\n{}",
+            "pack-tsv emitted unexpected node {} in:\n{}",
             node_id,
             pack_stdout
         );
@@ -690,22 +690,22 @@ fn test_syng_map_cli_gaf_and_paf() {
             "-q",
             query_path.to_str().unwrap(),
             "-o",
-            "pack",
+            "pack-tsv",
             "-O",
             pack_zst_path.to_str().unwrap(),
             "--min-anchors",
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o pack -O pack.tsv.zst");
+        .expect("failed to run impg map -o pack-tsv -O pack.tsv.zst");
     assert!(
         pack_zst.status.success(),
-        "impg map -o pack -O pack.tsv.zst failed: {}",
+        "impg map -o pack-tsv -O pack.tsv.zst failed: {}",
         String::from_utf8_lossy(&pack_zst.stderr)
     );
     assert!(
         pack_zst.stdout.is_empty(),
-        "pack output should go to -O path, got stdout: {}",
+        "pack-tsv output should go to -O path, got stdout: {}",
         String::from_utf8_lossy(&pack_zst.stdout)
     );
     let compressed = std::fs::read(&pack_zst_path).unwrap();
@@ -722,7 +722,7 @@ fn test_syng_map_cli_gaf_and_paf() {
     }
     assert_eq!(
         decoded_pack, pack_stdout,
-        ".zst-compressed pack output should decompress to plain pack TSV"
+        ".zst-compressed pack-tsv output should decompress to plain pack TSV"
     );
 
     let packbin_path = dir.join("pack.ipack");
@@ -734,7 +734,7 @@ fn test_syng_map_cli_gaf_and_paf() {
             "-q",
             query_path.to_str().unwrap(),
             "-o",
-            "packbin",
+            "pack",
             "-O",
             packbin_path.to_str().unwrap(),
             "--pack-compression-level",
@@ -745,15 +745,15 @@ fn test_syng_map_cli_gaf_and_paf() {
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o packbin");
+        .expect("failed to run impg map -o pack");
     assert!(
         packbin.status.success(),
-        "impg map -o packbin failed: {}",
+        "impg map -o pack failed: {}",
         String::from_utf8_lossy(&packbin.stderr)
     );
     assert!(
         packbin.stdout.is_empty(),
-        "packbin output should go to -O path, got stdout bytes: {}",
+        "pack output should go to -O path, got stdout bytes: {}",
         packbin.stdout.len()
     );
     let packbin_bytes = std::fs::read(&packbin_path).unwrap();
@@ -817,6 +817,47 @@ fn test_syng_map_cli_gaf_and_paf() {
     for &node_id in &expected_pack_nodes {
         assert_eq!(dense[(node_id - 1) as usize], 1, "packbin count for {}", node_id);
     }
+
+    let proj_path = dir.join("sample.proj");
+    let proj = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-q",
+            query_path.to_str().unwrap(),
+            "-o",
+            "proj",
+            "-O",
+            proj_path.to_str().unwrap(),
+            "--pack-compression-level",
+            "3",
+            "--pack-block-size",
+            "64",
+            "--min-anchors",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg map -o proj");
+    assert!(
+        proj.status.success(),
+        "impg map -o proj failed: {}",
+        String::from_utf8_lossy(&proj.stderr)
+    );
+    assert!(proj_path.join("manifest.json").exists());
+    assert_eq!(&std::fs::read(proj_path.join("sample.pack")).unwrap()[..8], b"IMPGPKB1");
+    let mut gaf_decoder =
+        zstd::stream::read::Decoder::new(std::fs::File::open(proj_path.join("reads.gaf.zst")).unwrap()).unwrap();
+    let mut projected_gaf = String::new();
+    {
+        use std::io::Read;
+        gaf_decoder.read_to_string(&mut projected_gaf).unwrap();
+    }
+    assert!(
+        projected_gaf.starts_with("read1\t"),
+        "projection should include GAF read walks, got:\n{}",
+        projected_gaf
+    );
 
     let gaf_rc = Command::new(&bin)
         .args([
@@ -928,15 +969,15 @@ fn test_syng_map_cli_gaf_and_paf() {
             "-q",
             query_path.to_str().unwrap(),
             "-o",
-            "pack",
+            "pack-tsv",
             "--min-anchors",
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o pack with only khash");
+        .expect("failed to run impg map -o pack-tsv with only khash");
     assert!(
         pack_khash_only.status.success(),
-        "impg map -o pack should only require .1khash/.meta, stderr: {}",
+        "impg map -o pack-tsv should only require .1khash/.meta, stderr: {}",
         String::from_utf8_lossy(&pack_khash_only.stderr)
     );
     assert_eq!(
@@ -1071,7 +1112,7 @@ fn test_syng_genotype_cos_cli_permutations() {
         writeln!(f, "{}", "I".repeat(hap_b.len())).unwrap();
     }
 
-    let packbin_path = dir.join("sample.packbin");
+    let proj_path = dir.join("sample.proj");
     let map = Command::new(&bin)
         .args([
             "map",
@@ -1080,9 +1121,9 @@ fn test_syng_genotype_cos_cli_permutations() {
             "-q",
             reads_path.to_str().unwrap(),
             "-o",
-            "packbin",
+            "proj",
             "-O",
-            packbin_path.to_str().unwrap(),
+            proj_path.to_str().unwrap(),
             "--pack-compression-level",
             "3",
             "--pack-block-size",
@@ -1091,12 +1132,13 @@ fn test_syng_genotype_cos_cli_permutations() {
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o packbin");
+        .expect("failed to run impg map -o proj");
     assert!(
         map.status.success(),
-        "impg map -o packbin failed: {}",
+        "impg map -o proj failed: {}",
         String::from_utf8_lossy(&map.stderr)
     );
+    let compact_pack_path = proj_path.join("sample.pack");
 
     let pack_path = dir.join("sample.pack.tsv");
     let map_pack = Command::new(&bin)
@@ -1107,17 +1149,17 @@ fn test_syng_genotype_cos_cli_permutations() {
             "-q",
             reads_path.to_str().unwrap(),
             "-o",
-            "pack",
+            "pack-tsv",
             "-O",
             pack_path.to_str().unwrap(),
             "--min-anchors",
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o pack");
+        .expect("failed to run impg map -o pack-tsv");
     assert!(
         map_pack.status.success(),
-        "impg map -o pack failed: {}",
+        "impg map -o pack-tsv failed: {}",
         String::from_utf8_lossy(&map_pack.stderr)
     );
 
@@ -1130,17 +1172,17 @@ fn test_syng_genotype_cos_cli_permutations() {
             "-q",
             reads_path.to_str().unwrap(),
             "-o",
-            "pack",
+            "pack-tsv",
             "-O",
             pack_zst_path.to_str().unwrap(),
             "--min-anchors",
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o pack -O sample.pack.tsv.zst");
+        .expect("failed to run impg map -o pack-tsv -O sample.pack.tsv.zst");
     assert!(
         map_pack_zst.status.success(),
-        "impg map -o pack -O sample.pack.tsv.zst failed: {}",
+        "impg map -o pack-tsv -O sample.pack.tsv.zst failed: {}",
         String::from_utf8_lossy(&map_pack_zst.stderr)
     );
     let compressed_pack = std::fs::read(&pack_zst_path).unwrap();
@@ -1187,9 +1229,9 @@ fn test_syng_genotype_cos_cli_permutations() {
     let methods = ["cos", "cosigt"];
     let candidate_modes = ["spanning", "overlapping"];
     let packs = [
-        ("pack", "pack", pack_path.as_path()),
-        ("pack.zst", "pack", pack_zst_path.as_path()),
-        ("packbin", "packbin", packbin_path.as_path()),
+        ("pack-tsv", "pack", pack_path.as_path()),
+        ("pack-tsv.zst", "pack", pack_zst_path.as_path()),
+        ("pack", "packbin", compact_pack_path.as_path()),
     ];
     let mut expected_by_pack_mode: std::collections::BTreeMap<(String, String), String> =
         std::collections::BTreeMap::new();
@@ -1302,8 +1344,37 @@ fn test_syng_genotype_cos_cli_permutations() {
     }
     assert_eq!(checked, 24, "expected to exercise the full genotype CLI matrix");
 
+    let genotype_proj = Command::new(&bin)
+        .args([
+            "genotype",
+            "cos",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
+            "-r",
+            "sampleA#0#chr1:0-2100",
+            "--top-n",
+            "1",
+            "--candidate-top-k",
+            "10",
+            "--min-span-fraction",
+            "0.7",
+        ])
+        .output()
+        .expect("failed to run impg genotype cos --proj");
+    assert!(
+        genotype_proj.status.success(),
+        "impg genotype cos --proj failed: {}",
+        String::from_utf8_lossy(&genotype_proj.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&genotype_proj.stdout).contains("#impg genotype cos"),
+        "genotype --proj should emit cos output"
+    );
+
     let idx_prefix_str = idx_prefix.to_str().unwrap();
-    let packbin_str = packbin_path.to_str().unwrap();
+    let packbin_str = compact_pack_path.to_str().unwrap();
     let target_range = "sampleA#0#chr1:0-2100";
     let run_gt = |extra: &[&str]| {
         let mut args = vec![
@@ -1722,7 +1793,7 @@ fn test_syng_infer_pack_partitions_and_discovery() {
         write_tiled_fastq(&mut f, "hapB", &hap_b, 250, 25).unwrap();
     }
 
-    let packbin_path = dir.join("sample.packbin");
+    let proj_path = dir.join("sample.proj");
     let map = Command::new(&bin)
         .args([
             "map",
@@ -1731,9 +1802,9 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "-q",
             reads_path.to_str().unwrap(),
             "-o",
-            "packbin",
+            "proj",
             "-O",
-            packbin_path.to_str().unwrap(),
+            proj_path.to_str().unwrap(),
             "--pack-compression-level",
             "3",
             "--pack-block-size",
@@ -1742,10 +1813,10 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "2",
         ])
         .output()
-        .expect("failed to run impg map -o packbin");
+        .expect("failed to run impg map -o proj");
     assert!(
         map.status.success(),
-        "impg map -o packbin failed: {}",
+        "impg map -o proj failed: {}",
         String::from_utf8_lossy(&map.stderr)
     );
 
@@ -1755,8 +1826,8 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "infer",
             "-a",
             idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
             "-r",
             &target_range,
             "--top-n",
@@ -1814,8 +1885,8 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "infer",
             "-a",
             idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
             "--target-bed",
             target_bed.to_str().unwrap(),
             "--top-n",
@@ -1866,8 +1937,8 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "infer",
             "-a",
             idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
             "--partitions",
             partitions_path.to_str().unwrap(),
             "--top-n",
@@ -1876,6 +1947,16 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "10",
             "--min-span-fraction",
             "0.7",
+            "--stitch",
+            "beam",
+            "--emit-mosaic",
+            dir.join("mosaic.tsv").to_str().unwrap(),
+            "--emit-fasta",
+            dir.join("mosaic.fa").to_str().unwrap(),
+            "--emit-gfa",
+            dir.join("mosaic.gfa").to_str().unwrap(),
+            "--sequence-files",
+            fasta_path.to_str().unwrap(),
         ])
         .output()
         .expect("failed to run impg infer --partitions");
@@ -1904,14 +1985,24 @@ fn test_syng_infer_pack_partitions_and_discovery() {
         "{}",
         partition_stdout
     );
+    let mosaic_tsv = std::fs::read_to_string(dir.join("mosaic.tsv")).unwrap();
+    assert!(mosaic_tsv.contains("#impg infer mosaic"), "{}", mosaic_tsv);
+    assert!(mosaic_tsv.contains("sampleA#0#chr1"), "{}", mosaic_tsv);
+    let mosaic_fa = std::fs::read_to_string(dir.join("mosaic.fa")).unwrap();
+    assert!(mosaic_fa.contains(">impg_phase_0"), "{}", mosaic_fa);
+    assert!(mosaic_fa.contains(">impg_phase_1"), "{}", mosaic_fa);
+    let mosaic_gfa = std::fs::read_to_string(dir.join("mosaic.gfa")).unwrap();
+    assert!(mosaic_gfa.starts_with("H\tVN:Z:1.0"), "{}", mosaic_gfa);
+    assert!(mosaic_gfa.contains("\nS\tphase0_"), "{}", mosaic_gfa);
+    assert!(mosaic_gfa.contains("\nP\timpg_phase_0"), "{}", mosaic_gfa);
 
     let no_d = Command::new(&bin)
         .args([
             "infer",
             "-a",
             idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
         ])
         .output()
         .expect("failed to run impg infer without target inputs");
@@ -1930,8 +2021,8 @@ fn test_syng_infer_pack_partitions_and_discovery() {
             "infer",
             "-a",
             idx_prefix.to_str().unwrap(),
-            "-p",
-            packbin_path.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
             "-w",
             "1500",
             "-d",


### PR DESCRIPTION
## Summary
- make `impg map -o pack` the compact binary graph support vector and add `pack-tsv` for text output while keeping `packbin` as a compatibility alias
- add `impg map -o proj` projection bundles with `manifest.json`, `sample.pack`, and `reads.gaf.zst`
- teach `impg genotype cos` and `impg infer` to consume `--proj` as well as `--pack`
- refactor `infer` through local call sets and add beam stitching into phased mosaics
- add `--emit-mosaic`, `--emit-fasta`, and `--emit-gfa` for stitched diplotype materialization from FASTA/AGC sequence input
- update docs for pack/proj naming and inference workflow

## Validation
- `cargo check`
- `cargo test`
- `cargo test --test test_syng_integration -- --nocapture`
- `cargo test --test test_syng_integration test_syng_map_cli_gaf_and_paf -- --nocapture`
- `cargo test --test test_syng_integration test_syng_genotype_cos_cli_permutations -- --nocapture`
- `cargo test --test test_syng_integration test_syng_infer_pack_partitions_and_discovery -- --nocapture`
- `git diff --check`