### PR TITLE
Add infer phase block stitching

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,9 @@ calls into phased mosaic paths and materialize sequence. When `--proj` or
 `--gaf` read walks are available, stitched inference rewards phase transitions
 supported by the same reads (`--read-link-weight`,
 `--min-read-link-anchors`) while `--switch-penalty` keeps unnecessary panel
-crossovers expensive. See `docs/infer-design.md`.
+crossovers expensive. Add `--phase-block-size N` to split broad targets into
+internal phase blocks before stitching, which lets the same model infer copied
+segments inside a partition. See `docs/infer-design.md`.
 
 `-r` splits on the **last** `:`. Path names from `odgi paths -f`
 already contain coordinates (`grch38#chr6:31972046-32055647`), so a

--- a/docs/infer-design.md
+++ b/docs/infer-design.md
@@ -181,9 +181,13 @@ shared sequence does not create artificial certainty. The mosaic TSV reports
 `read_link_reward` per phase.
 
 This is now a real read-link imputer across the current partition lattice. The
-next refinement is to split a partition into internal candidate blocks, using
-the same state/transition machinery to infer IBD copied segments within a large
-partition as well as between partitions.
+same state/transition machinery can also be run within a large target by adding
+`--phase-block-size N`, which splits each target/partition into fixed-width
+internal phase blocks before local genotyping and stitching. This lets `infer`
+discover copied IBD segments inside a broad partition and then carry phase
+between adjacent partitions with the same model. The fixed grid is an initial
+lattice; future work can choose block boundaries from read density, graph
+breakpoints, or local ambiguity instead of a constant width.
 
 ## Output
 

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -61,6 +61,7 @@ pub struct InferConfig<'a> {
     pub min_span_fraction: f64,
     pub gaf_path: Option<&'a str>,
     pub stitch: StitchMode,
+    pub phase_block_size: usize,
     pub stitch_beam: usize,
     pub switch_penalty: f64,
     pub stitch_gap: u64,
@@ -352,6 +353,39 @@ fn resolve_targets(config: &InferConfig<'_>) -> io::Result<Vec<InferTarget>> {
     Ok(targets)
 }
 
+fn split_phase_blocks(targets: Vec<InferTarget>, block_size: usize) -> Vec<InferTarget> {
+    if block_size == 0 {
+        return targets;
+    }
+
+    let mut blocks = Vec::new();
+    for target in targets {
+        let len = target.end.saturating_sub(target.start) as usize;
+        if len <= block_size {
+            blocks.push(target);
+            continue;
+        }
+
+        let mut block_start = target.start;
+        let mut block_idx = 0usize;
+        while block_start < target.end {
+            let block_end = block_start
+                .saturating_add(block_size.min(i32::MAX as usize) as i32)
+                .min(target.end);
+            blocks.push(InferTarget {
+                partition: format!("{}#block{}", target.partition, block_idx),
+                chrom: target.chrom.clone(),
+                start: block_start,
+                end: block_end,
+                name: format!("{}#block{}", target.name, block_idx),
+            });
+            block_start = block_end;
+            block_idx += 1;
+        }
+    }
+    blocks
+}
+
 fn compute_local_call_sets(
     syng_index: &syng::SyngIndex,
     coverage: &pack::Coverage,
@@ -407,6 +441,9 @@ fn write_local_infer_output<W: Write>(
     writeln!(out, "#score\tcos")?;
     writeln!(out, "#feature_space\tsyng-syncmer-node")?;
     writeln!(out, "#targets\t{}", call_sets.len())?;
+    if config.phase_block_size > 0 {
+        writeln!(out, "#phase_block_size\t{}", config.phase_block_size)?;
+    }
     writeln!(out, "#candidate_mode\t{:?}", config.candidate_mode)?;
     writeln!(out, "#ploidy\t{}", config.ploidy)?;
     writeln!(
@@ -1028,7 +1065,7 @@ fn write_mosaic_gfa(
 }
 
 pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> io::Result<()> {
-    let targets = resolve_targets(config)?;
+    let targets = split_phase_blocks(resolve_targets(config)?, config.phase_block_size);
 
     info!("Loading syng index from prefix: {}", config.syng_prefix);
     let syng_index = syng::SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3240,6 +3240,10 @@ enum Args {
         #[clap(long, value_enum, default_value_t = infer::StitchMode::None)]
         stitch: infer::StitchMode,
 
+        /// Split each target into fixed-size phase blocks before stitching (0 disables)
+        #[clap(long, value_parser, default_value_t = 0)]
+        phase_block_size: usize,
+
         /// Number of partial mosaics retained during beam stitching
         #[clap(long, value_parser, default_value_t = 200)]
         stitch_beam: usize,
@@ -5200,6 +5204,7 @@ fn run() -> io::Result<()> {
             min_span_fraction,
             output,
             stitch,
+            phase_block_size,
             stitch_beam,
             switch_penalty,
             stitch_gap,
@@ -5302,6 +5307,12 @@ fn run() -> io::Result<()> {
                     "--stitch-beam must be greater than 0",
                 ));
             }
+            if phase_block_size > i32::MAX as usize {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--phase-block-size must fit in signed 32-bit coordinates",
+                ));
+            }
             if switch_penalty < 0.0 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -5346,6 +5357,7 @@ fn run() -> io::Result<()> {
                 min_span_fraction,
                 gaf_path: gaf_path.as_deref(),
                 stitch,
+                phase_block_size,
                 stitch_beam,
                 switch_penalty,
                 stitch_gap,

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -2251,6 +2251,85 @@ fn test_syng_infer_read_walk_links_phase_recombinant_mosaic() {
         mosaic
     );
 
+    let block_mosaic_path = dir.join("mosaic.phase_blocks.tsv");
+    let target_range = "sampleA#0#chr1:0-1900";
+    let infer_blocks = Command::new(&bin)
+        .args([
+            "infer",
+            "-a",
+            idx_prefix.to_str().unwrap(),
+            "--proj",
+            proj_path.to_str().unwrap(),
+            "-r",
+            target_range,
+            "--phase-block-size",
+            "950",
+            "--top-n",
+            "20",
+            "--candidate-top-k",
+            "20",
+            "--min-span-fraction",
+            "0.7",
+            "--stitch",
+            "beam",
+            "--stitch-beam",
+            "500",
+            "--read-link-weight",
+            "5",
+            "--emit-mosaic",
+            block_mosaic_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run impg infer with phase-block stitching");
+    assert!(
+        infer_blocks.status.success(),
+        "impg infer with phase-block stitching failed: {}",
+        String::from_utf8_lossy(&infer_blocks.stderr)
+    );
+    let block_mosaic = std::fs::read_to_string(&block_mosaic_path).unwrap();
+    assert!(
+        block_mosaic.contains("#phase_block_size\t950")
+            || String::from_utf8_lossy(&infer_blocks.stdout).contains("#phase_block_size\t950"),
+        "phase-block inference should record the internal block size:\nstdout:\n{}\nmosaic:\n{}",
+        String::from_utf8_lossy(&infer_blocks.stdout),
+        block_mosaic
+    );
+    let block_rows: Vec<Vec<&str>> = block_mosaic
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .map(|line| line.split('\t').collect())
+        .collect();
+    assert_eq!(
+        block_rows.len(),
+        4,
+        "expected two phases across two internal phase blocks:\n{}",
+        block_mosaic
+    );
+    assert!(
+        block_rows
+            .iter()
+            .filter(|row| row[1].ends_with("#block1"))
+            .all(|row| row[16].parse::<f64>().unwrap() > 0.0),
+        "second internal phase block should be rewarded by spanning read walks:\n{}",
+        block_mosaic
+    );
+    let mut block_phase_paths: std::collections::BTreeMap<&str, Vec<&str>> =
+        std::collections::BTreeMap::new();
+    for row in &block_rows {
+        block_phase_paths.entry(row[0]).or_default().push(row[5]);
+    }
+    let mut block_stitched_paths: Vec<Vec<&str>> = block_phase_paths.into_values().collect();
+    block_stitched_paths.sort();
+    assert_eq!(
+        block_stitched_paths,
+        vec![
+            vec!["sampleC#0#chr1", "sampleC#0#chr1"],
+            vec!["sampleD#0#chr1", "sampleD#0#chr1"],
+        ],
+        "phase-block stitching should infer copied recombinant segments inside one target:\n{}",
+        block_mosaic
+    );
+
     std::fs::remove_dir_all(&dir).ok();
 }
 


### PR DESCRIPTION
## Summary
- add --phase-block-size to split broad infer targets into internal phase blocks before local genotyping and stitching
- reuse the read-walk/crossover beam model to infer copied IBD segments inside a partition
- extend the recombinant phasing integration test to cover both explicit partitions and one broad target split into phase blocks
- document the phase-block lattice in README and infer design notes

## Tests
- cargo check
- cargo test --test test_syng_integration test_syng_infer_read_walk_links_phase_recombinant_mosaic -- --nocapture
- cargo test