### PR TITLE
Use whole read walks for infer evidence

### DIFF
--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -25,13 +25,13 @@ pub struct HaplotypeCandidate {
     pub anchors: usize,
     pub query_span_fraction: f64,
     pub features: Vec<(u32, u64)>,
-    pub oriented_links: Vec<((i32, i32), u64)>,
+    pub oriented_walk: Vec<i32>,
     single_similarity: f64,
 }
 
 struct CandidateFeatures {
     unoriented: Vec<(u32, u64)>,
-    oriented_links: Vec<((i32, i32), u64)>,
+    oriented_walk: Vec<i32>,
 }
 
 #[derive(Debug)]
@@ -141,24 +141,16 @@ fn syng_candidate_features(
             )
         })? as usize;
     let mut counts: FxHashMap<u32, u64> = FxHashMap::default();
-    let mut oriented_link_counts: FxHashMap<(i32, i32), u64> = FxHashMap::default();
-    let mut prev = None;
+    let mut oriented_walk = Vec::new();
     for (signed_node, _) in syng_index.walk_path_range(path_idx, start, end)? {
         *counts.entry(signed_node.unsigned_abs()).or_insert(0) += 1;
-        if let Some(prev_node) = prev {
-            *oriented_link_counts
-                .entry((prev_node, signed_node))
-                .or_insert(0) += 1;
-        }
-        prev = Some(signed_node);
+        oriented_walk.push(signed_node);
     }
     let mut unoriented: Vec<(u32, u64)> = counts.into_iter().collect();
     unoriented.sort_unstable_by_key(|&(feature_id, _)| feature_id);
-    let mut oriented_links: Vec<((i32, i32), u64)> = oriented_link_counts.into_iter().collect();
-    oriented_links.sort_unstable_by_key(|&(feature_id, _)| feature_id);
     Ok(CandidateFeatures {
         unoriented,
-        oriented_links,
+        oriented_walk,
     })
 }
 
@@ -205,7 +197,7 @@ fn collect_syng_candidates(
                     anchors: hit.anchors.len(),
                     query_span_fraction,
                     features: features.unoriented,
-                    oriented_links: features.oriented_links,
+                    oriented_walk: features.oriented_walk,
                     single_similarity: 0.0,
                 });
             }
@@ -258,7 +250,7 @@ fn collect_syng_candidates(
                     anchors: group.anchors.len(),
                     query_span_fraction,
                     features: features.unoriented,
-                    oriented_links: features.oriented_links,
+                    oriented_walk: features.oriented_walk,
                     single_similarity: 0.0,
                 });
             }

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -95,6 +95,12 @@ struct CandidateKey {
     candidate_idx: usize,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct WalkOccurrence {
+    key: CandidateKey,
+    position: u32,
+}
+
 #[derive(Debug, Default, Clone)]
 struct LinkEvidence {
     read_weight: f64,
@@ -742,16 +748,59 @@ fn add_candidate_support(
     }
 }
 
-fn add_candidate_hits_from_map<K: Copy + Eq + std::hash::Hash>(
-    counts: &mut FxHashMap<CandidateKey, u32>,
-    feature_to_candidates: &FxHashMap<K, Vec<CandidateKey>>,
-    feature: K,
-) {
-    if let Some(candidate_keys) = feature_to_candidates.get(&feature) {
-        for &key in candidate_keys {
-            *counts.entry(key).or_insert(0) += 1;
+fn lis_len(values: &[u32]) -> u32 {
+    let mut tails: Vec<u32> = Vec::new();
+    for &value in values {
+        let idx = tails.partition_point(|&tail| tail < value);
+        if idx == tails.len() {
+            tails.push(value);
+        } else {
+            tails[idx] = value;
         }
     }
+    tails.len() as u32
+}
+
+fn add_whole_walk_orientation_hits(
+    counts: &mut FxHashMap<CandidateKey, u32>,
+    walk_index: &FxHashMap<i32, Vec<WalkOccurrence>>,
+    nodes: &[i32],
+) {
+    let mut positions_by_candidate: FxHashMap<CandidateKey, Vec<u32>> = FxHashMap::default();
+    for &node in nodes {
+        if let Some(occurrences) = walk_index.get(&node) {
+            for &occurrence in occurrences {
+                positions_by_candidate
+                    .entry(occurrence.key)
+                    .or_default()
+                    .push(occurrence.position);
+            }
+        }
+    }
+
+    for (key, positions) in positions_by_candidate {
+        let matched = lis_len(&positions);
+        if matched == 0 {
+            continue;
+        }
+        let entry = counts.entry(key).or_insert(0);
+        *entry = (*entry).max(matched);
+    }
+}
+
+fn add_whole_walk_hits(
+    counts: &mut FxHashMap<CandidateKey, u32>,
+    walk_index: &FxHashMap<i32, Vec<WalkOccurrence>>,
+    nodes: &[i32],
+    reverse_nodes: &mut Vec<i32>,
+) {
+    if nodes.is_empty() {
+        return;
+    }
+    add_whole_walk_orientation_hits(counts, walk_index, nodes);
+    reverse_nodes.clear();
+    reverse_nodes.extend(nodes.iter().rev().map(|node| -*node));
+    add_whole_walk_orientation_hits(counts, walk_index, reverse_nodes);
 }
 
 fn build_read_walk_evidence(
@@ -759,35 +808,38 @@ fn build_read_walk_evidence(
     gaf_path: &str,
     min_read_link_anchors: usize,
 ) -> io::Result<ReadWalkEvidence> {
-    let mut node_to_candidates: FxHashMap<u32, Vec<CandidateKey>> = FxHashMap::default();
-    let mut link_to_candidates: FxHashMap<(i32, i32), Vec<CandidateKey>> = FxHashMap::default();
+    let mut walk_index: FxHashMap<i32, Vec<WalkOccurrence>> = FxHashMap::default();
     for (call_idx, call_set) in call_sets.iter().enumerate() {
         let Some(output) = &call_set.output else {
             continue;
         };
         for (candidate_idx, candidate) in output.candidates.iter().enumerate() {
-            for &(node_id, _) in &candidate.features {
-                node_to_candidates
-                    .entry(node_id)
+            let key = CandidateKey {
+                call_idx,
+                candidate_idx,
+            };
+            for (position, &node) in candidate.oriented_walk.iter().enumerate() {
+                walk_index
+                    .entry(node)
                     .or_default()
-                    .push(CandidateKey {
-                        call_idx,
-                        candidate_idx,
-                    });
-            }
-            for &(link, _) in &candidate.oriented_links {
-                link_to_candidates
-                    .entry(link)
-                    .or_default()
-                    .push(CandidateKey {
-                        call_idx,
-                        candidate_idx,
+                    .push(WalkOccurrence {
+                        key,
+                        position: position as u32,
                     });
             }
         }
     }
+    for occurrences in walk_index.values_mut() {
+        occurrences.sort_unstable_by(|a, b| {
+            a.key
+                .call_idx
+                .cmp(&b.key.call_idx)
+                .then(a.key.candidate_idx.cmp(&b.key.candidate_idx))
+                .then(b.position.cmp(&a.position))
+        });
+    }
 
-    if node_to_candidates.is_empty() {
+    if walk_index.is_empty() {
         return Ok(ReadWalkEvidence::default());
     }
 
@@ -798,6 +850,7 @@ fn build_read_walk_evidence(
     let reader = BufReader::with_capacity(8 * 1024 * 1024, reader);
     let mut evidence = ReadWalkEvidence::default();
     let mut nodes = Vec::new();
+    let mut reverse_nodes = Vec::new();
 
     for (line_no, line) in reader.lines().enumerate() {
         let line = line?;
@@ -813,32 +866,11 @@ fn build_read_walk_evidence(
             ));
         }
         parse_gaf_path_nodes(fields[5], &mut nodes)?;
-        let mut node_counts: FxHashMap<CandidateKey, u32> = FxHashMap::default();
-        for &signed_node in &nodes {
-            add_candidate_hits_from_map(
-                &mut node_counts,
-                &node_to_candidates,
-                signed_node.unsigned_abs(),
-            );
-        }
-        let hits_by_call = sorted_candidate_hits(node_counts, min_read_link_anchors);
-
-        let mut link_counts: FxHashMap<CandidateKey, u32> = FxHashMap::default();
-        for pair in nodes.windows(2) {
-            let forward = (pair[0], pair[1]);
-            let reverse = (-pair[1], -pair[0]);
-            add_candidate_hits_from_map(&mut link_counts, &link_to_candidates, forward);
-            if reverse != forward {
-                add_candidate_hits_from_map(&mut link_counts, &link_to_candidates, reverse);
-            }
-        }
-        let link_hits_by_call = sorted_candidate_hits(link_counts, min_read_link_anchors);
-        if link_hits_by_call.is_empty() {
-            add_candidate_support(&mut evidence, &hits_by_call);
-        } else {
-            add_candidate_support(&mut evidence, &link_hits_by_call);
-        }
-        add_read_links(&mut evidence, &hits_by_call);
+        let mut walk_counts: FxHashMap<CandidateKey, u32> = FxHashMap::default();
+        add_whole_walk_hits(&mut walk_counts, &walk_index, &nodes, &mut reverse_nodes);
+        let walk_hits_by_call = sorted_candidate_hits(walk_counts, min_read_link_anchors);
+        add_candidate_support(&mut evidence, &walk_hits_by_call);
+        add_read_links(&mut evidence, &walk_hits_by_call);
     }
 
     Ok(evidence)

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -3031,27 +3031,36 @@ fn test_syng_infer_read_walk_emission_resolves_order_decoy() {
     std::fs::create_dir_all(&dir).unwrap();
 
     let left = numeric_to_ascii(&make_sequence_numeric(420, 151));
-    let x = numeric_to_ascii(&make_sequence_numeric(540, 152));
-    let y = numeric_to_ascii(&make_sequence_numeric(540, 153));
-    let right = numeric_to_ascii(&make_sequence_numeric(420, 154));
+    let copy_a = numeric_to_ascii(&make_sequence_numeric(480, 152));
+    let copy_b = numeric_to_ascii(&make_sequence_numeric(480, 153));
+    let copy_c = numeric_to_ascii(&make_sequence_numeric(480, 154));
+    let right = numeric_to_ascii(&make_sequence_numeric(420, 155));
+
+    let mut true_repeat = Vec::new();
+    true_repeat.extend_from_slice(&copy_a);
+    true_repeat.extend_from_slice(&copy_b);
+    true_repeat.extend_from_slice(&copy_a);
+    true_repeat.extend_from_slice(&copy_c);
+    true_repeat.extend_from_slice(&copy_a);
+
+    let mut decoy_repeat = Vec::new();
+    decoy_repeat.extend_from_slice(&copy_a);
+    decoy_repeat.extend_from_slice(&copy_c);
+    decoy_repeat.extend_from_slice(&copy_a);
+    decoy_repeat.extend_from_slice(&copy_b);
+    decoy_repeat.extend_from_slice(&copy_a);
 
     let mut hap_ref = Vec::new();
     hap_ref.extend_from_slice(&left);
-    hap_ref.extend_from_slice(&x);
-    hap_ref.extend_from_slice(&y);
-    hap_ref.extend_from_slice(&x);
-    hap_ref.extend_from_slice(&y);
+    hap_ref.extend_from_slice(&true_repeat);
     hap_ref.extend_from_slice(&right);
 
-    // Same node-count projection as the target interval, but with the repeated
-    // copies in a different order. Read-walk adjacent-step evidence should
-    // break the pack/cos tie in favor of the true X-Y-X-Y order.
+    // Same node-count and adjacent-transition projection as the target interval:
+    // A-B-A-C-A and A-C-A-B-A both contain AB, BA, AC, and CA once. Only the
+    // whole read walk disambiguates the true order.
     let mut hap_decoy = Vec::new();
     hap_decoy.extend_from_slice(&left);
-    hap_decoy.extend_from_slice(&y);
-    hap_decoy.extend_from_slice(&x);
-    hap_decoy.extend_from_slice(&y);
-    hap_decoy.extend_from_slice(&x);
+    hap_decoy.extend_from_slice(&decoy_repeat);
     hap_decoy.extend_from_slice(&right);
 
     let fasta_path = dir.join("index.fa");
@@ -3088,7 +3097,7 @@ fn test_syng_infer_read_walk_emission_resolves_order_decoy() {
     let reads_path = dir.join("ordered_repeat_reads.fq");
     {
         let mut f = std::fs::File::create(&reads_path).unwrap();
-        write_tiled_fastq(&mut f, "ordered", &hap_ref, 900, 120).unwrap();
+        write_tiled_fastq(&mut f, "ordered", &true_repeat, true_repeat.len(), 120).unwrap();
     }
 
     let proj_path = dir.join("ordered.proj");
@@ -3121,7 +3130,7 @@ fn test_syng_infer_read_walk_emission_resolves_order_decoy() {
     let target_range = format!(
         "sampleRef#0#chr1:{}-{}",
         left.len(),
-        hap_ref.len() - right.len()
+        left.len() + true_repeat.len()
     );
     let mosaic_path = dir.join("ordered_repeat_mosaic.tsv");
     let infer = Command::new(&bin)
@@ -3174,12 +3183,12 @@ fn test_syng_infer_read_walk_emission_resolves_order_decoy() {
     assert_eq!(rows.len(), 1, "expected a single stitched interval:\n{}", mosaic);
     assert!(
         rows[0][5] == "sampleRef#0#chr1" && rows[0][19].parse::<f64>().unwrap() > 0.0,
-        "read-walk emission should choose the true X-Y-X-Y path and expose support:\n{}",
+        "whole-read-walk emission should choose the true A-B-A-C-A path and expose support:\n{}",
         mosaic
     );
     assert!(
         !rows.iter().any(|row| row[5] == "sampleADecoy#0#chr1"),
-        "node-count-equivalent order decoy should not win once read-walk pairs are scored:\n{}",
+        "node-count and adjacent-transition equivalent decoy should not win once whole walks are scored:\n{}",
         mosaic
     );
 


### PR DESCRIPTION
## Summary
- replace adjacent syncmer-pair candidate evidence with exact candidate oriented walks
- score read GAF paths by whole-walk ordered matching against candidate intervals, checking both read orientations
- use whole-walk hits for both local read emissions and mosaic transition links
- strengthen the adversarial order-decoy test so the decoy has the same node counts and adjacent transitions as the true haplotype

## Tests
- cargo check
- cargo test --test test_syng_integration test_syng_infer_read_walk_emission_resolves_order_decoy -- --nocapture
- cargo test --test test_syng_integration test_syng_infer_nested_sv_noisy_low_coverage_phase_blocks -- --nocapture
- cargo test --test test_syng_integration -- --nocapture
- cargo test