### PR TITLE
Use read walks to score infer mosaics

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,11 @@ discovery, which requires `-d/--merge-distance`. `infer` can consume `--pack`
 for aggregate graph support or `--proj` for a bundle that also carries read
 walks. Add `--stitch beam --emit-mosaic out.tsv --emit-fasta haps.fa
 --emit-gfa diplotype.gfa --sequence-files panel.fa-or.agc` to stitch local
-calls into phased mosaic paths and materialize sequence. See
-`docs/infer-design.md`.
+calls into phased mosaic paths and materialize sequence. When `--proj` or
+`--gaf` read walks are available, stitched inference rewards phase transitions
+supported by the same reads (`--read-link-weight`,
+`--min-read-link-anchors`) while `--switch-penalty` keeps unnecessary panel
+crossovers expensive. See `docs/infer-design.md`.
 
 `-r` splits on the **last** `:`. Path names from `odgi paths -f`
 already contain coordinates (`grch38#chr6:31972046-32055647`), so a

--- a/docs/infer-design.md
+++ b/docs/infer-design.md
@@ -122,9 +122,9 @@ sample.proj/
 ```
 
 `sample.pack` is the aggregate support vector. `reads.gaf.zst` is the per-read
-syncmer walk layer that can later supply linkage/phase evidence. Commands should
-prefer `--proj` when both layers are available, while still accepting `--pack`
-for large cohort-scale aggregate workflows.
+syncmer walk layer used by stitched inference to supply linkage/phase evidence.
+Commands should prefer `--proj` when both layers are available, while still
+accepting `--pack` for large cohort-scale aggregate workflows.
 
 ## Scoring
 
@@ -160,12 +160,30 @@ best genome = argmax sum_j emission_j + transition_j
 This can start as beam search over the top local genotype states, then move to
 more principled HMM/Viterbi inference.
 
-Current stitching is the conservative first layer: retained local calls are
-expanded into ordered ploidy states, same-path continuation is cheap, and
-haplotype switches pay a configurable `--switch-penalty`. This is a panel
-copying prior over local calls, not yet a full read-link imputer. Projection GAF
-walks are carried through the interface so read-link transition evidence can be
-added without changing the user workflow.
+Current stitching is a beam-search haplotype-copying model over retained local
+calls. Each local genotype is expanded into ordered ploidy states. Same-path
+continuation is cheap, haplotype switches pay `--switch-penalty`, and read walks
+from a projection bundle add transition reward when the same read supports the
+specific previous-candidate -> current-candidate phase link.
+
+The read-link reward is intentionally simple and auditable:
+
+```text
+candidate feature = syng syncmer node
+read hits candidate = shared read-walk nodes >= --min-read-link-anchors
+transition support = adjacent candidate hits from the same read walk
+transition reward = --read-link-weight * 10 * log10(1 + normalized_anchor_support)
+```
+
+Ambiguous reads divide their support across all candidate links they match, so
+shared sequence does not create artificial certainty. The mosaic TSV reports
+`transition_cost`, `read_link_reads`, `read_link_anchors`, and
+`read_link_reward` per phase.
+
+This is now a real read-link imputer across the current partition lattice. The
+next refinement is to split a partition into internal candidate blocks, using
+the same state/transition machinery to infer IBD copied segments within a large
+partition as well as between partitions.
 
 ## Output
 

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -1,5 +1,6 @@
 use clap::ValueEnum;
 use log::info;
+use rustc_hash::FxHashMap;
 use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
@@ -63,6 +64,8 @@ pub struct InferConfig<'a> {
     pub stitch_beam: usize,
     pub switch_penalty: f64,
     pub stitch_gap: u64,
+    pub read_link_weight: f64,
+    pub min_read_link_anchors: usize,
     pub strict_stitch: bool,
     pub emit_mosaic: Option<&'a str>,
     pub emit_fasta: Option<&'a str>,
@@ -82,6 +85,36 @@ struct OrderedState {
     result_idx: usize,
     candidates: Vec<usize>,
     emission: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct CandidateKey {
+    call_idx: usize,
+    candidate_idx: usize,
+}
+
+#[derive(Debug, Default, Clone)]
+struct LinkEvidence {
+    read_weight: f64,
+    anchor_weight: f64,
+}
+
+#[derive(Debug, Default)]
+struct ReadWalkEvidence {
+    links: FxHashMap<(CandidateKey, CandidateKey), LinkEvidence>,
+    records: u64,
+    records_with_candidate_hits: u64,
+    candidate_hits: u64,
+    linked_read_pairs: u64,
+}
+
+#[derive(Debug, Clone)]
+struct PhaseTransitionScore {
+    kind: TransitionKind,
+    cost: f64,
+    read_link_reads: f64,
+    read_link_anchors: f64,
+    read_link_reward: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,8 +140,7 @@ impl TransitionKind {
 struct MosaicStep {
     call_idx: usize,
     state: OrderedState,
-    transition_kinds: Vec<TransitionKind>,
-    transition_cost: f64,
+    transitions: Vec<PhaseTransitionScore>,
 }
 
 #[derive(Debug, Clone)]
@@ -366,6 +398,11 @@ fn write_local_infer_output<W: Write>(
     writeln!(out, "#evidence_backend\tpack")?;
     if config.gaf_path.is_some() {
         writeln!(out, "#read_walks\tgaf")?;
+        writeln!(
+            out,
+            "#read_link_model\tadjacent-candidate-walk-links;min_anchors={};weight={:.6}",
+            config.min_read_link_anchors, config.read_link_weight
+        )?;
     }
     writeln!(out, "#score\tcos")?;
     writeln!(out, "#feature_space\tsyng-syncmer-node")?;
@@ -487,6 +524,178 @@ fn ordered_states(call_set: &LocalCallSet) -> Vec<OrderedState> {
     states
 }
 
+fn start_transition() -> PhaseTransitionScore {
+    PhaseTransitionScore {
+        kind: TransitionKind::Start,
+        cost: 0.0,
+        read_link_reads: 0.0,
+        read_link_anchors: 0.0,
+        read_link_reward: 0.0,
+    }
+}
+
+fn parse_gaf_path_nodes(path: &str, nodes: &mut Vec<u32>) -> io::Result<()> {
+    nodes.clear();
+    let bytes = path.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] != b'>' && bytes[i] != b'<' {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("GAF path contains non-orientation byte at offset {i}: {path}"),
+            ));
+        }
+        i += 1;
+        let start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == start {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("GAF path step is missing numeric syncmer node: {path}"),
+            ));
+        }
+        let node = path[start..i].parse::<u32>().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid syncmer node in GAF path '{path}': {e}"),
+            )
+        })?;
+        nodes.push(node);
+    }
+    Ok(())
+}
+
+fn sorted_candidate_hits(
+    counts: FxHashMap<CandidateKey, u32>,
+    min_read_link_anchors: usize,
+) -> Vec<(usize, Vec<(usize, u32)>)> {
+    let mut by_call: BTreeMap<usize, Vec<(usize, u32)>> = BTreeMap::new();
+    let min_read_link_anchors = min_read_link_anchors.max(1) as u32;
+    for (key, count) in counts {
+        if count >= min_read_link_anchors {
+            by_call
+                .entry(key.call_idx)
+                .or_default()
+                .push((key.candidate_idx, count));
+        }
+    }
+    let mut hits: Vec<(usize, Vec<(usize, u32)>)> = by_call.into_iter().collect();
+    for (_, candidates) in &mut hits {
+        candidates.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    }
+    hits
+}
+
+fn add_read_links(evidence: &mut ReadWalkEvidence, hits_by_call: &[(usize, Vec<(usize, u32)>)]) {
+    if hits_by_call.len() < 2 {
+        return;
+    }
+    evidence.records_with_candidate_hits += 1;
+    evidence.candidate_hits += hits_by_call
+        .iter()
+        .map(|(_, hits)| hits.len() as u64)
+        .sum::<u64>();
+
+    for adjacent in hits_by_call.windows(2) {
+        let (prev_call_idx, prev_hits) = &adjacent[0];
+        let (curr_call_idx, curr_hits) = &adjacent[1];
+        if prev_hits.is_empty() || curr_hits.is_empty() {
+            continue;
+        }
+        let denominator = (prev_hits.len() * curr_hits.len()) as f64;
+        for &(prev_candidate_idx, prev_count) in prev_hits {
+            for &(curr_candidate_idx, curr_count) in curr_hits {
+                let prev_key = CandidateKey {
+                    call_idx: *prev_call_idx,
+                    candidate_idx: prev_candidate_idx,
+                };
+                let curr_key = CandidateKey {
+                    call_idx: *curr_call_idx,
+                    candidate_idx: curr_candidate_idx,
+                };
+                let entry = evidence.links.entry((prev_key, curr_key)).or_default();
+                entry.read_weight += 1.0 / denominator;
+                entry.anchor_weight += f64::from(prev_count.min(curr_count)) / denominator;
+                evidence.linked_read_pairs += 1;
+            }
+        }
+    }
+}
+
+fn build_read_walk_evidence(
+    call_sets: &[LocalCallSet],
+    gaf_path: &str,
+    min_read_link_anchors: usize,
+) -> io::Result<ReadWalkEvidence> {
+    let mut node_to_candidates: FxHashMap<u32, Vec<CandidateKey>> = FxHashMap::default();
+    for (call_idx, call_set) in call_sets.iter().enumerate() {
+        let Some(output) = &call_set.output else {
+            continue;
+        };
+        for (candidate_idx, candidate) in output.candidates.iter().enumerate() {
+            for &(node_id, _) in &candidate.features {
+                node_to_candidates
+                    .entry(node_id)
+                    .or_default()
+                    .push(CandidateKey {
+                        call_idx,
+                        candidate_idx,
+                    });
+            }
+        }
+    }
+
+    if node_to_candidates.is_empty() {
+        return Ok(ReadWalkEvidence::default());
+    }
+
+    let file = File::open(gaf_path)?;
+    let (reader, _) = niffler::get_reader(Box::new(file)).map_err(|e| {
+        io::Error::other(format!("failed to open read-walk GAF '{}': {e}", gaf_path))
+    })?;
+    let reader = BufReader::with_capacity(8 * 1024 * 1024, reader);
+    let mut evidence = ReadWalkEvidence::default();
+    let mut nodes = Vec::new();
+
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        evidence.records += 1;
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 6 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("GAF line {} has fewer than 6 fields", line_no + 1),
+            ));
+        }
+        parse_gaf_path_nodes(fields[5], &mut nodes)?;
+        let mut counts: FxHashMap<CandidateKey, u32> = FxHashMap::default();
+        for &node_id in &nodes {
+            if let Some(candidate_keys) = node_to_candidates.get(&node_id) {
+                for &key in candidate_keys {
+                    *counts.entry(key).or_insert(0) += 1;
+                }
+            }
+        }
+        let hits_by_call = sorted_candidate_hits(counts, min_read_link_anchors);
+        add_read_links(&mut evidence, &hits_by_call);
+    }
+
+    Ok(evidence)
+}
+
+fn read_link_reward(anchor_weight: f64, read_link_weight: f64) -> f64 {
+    if anchor_weight <= 0.0 || read_link_weight <= 0.0 {
+        0.0
+    } else {
+        read_link_weight * 10.0 * (1.0 + anchor_weight).log10()
+    }
+}
+
 fn phase_transition(
     prev: &genotype::HaplotypeCandidate,
     curr: &genotype::HaplotypeCandidate,
@@ -509,19 +718,23 @@ fn phase_transition(
 
 fn transition_between(
     prev_call: &LocalCallSet,
+    prev_call_idx: usize,
     prev_state: &OrderedState,
     curr_call: &LocalCallSet,
+    curr_call_idx: usize,
     curr_state: &OrderedState,
     config: &InferConfig<'_>,
-) -> (Vec<TransitionKind>, f64) {
+    read_evidence: Option<&ReadWalkEvidence>,
+) -> (Vec<PhaseTransitionScore>, f64, f64) {
     let Some(prev_output) = &prev_call.output else {
-        return (Vec::new(), 0.0);
+        return (Vec::new(), 0.0, 0.0);
     };
     let Some(curr_output) = &curr_call.output else {
-        return (Vec::new(), 0.0);
+        return (Vec::new(), 0.0, 0.0);
     };
-    let mut kinds = Vec::with_capacity(prev_state.candidates.len());
-    let mut cost = 0.0;
+    let mut transitions = Vec::with_capacity(prev_state.candidates.len());
+    let mut total_cost = 0.0;
+    let mut total_reward = 0.0;
     for (&prev_idx, &curr_idx) in prev_state
         .candidates
         .iter()
@@ -533,15 +746,39 @@ fn transition_between(
             config.switch_penalty,
             config.stitch_gap,
         );
-        kinds.push(kind);
-        cost += phase_cost;
+        let link = read_evidence
+            .and_then(|evidence| {
+                evidence.links.get(&(
+                    CandidateKey {
+                        call_idx: prev_call_idx,
+                        candidate_idx: prev_idx,
+                    },
+                    CandidateKey {
+                        call_idx: curr_call_idx,
+                        candidate_idx: curr_idx,
+                    },
+                ))
+            })
+            .cloned()
+            .unwrap_or_default();
+        let reward = read_link_reward(link.anchor_weight, config.read_link_weight);
+        total_cost += phase_cost;
+        total_reward += reward;
+        transitions.push(PhaseTransitionScore {
+            kind,
+            cost: phase_cost,
+            read_link_reads: link.read_weight,
+            read_link_anchors: link.anchor_weight,
+            read_link_reward: reward,
+        });
     }
-    (kinds, cost)
+    (transitions, total_cost, total_reward)
 }
 
 fn stitch_mosaic(
     call_sets: &[LocalCallSet],
     config: &InferConfig<'_>,
+    read_evidence: Option<&ReadWalkEvidence>,
 ) -> io::Result<Option<MosaicPath>> {
     let indexed_states: Vec<(usize, Vec<OrderedState>)> = call_sets
         .iter()
@@ -567,8 +804,7 @@ fn stitch_mosaic(
             steps: vec![MosaicStep {
                 call_idx: *first_idx,
                 state: state.clone(),
-                transition_kinds: vec![TransitionKind::Start; state.candidates.len()],
-                transition_cost: 0.0,
+                transitions: vec![start_transition(); state.candidates.len()],
             }],
         })
         .collect();
@@ -581,20 +817,22 @@ fn stitch_mosaic(
             let prev_step = path.steps.last().expect("beam path has at least one step");
             let prev_call = &call_sets[prev_step.call_idx];
             for state in states {
-                let (kinds, transition_cost) = transition_between(
+                let (transitions, transition_cost, read_link_reward) = transition_between(
                     prev_call,
+                    prev_step.call_idx,
                     &prev_step.state,
                     &call_sets[*call_idx],
+                    *call_idx,
                     state,
                     config,
+                    read_evidence,
                 );
                 let mut candidate = path.clone();
-                candidate.score += state.emission - transition_cost;
+                candidate.score += state.emission - transition_cost + read_link_reward;
                 candidate.steps.push(MosaicStep {
                     call_idx: *call_idx,
                     state: state.clone(),
-                    transition_kinds: kinds,
-                    transition_cost,
+                    transitions,
                 });
                 next.push(candidate);
             }
@@ -607,13 +845,26 @@ fn stitch_mosaic(
     Ok(beam.into_iter().max_by(|a, b| a.score.total_cmp(&b.score)))
 }
 
+fn transition_for_phase(step: &MosaicStep, phase: usize) -> PhaseTransitionScore {
+    step.transitions
+        .get(phase)
+        .cloned()
+        .unwrap_or_else(|| PhaseTransitionScore {
+            kind: TransitionKind::Uncertain,
+            cost: 0.0,
+            read_link_reads: 0.0,
+            read_link_anchors: 0.0,
+            read_link_reward: 0.0,
+        })
+}
+
 fn write_mosaic_tsv(path: &str, mosaic: &MosaicPath, call_sets: &[LocalCallSet]) -> io::Result<()> {
     let mut out = BufWriter::new(File::create(path)?);
     writeln!(out, "#impg infer mosaic")?;
     writeln!(out, "#score\t{:.6}", mosaic.score)?;
     writeln!(
         out,
-        "#phase\tpartition\tchrom\tstart\tend\tpath\tpath_start\tpath_end\tstrand\tlocal_rank\tlocal_similarity\tlocal_qv\ttransition_kind\ttransition_cost"
+        "#phase\tpartition\tchrom\tstart\tend\tpath\tpath_start\tpath_end\tstrand\tlocal_rank\tlocal_similarity\tlocal_qv\ttransition_kind\ttransition_cost\tread_link_reads\tread_link_anchors\tread_link_reward"
     )?;
     for step in &mosaic.steps {
         let call_set = &call_sets[step.call_idx];
@@ -621,9 +872,10 @@ fn write_mosaic_tsv(path: &str, mosaic: &MosaicPath, call_sets: &[LocalCallSet])
         let result = &output.results[step.state.result_idx];
         for (phase, &candidate_idx) in step.state.candidates.iter().enumerate() {
             let candidate = &output.candidates[candidate_idx];
+            let transition = transition_for_phase(step, phase);
             writeln!(
                 out,
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.9}\t{:.3}\t{}\t{:.3}",
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.9}\t{:.3}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
                 phase,
                 call_set.target.partition,
                 call_set.target.chrom,
@@ -636,12 +888,11 @@ fn write_mosaic_tsv(path: &str, mosaic: &MosaicPath, call_sets: &[LocalCallSet])
                 step.state.result_idx + 1,
                 result.similarity,
                 result.qv,
-                step.transition_kinds
-                    .get(phase)
-                    .copied()
-                    .unwrap_or(TransitionKind::Uncertain)
-                    .as_str(),
-                step.transition_cost,
+                transition.kind.as_str(),
+                transition.cost,
+                transition.read_link_reads,
+                transition.read_link_anchors,
+                transition.read_link_reward,
             )?;
         }
     }
@@ -689,11 +940,7 @@ fn write_mosaic_fasta(
         let call_set = &call_sets[step.call_idx];
         let output = call_set.output.as_ref().expect("mosaic step has output");
         for (phase, &candidate_idx) in step.state.candidates.iter().enumerate() {
-            let kind = step
-                .transition_kinds
-                .get(phase)
-                .copied()
-                .unwrap_or(TransitionKind::Uncertain);
+            let kind = transition_for_phase(step, phase).kind;
             if matches!(kind, TransitionKind::Recombine | TransitionKind::Uncertain)
                 && !phase_sequences[phase].is_empty()
             {
@@ -739,11 +986,7 @@ fn write_mosaic_gfa(
         let call_set = &call_sets[step.call_idx];
         let output = call_set.output.as_ref().expect("mosaic step has output");
         for (phase, &candidate_idx) in step.state.candidates.iter().enumerate() {
-            let kind = step
-                .transition_kinds
-                .get(phase)
-                .copied()
-                .unwrap_or(TransitionKind::Uncertain);
+            let kind = transition_for_phase(step, phase).kind;
             if strict
                 && matches!(kind, TransitionKind::Recombine | TransitionKind::Uncertain)
                 && !phase_segments[phase].is_empty()
@@ -803,12 +1046,29 @@ pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> i
         || config.emit_fasta.is_some()
         || config.emit_gfa.is_some();
     if wants_stitch {
-        let mosaic = stitch_mosaic(&call_sets, config)?.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "no PASS local calls available to stitch into a mosaic",
-            )
-        })?;
+        let read_evidence = if let Some(gaf_path) = config.gaf_path {
+            let evidence =
+                build_read_walk_evidence(&call_sets, gaf_path, config.min_read_link_anchors)?;
+            info!(
+                "Loaded read-walk evidence from {}: {} GAF records, {} records with candidate hits, {} candidate hits, {} linked candidate pairs, {} scored transitions",
+                gaf_path,
+                evidence.records,
+                evidence.records_with_candidate_hits,
+                evidence.candidate_hits,
+                evidence.linked_read_pairs,
+                evidence.links.len()
+            );
+            Some(evidence)
+        } else {
+            None
+        };
+        let mosaic =
+            stitch_mosaic(&call_sets, config, read_evidence.as_ref())?.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "no PASS local calls available to stitch into a mosaic",
+                )
+            })?;
         if let Some(path) = config.emit_mosaic {
             write_mosaic_tsv(path, &mosaic, &call_sets)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3252,6 +3252,14 @@ enum Args {
         #[clap(long, value_parser, default_value_t = 1000)]
         stitch_gap: u64,
 
+        /// Weight for read-walk evidence when scoring stitched phase transitions
+        #[clap(long, value_parser, default_value_t = 1.0)]
+        read_link_weight: f64,
+
+        /// Minimum read syncmer anchors a candidate must share before it contributes read-link evidence
+        #[clap(long, value_parser, default_value_t = 2)]
+        min_read_link_anchors: usize,
+
         /// Reject uncertain FASTA/GFA sequence joins instead of labeling or padding them
         #[clap(long, action)]
         strict_stitch: bool,
@@ -5195,6 +5203,8 @@ fn run() -> io::Result<()> {
             stitch_beam,
             switch_penalty,
             stitch_gap,
+            read_link_weight,
+            min_read_link_anchors,
             strict_stitch,
             emit_mosaic,
             emit_fasta,
@@ -5298,6 +5308,18 @@ fn run() -> io::Result<()> {
                     "--switch-penalty must be >= 0",
                 ));
             }
+            if read_link_weight < 0.0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--read-link-weight must be >= 0",
+                ));
+            }
+            if min_read_link_anchors == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--min-read-link-anchors must be greater than 0",
+                ));
+            }
             let sequence_index = if emit_fasta.is_some() || emit_gfa.is_some() {
                 Some(sequence.build_sequence_index()?.ok_or_else(|| {
                     io::Error::new(
@@ -5327,6 +5349,8 @@ fn run() -> io::Result<()> {
                 stitch_beam,
                 switch_penalty,
                 stitch_gap,
+                read_link_weight,
+                min_read_link_anchors,
                 strict_stitch,
                 emit_mosaic: emit_mosaic.as_deref(),
                 emit_fasta: emit_fasta.as_deref(),

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -2059,6 +2059,202 @@ fn test_syng_infer_pack_partitions_and_discovery() {
 }
 
 #[test]
+fn test_syng_infer_read_walk_links_phase_recombinant_mosaic() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_syng_infer_read_links");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    fn mutate_ascii(seq: &[u8], offset: usize, stride: usize) -> Vec<u8> {
+        let mut out = seq.to_vec();
+        for i in (offset..out.len()).step_by(stride) {
+            out[i] = match out[i] {
+                b'A' => b'C',
+                b'C' => b'G',
+                b'G' => b'T',
+                b'T' => b'A',
+                other => other,
+            };
+        }
+        out
+    }
+
+    let left_1 = numeric_to_ascii(&make_sequence_numeric(950, 81));
+    let left_2 = mutate_ascii(&left_1, 37, 127);
+    let right_1 = numeric_to_ascii(&make_sequence_numeric(950, 83));
+    let right_2 = mutate_ascii(&right_1, 53, 131);
+
+    let mut hap_a = Vec::new();
+    hap_a.extend_from_slice(&left_1);
+    hap_a.extend_from_slice(&right_1);
+    let mut hap_b = Vec::new();
+    hap_b.extend_from_slice(&left_2);
+    hap_b.extend_from_slice(&right_2);
+    let mut hap_c = Vec::new();
+    hap_c.extend_from_slice(&left_1);
+    hap_c.extend_from_slice(&right_2);
+    let mut hap_d = Vec::new();
+    hap_d.extend_from_slice(&left_2);
+    hap_d.extend_from_slice(&right_1);
+
+    let fasta_path = dir.join("index.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        writeln!(f, ">sampleA#0#chr1").unwrap();
+        f.write_all(&hap_a).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#0#chr1").unwrap();
+        f.write_all(&hap_b).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleC#0#chr1").unwrap();
+        f.write_all(&hap_c).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleD#0#chr1").unwrap();
+        f.write_all(&hap_d).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let idx_prefix = dir.join("idx");
+    let build = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "-o",
+            idx_prefix.to_str().unwrap(),
+            "--position-sample-rate",
+            "1",
+        ])
+        .output()
+        .expect("failed to run impg syng");
+    assert!(
+        build.status.success(),
+        "impg syng failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let reads_path = dir.join("simulated_recombinant_reads.fq");
+    {
+        let mut f = std::fs::File::create(&reads_path).unwrap();
+        write_tiled_fastq(&mut f, "hapC", &hap_c, 1200, 175).unwrap();
+        write_tiled_fastq(&mut f, "hapD", &hap_d, 1200, 175).unwrap();
+    }
+
+    let proj_path = dir.join("sample.proj");
+    let map = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "-q",
+            reads_path.to_str().unwrap(),
+            "-o",
+            "proj",
+            "-O",
+            proj_path.to_str().unwrap(),
+            "--pack-compression-level",
+            "3",
+            "--pack-block-size",
+            "64",
+            "--min-anchors",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg map -o proj");
+    assert!(
+        map.status.success(),
+        "impg map -o proj failed: {}",
+        String::from_utf8_lossy(&map.stderr)
+    );
+
+    let partitions_path = dir.join("partitions.bed");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&partitions_path).unwrap();
+        writeln!(f, "sampleA#0#chr1\t0\t950\tleft").unwrap();
+        writeln!(f, "sampleA#0#chr1\t950\t1900\tright").unwrap();
+    }
+
+    let mosaic_path = dir.join("mosaic.tsv");
+    let infer = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
+            "--partitions",
+            partitions_path.to_str().unwrap(),
+            "--top-n",
+            "20",
+            "--candidate-top-k",
+            "20",
+            "--min-span-fraction",
+            "0.7",
+            "--stitch",
+            "beam",
+            "--stitch-beam",
+            "500",
+            "--read-link-weight",
+            "5",
+            "--emit-mosaic",
+            mosaic_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run impg infer with read-link stitching");
+    assert!(
+        infer.status.success(),
+        "impg infer with read-link stitching failed: {}",
+        String::from_utf8_lossy(&infer.stderr)
+    );
+
+    let mosaic = std::fs::read_to_string(&mosaic_path).unwrap();
+    assert!(
+        mosaic.contains("read_link_reward"),
+        "mosaic output should expose read-link scoring columns:\n{}",
+        mosaic
+    );
+    let rows: Vec<Vec<&str>> = mosaic
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .map(|line| line.split('\t').collect())
+        .collect();
+    assert_eq!(rows.len(), 4, "expected two phases across two partitions:\n{}", mosaic);
+    assert!(
+        rows.iter()
+            .filter(|row| row[1] == "right")
+            .all(|row| row[16].parse::<f64>().unwrap() > 0.0),
+        "right-partition transitions should be rewarded by spanning read walks:\n{}",
+        mosaic
+    );
+
+    let mut phase_paths: std::collections::BTreeMap<&str, Vec<&str>> =
+        std::collections::BTreeMap::new();
+    for row in &rows {
+        phase_paths.entry(row[0]).or_default().push(row[5]);
+    }
+    let mut stitched_paths: Vec<Vec<&str>> = phase_paths.into_values().collect();
+    stitched_paths.sort();
+    assert_eq!(
+        stitched_paths,
+        vec![
+            vec!["sampleC#0#chr1", "sampleC#0#chr1"],
+            vec!["sampleD#0#chr1", "sampleD#0#chr1"],
+        ],
+        "read links plus crossover penalty should choose the sampled recombinant haplotypes:\n{}",
+        mosaic
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_syng_map_cli_sampled_positions_paf() {
     let _guard = lock_syng();
     let Some(bin) = impg_binary() else {


### PR DESCRIPTION
## Summary
- build read-walk transition evidence from projection GAF walks during stitched infer
- reward phase transitions supported by the same reads while keeping switch penalties for panel crossovers
- expose read-link score columns in mosaic output and document the model
- add an end-to-end recombinant phasing integration test

## Tests
- cargo check
- cargo test --test test_syng_integration test_syng_infer_read_walk_links_phase_recombinant_mosaic -- --nocapture
- cargo test --test test_syng_integration test_syng_infer_pack_partitions_and_discovery -- --nocapture
- cargo test