### PR TITLE
Use GBWT MEMs for syng read evidence

### DIFF
--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -25,13 +25,13 @@ pub struct HaplotypeCandidate {
     pub anchors: usize,
     pub query_span_fraction: f64,
     pub features: Vec<(u32, u64)>,
-    pub oriented_walk: Vec<i32>,
+    pub oriented_walk: Vec<syng::SyngWalkStep>,
     single_similarity: f64,
 }
 
 struct CandidateFeatures {
     unoriented: Vec<(u32, u64)>,
-    oriented_walk: Vec<i32>,
+    oriented_walk: Vec<syng::SyngWalkStep>,
 }
 
 #[derive(Debug)]
@@ -142,9 +142,12 @@ fn syng_candidate_features(
         })? as usize;
     let mut counts: FxHashMap<u32, u64> = FxHashMap::default();
     let mut oriented_walk = Vec::new();
-    for (signed_node, _) in syng_index.walk_path_range(path_idx, start, end)? {
+    for (signed_node, bp_pos) in syng_index.walk_path_range(path_idx, start, end)? {
         *counts.entry(signed_node.unsigned_abs()).or_insert(0) += 1;
-        oriented_walk.push(signed_node);
+        oriented_walk.push(syng::SyngWalkStep {
+            signed_node,
+            bp_pos,
+        });
     }
     let mut unoriented: Vec<(u32, u64)> = counts.into_iter().collect();
     unoriented.sort_unstable_by_key(|&(feature_id, _)| feature_id);

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -666,6 +666,69 @@ fn parse_gaf_path_nodes(path: &str, nodes: &mut Vec<i32>) -> io::Result<()> {
     Ok(())
 }
 
+fn parse_gaf_query_positions(fields: &[&str], anchors: usize) -> io::Result<Option<Vec<u64>>> {
+    for field in fields.iter().skip(12) {
+        if let Some(values) = field.strip_prefix("qp:B:I") {
+            let mut positions = Vec::with_capacity(anchors);
+            let values = values.strip_prefix(',').unwrap_or(values);
+            if !values.is_empty() {
+                for value in values.split(',') {
+                    positions.push(value.parse::<u64>().map_err(|e| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("invalid qp:B:I query position in GAF tag '{field}': {e}"),
+                        )
+                    })?);
+                }
+            }
+            if positions.len() != anchors {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "GAF qp:B:I tag has {} positions but path has {} syncmer nodes",
+                        positions.len(),
+                        anchors
+                    ),
+                ));
+            }
+            return Ok(Some(positions));
+        }
+    }
+    Ok(None)
+}
+
+fn build_read_walk_steps(
+    nodes: &[i32],
+    positions: &[u64],
+    out: &mut Vec<syng::SyngWalkStep>,
+) {
+    out.clear();
+    out.extend(
+        nodes
+            .iter()
+            .zip(positions.iter())
+            .map(|(&signed_node, &bp_pos)| syng::SyngWalkStep {
+                signed_node,
+                bp_pos,
+            }),
+    );
+    out.sort_unstable_by(|a, b| a.bp_pos.cmp(&b.bp_pos).then(a.signed_node.cmp(&b.signed_node)));
+}
+
+fn reverse_read_walk_steps(
+    steps: &[syng::SyngWalkStep],
+    query_len: u64,
+    syncmer_len: u64,
+    out: &mut Vec<syng::SyngWalkStep>,
+) {
+    out.clear();
+    out.extend(steps.iter().rev().map(|step| syng::SyngWalkStep {
+        signed_node: -step.signed_node,
+        bp_pos: query_len.saturating_sub(step.bp_pos.saturating_add(syncmer_len)),
+    }));
+    out.sort_unstable_by(|a, b| a.bp_pos.cmp(&b.bp_pos).then(a.signed_node.cmp(&b.signed_node)));
+}
+
 fn sorted_candidate_hits(
     counts: FxHashMap<CandidateKey, u32>,
     min_read_link_anchors: usize,
@@ -803,7 +866,118 @@ fn add_whole_walk_hits(
     add_whole_walk_orientation_hits(counts, walk_index, reverse_nodes);
 }
 
+fn candidate_mem_overlap_len(
+    read_steps: &[syng::SyngWalkStep],
+    mem_start: usize,
+    mem_end: usize,
+    read_start: usize,
+    candidate_walk: &[syng::SyngWalkStep],
+    candidate_start: usize,
+) -> u32 {
+    if read_start >= mem_end
+        || candidate_start >= candidate_walk.len()
+        || read_steps[read_start].signed_node != candidate_walk[candidate_start].signed_node
+    {
+        return 0;
+    }
+
+    let mut read_left = read_start;
+    let mut candidate_left = candidate_start;
+    while read_left > mem_start && candidate_left > 0 {
+        let prev_read = read_left - 1;
+        let prev_candidate = candidate_left - 1;
+        if read_steps[prev_read].signed_node != candidate_walk[prev_candidate].signed_node {
+            break;
+        }
+        let Some(read_offset) = read_steps[read_left]
+            .bp_pos
+            .checked_sub(read_steps[prev_read].bp_pos)
+        else {
+            break;
+        };
+        let Some(candidate_offset) = candidate_walk[candidate_left]
+            .bp_pos
+            .checked_sub(candidate_walk[prev_candidate].bp_pos)
+        else {
+            break;
+        };
+        if read_offset != candidate_offset {
+            break;
+        }
+        read_left = prev_read;
+        candidate_left = prev_candidate;
+    }
+
+    let mut read_right = read_start;
+    let mut candidate_right = candidate_start;
+    while read_right + 1 < mem_end && candidate_right + 1 < candidate_walk.len() {
+        let next_read = read_right + 1;
+        let next_candidate = candidate_right + 1;
+        if read_steps[next_read].signed_node != candidate_walk[next_candidate].signed_node {
+            break;
+        }
+        let Some(read_offset) = read_steps[next_read]
+            .bp_pos
+            .checked_sub(read_steps[read_right].bp_pos)
+        else {
+            break;
+        };
+        let Some(candidate_offset) = candidate_walk[next_candidate]
+            .bp_pos
+            .checked_sub(candidate_walk[candidate_right].bp_pos)
+        else {
+            break;
+        };
+        if read_offset != candidate_offset {
+            break;
+        }
+        read_right = next_read;
+        candidate_right = next_candidate;
+    }
+
+    (read_right - read_left + 1) as u32
+}
+
+fn add_mem_hits(
+    counts: &mut FxHashMap<CandidateKey, u32>,
+    call_sets: &[LocalCallSet],
+    walk_index: &FxHashMap<i32, Vec<WalkOccurrence>>,
+    read_steps: &[syng::SyngWalkStep],
+    mems: &[syng::SyngGbwtMem],
+) {
+    for mem in mems {
+        let mut best_by_candidate: FxHashMap<CandidateKey, u32> = FxHashMap::default();
+        for read_idx in mem.step_start..mem.step_end {
+            let Some(occurrences) = walk_index.get(&read_steps[read_idx].signed_node) else {
+                continue;
+            };
+            for &occurrence in occurrences {
+                let Some(output) = &call_sets[occurrence.key.call_idx].output else {
+                    continue;
+                };
+                let candidate = &output.candidates[occurrence.key.candidate_idx];
+                let overlap = candidate_mem_overlap_len(
+                    read_steps,
+                    mem.step_start,
+                    mem.step_end,
+                    read_idx,
+                    &candidate.oriented_walk,
+                    occurrence.position as usize,
+                );
+                let entry = best_by_candidate.entry(occurrence.key).or_insert(0);
+                *entry = (*entry).max(overlap);
+            }
+        }
+        for (key, anchors) in best_by_candidate {
+            if anchors > 0 {
+                *counts.entry(key).or_insert(0) += anchors;
+            }
+        }
+    }
+}
+
 fn build_read_walk_evidence(
+    syng_index: &syng::SyngIndex,
     call_sets: &[LocalCallSet],
     gaf_path: &str,
     min_read_link_anchors: usize,
@@ -820,7 +994,7 @@ fn build_read_walk_evidence(
             };
             for (position, &node) in candidate.oriented_walk.iter().enumerate() {
                 walk_index
-                    .entry(node)
+                    .entry(node.signed_node)
                     .or_default()
                     .push(WalkOccurrence {
                         key,
@@ -851,6 +1025,9 @@ fn build_read_walk_evidence(
     let mut evidence = ReadWalkEvidence::default();
     let mut nodes = Vec::new();
     let mut reverse_nodes = Vec::new();
+    let mut read_steps = Vec::new();
+    let mut reverse_steps = Vec::new();
+    let syncmer_len = syng_index.syncmer_length_bp() as u64;
 
     for (line_no, line) in reader.lines().enumerate() {
         let line = line?;
@@ -867,7 +1044,28 @@ fn build_read_walk_evidence(
         }
         parse_gaf_path_nodes(fields[5], &mut nodes)?;
         let mut walk_counts: FxHashMap<CandidateKey, u32> = FxHashMap::default();
-        add_whole_walk_hits(&mut walk_counts, &walk_index, &nodes, &mut reverse_nodes);
+        if let Some(positions) = parse_gaf_query_positions(&fields, nodes.len())? {
+            let query_len = fields[1].parse::<u64>().map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid GAF query length on line {}: {e}", line_no + 1),
+                )
+            })?;
+            build_read_walk_steps(&nodes, &positions, &mut read_steps);
+            let mems = syng_index.gbwt_mems_for_walk(&read_steps)?;
+            add_mem_hits(&mut walk_counts, call_sets, &walk_index, &read_steps, &mems);
+            reverse_read_walk_steps(&read_steps, query_len, syncmer_len, &mut reverse_steps);
+            let reverse_mems = syng_index.gbwt_mems_for_walk(&reverse_steps)?;
+            add_mem_hits(
+                &mut walk_counts,
+                call_sets,
+                &walk_index,
+                &reverse_steps,
+                &reverse_mems,
+            );
+        } else {
+            add_whole_walk_hits(&mut walk_counts, &walk_index, &nodes, &mut reverse_nodes);
+        }
         let walk_hits_by_call = sorted_candidate_hits(walk_counts, min_read_link_anchors);
         add_candidate_support(&mut evidence, &walk_hits_by_call);
         add_read_links(&mut evidence, &walk_hits_by_call);
@@ -1242,8 +1440,12 @@ pub fn run_syng_pack_infer<W: Write>(out: &mut W, config: &InferConfig<'_>) -> i
         || config.emit_gfa.is_some();
     if wants_stitch {
         let read_evidence = if let Some(gaf_path) = config.gaf_path {
-            let evidence =
-                build_read_walk_evidence(&call_sets, gaf_path, config.min_read_link_anchors)?;
+            let evidence = build_read_walk_evidence(
+                &syng_index,
+                &call_sets,
+                gaf_path,
+                config.min_read_link_anchors,
+            )?;
             info!(
                 "Loaded read-walk evidence from {}: {} GAF records, {} records with candidate hits, {} candidate hits, {} local candidate scores, {} linked candidate pairs, {} scored transitions",
                 gaf_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,13 +396,18 @@ fn write_syng_map_gaf<W: Write>(
         path.push(orient);
         path.push_str(&sm.node_id.to_string());
     }
+    let mut query_positions = String::from("qp:B:I");
+    for sm in syncmers {
+        query_positions.push(',');
+        query_positions.push_str(&sm.query_pos.to_string());
+    }
     let path_len = (syncmers.len() as u64).saturating_mul(syncmer_len);
     let matches = path_len.min(qend.saturating_sub(qstart));
     let block_len = qend.saturating_sub(qstart);
     out.write_all(query_name)?;
     writeln!(
         out,
-        "\t{}\t{}\t{}\t+\t{}\t{}\t0\t{}\t{}\t{}\t0\tan:i:{}\tsk:i:{}",
+        "\t{}\t{}\t{}\t+\t{}\t{}\t0\t{}\t{}\t{}\t0\tan:i:{}\tsk:i:{}\t{}",
         query_len,
         qstart,
         qend,
@@ -412,7 +417,8 @@ fn write_syng_map_gaf<W: Write>(
         matches,
         block_len,
         syncmers.len(),
-        syncmer_len
+        syncmer_len,
+        query_positions
     )
 }
 

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -1474,6 +1474,24 @@ pub struct SyngQuerySyncmer {
     pub query_pos: u64,
 }
 
+/// A signed syncmer walk step with a bp-coordinate position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyngWalkStep {
+    pub signed_node: i32,
+    pub bp_pos: u64,
+}
+
+/// A maximal exact match of a signed syncmer walk in the syng GBWT.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyngGbwtMem {
+    pub step_start: usize,
+    pub step_end: usize,
+    pub query_start: u64,
+    pub query_end: u64,
+    pub anchors: usize,
+    pub occurrences: u32,
+}
+
 /// A rough syncmer-only mapping projected to a path in the syng index.
 #[derive(Debug, Clone)]
 pub struct SyngMapHit {
@@ -3255,6 +3273,261 @@ impl SyngIndex {
         Ok(high)
     }
 
+    fn valid_walk_node(&self, signed_node: i32) -> bool {
+        let node_id = signed_node.unsigned_abs() as usize;
+        signed_node != 0 && node_id <= self.num_syncmer_nodes()
+    }
+
+    fn walk_step_offset(prev: SyngWalkStep, next: SyngWalkStep) -> Option<u32> {
+        next.bp_pos
+            .checked_sub(prev.bp_pos)
+            .and_then(|offset| u32::try_from(offset).ok())
+    }
+
+    fn start_gbwt_match(
+        &self,
+        signed_node: i32,
+    ) -> io::Result<Option<(*mut syng_ffi::SyngBWTpath, u32, u32)>> {
+        if !self.valid_walk_node(signed_node) {
+            return Ok(None);
+        }
+        let mut high = 0u32;
+        let sbp = unsafe { syng_ffi::syngBWTmatchStart(self.gbwt, signed_node, &mut high) };
+        if sbp.is_null() {
+            return Err(io::Error::other("syngBWTmatchStart returned null"));
+        }
+        if high == 0 {
+            unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+            return Ok(None);
+        }
+        Ok(Some((sbp, 0, high)))
+    }
+
+    fn advance_gbwt_match(
+        &self,
+        sbp: *mut syng_ffi::SyngBWTpath,
+        low: &mut u32,
+        high: &mut u32,
+        signed_node: i32,
+        offset: u32,
+    ) -> bool {
+        if !self.valid_walk_node(signed_node) {
+            return false;
+        }
+        let mut next_low = *low;
+        let mut next_high = *high;
+        let matched = unsafe {
+            syng_ffi::syngBWTmatchNext(
+                sbp,
+                signed_node,
+                offset,
+                &mut next_low,
+                &mut next_high,
+            )
+        };
+        if matched {
+            *low = next_low;
+            *high = next_high;
+        }
+        matched
+    }
+
+    fn push_gbwt_mem(
+        &self,
+        walk: &[SyngWalkStep],
+        start: usize,
+        end: usize,
+        occurrences: u32,
+        mems: &mut Vec<SyngGbwtMem>,
+    ) {
+        if start >= end || occurrences == 0 {
+            return;
+        }
+        let query_start = walk[start].bp_pos;
+        let query_end = walk[end - 1]
+            .bp_pos
+            .saturating_add(self.syncmer_length_bp() as u64);
+        mems.push(SyngGbwtMem {
+            step_start: start,
+            step_end: end,
+            query_start,
+            query_end,
+            anchors: end - start,
+            occurrences,
+        });
+    }
+
+    fn prune_contained_gbwt_mems(candidates: Vec<SyngGbwtMem>) -> Vec<SyngGbwtMem> {
+        let mut candidates = candidates;
+        candidates.sort_by(|a, b| {
+            a.step_start
+                .cmp(&b.step_start)
+                .then(b.step_end.cmp(&a.step_end))
+                .then(a.occurrences.cmp(&b.occurrences))
+        });
+        let mut mems: Vec<SyngGbwtMem> = Vec::new();
+        'candidate: for candidate in candidates {
+            for kept in &mems {
+                if kept.step_start <= candidate.step_start
+                    && kept.step_end >= candidate.step_end
+                    && kept.anchors >= candidate.anchors
+                {
+                    continue 'candidate;
+                }
+            }
+            mems.retain(|kept| {
+                !(candidate.step_start <= kept.step_start
+                    && candidate.step_end >= kept.step_end
+                    && candidate.anchors >= kept.anchors)
+            });
+            mems.push(candidate);
+        }
+        mems.sort_by(|a, b| {
+            a.step_start
+                .cmp(&b.step_start)
+                .then(a.step_end.cmp(&b.step_end))
+        });
+        mems
+    }
+
+    fn restart_gbwt_match_at_suffix(
+        &self,
+        walk: &[SyngWalkStep],
+        run_start: usize,
+        current: usize,
+    ) -> io::Result<Option<(*mut syng_ffi::SyngBWTpath, usize, u32, u32)>> {
+        let Some((reverse_sbp, mut reverse_low, mut reverse_high)) =
+            self.start_gbwt_match(-walk[current].signed_node)?
+        else {
+            return Ok(None);
+        };
+
+        let mut suffix_start = current;
+        while suffix_start > run_start {
+            let prev = suffix_start - 1;
+            let Some(offset) = Self::walk_step_offset(walk[prev], walk[suffix_start]) else {
+                break;
+            };
+            if !self.advance_gbwt_match(
+                reverse_sbp,
+                &mut reverse_low,
+                &mut reverse_high,
+                -walk[prev].signed_node,
+                offset,
+            ) {
+                break;
+            }
+            suffix_start = prev;
+        }
+        unsafe { syng_ffi::syngBWTpathDestroy(reverse_sbp) };
+
+        let Some((sbp, mut low, mut high)) = self.start_gbwt_match(walk[suffix_start].signed_node)?
+        else {
+            return Ok(None);
+        };
+        for next in suffix_start + 1..=current {
+            let Some(offset) = Self::walk_step_offset(walk[next - 1], walk[next]) else {
+                unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+                return Ok(None);
+            };
+            if !self.advance_gbwt_match(sbp, &mut low, &mut high, walk[next].signed_node, offset) {
+                unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+                return Ok(None);
+            }
+        }
+        Ok(Some((sbp, suffix_start, low, high)))
+    }
+
+    /// Find maximal exact matches of a signed syncmer walk in the syng GBWT.
+    ///
+    /// This mirrors syngmap's GBWT MEM procedure: extend the current match by
+    /// signed syncmer node and bp offset, then on failure reverse-search to the
+    /// longest suffix that can seed the next match. Returned MEMs use half-open
+    /// step coordinates `[step_start, step_end)`.
+    pub fn gbwt_mems_for_walk(&self, walk: &[SyngWalkStep]) -> io::Result<Vec<SyngGbwtMem>> {
+        if walk.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut candidates = Vec::new();
+        let mut sbp: *mut syng_ffi::SyngBWTpath = std::ptr::null_mut();
+        let mut active_start = 0usize;
+        let mut run_start = 0usize;
+        let mut low = 0u32;
+        let mut high = 0u32;
+
+        for idx in 0..walk.len() {
+            if !self.valid_walk_node(walk[idx].signed_node) {
+                if !sbp.is_null() {
+                    self.push_gbwt_mem(walk, active_start, idx, high - low, &mut candidates);
+                    unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+                    sbp = std::ptr::null_mut();
+                }
+                run_start = idx + 1;
+                continue;
+            }
+
+            if sbp.is_null() {
+                let Some((started_sbp, started_low, started_high)) =
+                    self.start_gbwt_match(walk[idx].signed_node)?
+                else {
+                    run_start = idx + 1;
+                    continue;
+                };
+                sbp = started_sbp;
+                active_start = idx;
+                run_start = idx;
+                low = started_low;
+                high = started_high;
+                continue;
+            }
+
+            let Some(offset) = Self::walk_step_offset(walk[idx - 1], walk[idx]) else {
+                self.push_gbwt_mem(walk, active_start, idx, high - low, &mut candidates);
+                unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+                sbp = std::ptr::null_mut();
+                let Some((started_sbp, started_low, started_high)) =
+                    self.start_gbwt_match(walk[idx].signed_node)?
+                else {
+                    run_start = idx + 1;
+                    continue;
+                };
+                sbp = started_sbp;
+                active_start = idx;
+                run_start = idx;
+                low = started_low;
+                high = started_high;
+                continue;
+            };
+
+            if self.advance_gbwt_match(sbp, &mut low, &mut high, walk[idx].signed_node, offset) {
+                continue;
+            }
+
+            self.push_gbwt_mem(walk, active_start, idx, high - low, &mut candidates);
+            unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+            match self.restart_gbwt_match_at_suffix(walk, run_start, idx)? {
+                Some((restarted_sbp, restarted_start, restarted_low, restarted_high)) => {
+                    sbp = restarted_sbp;
+                    active_start = restarted_start;
+                    low = restarted_low;
+                    high = restarted_high;
+                }
+                None => {
+                    sbp = std::ptr::null_mut();
+                    run_start = idx + 1;
+                }
+            }
+        }
+
+        if !sbp.is_null() {
+            self.push_gbwt_mem(walk, active_start, walk.len(), high - low, &mut candidates);
+            unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+        }
+
+        Ok(Self::prune_contained_gbwt_mems(candidates))
+    }
+
     fn locate_signed_node_occurrences(
         &self,
         signed_node: i32,
@@ -4224,6 +4497,58 @@ mod tests {
         forward_nodes.sort_unstable();
         rc_nodes.sort_unstable();
         assert_eq!(rc_nodes, forward_nodes);
+    }
+
+    #[test]
+    fn test_gbwt_mems_for_walk_uses_syncmer_offsets() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let seq = make_test_sequence(5000, 43);
+        let index = SyngIndex::build(
+            params,
+            vec![("sample#0#chr1".to_string(), seq.clone())].into_iter(),
+        );
+
+        let mut matches = index.matched_syncmers_in_sequence(&seq);
+        matches.sort_unstable_by_key(|sm| sm.query_pos);
+        assert!(
+            matches.len() >= 4,
+            "test sequence should produce several indexed syncmer matches"
+        );
+        let walk: Vec<_> = matches
+            .iter()
+            .map(|sm| SyngWalkStep {
+                signed_node: sm.signed_node,
+                bp_pos: sm.query_pos,
+            })
+            .collect();
+
+        let mems = index.gbwt_mems_for_walk(&walk).unwrap();
+        assert!(
+            mems.iter().any(|mem| mem.step_start == 0
+                && mem.step_end == walk.len()
+                && mem.query_start == walk[0].bp_pos
+                && mem.query_end
+                    == walk.last().unwrap().bp_pos + index.syncmer_length_bp() as u64),
+            "the exact query walk should produce a full-length GBWT MEM: {:?}",
+            mems
+        );
+
+        let Some(shift_idx) =
+            (1..walk.len() - 1).find(|&idx| walk[idx].bp_pos + 1 < walk[idx + 1].bp_pos)
+        else {
+            return;
+        };
+        let mut shifted = walk.clone();
+        shifted[shift_idx].bp_pos += 1;
+        let shifted_mems = index.gbwt_mems_for_walk(&shifted).unwrap();
+        assert!(
+            shifted_mems
+                .iter()
+                .all(|mem| mem.step_start != 0 || mem.step_end != shifted.len()),
+            "changing a syncmer offset must break the full-length GBWT MEM: {:?}",
+            shifted_mems
+        );
     }
 
     #[test]

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -3126,6 +3126,20 @@ fn test_syng_infer_read_walk_emission_resolves_order_decoy() {
         "impg map -o proj for ordered repeat reads failed: {}",
         String::from_utf8_lossy(&map.stderr)
     );
+    let mut gaf_decoder = zstd::stream::read::Decoder::new(
+        std::fs::File::open(proj_path.join("reads.gaf.zst")).unwrap(),
+    )
+    .unwrap();
+    let mut projected_gaf = String::new();
+    {
+        use std::io::Read;
+        gaf_decoder.read_to_string(&mut projected_gaf).unwrap();
+    }
+    assert!(
+        projected_gaf.contains("\tqp:B:I,"),
+        "projection GAF should carry query syncmer positions for GBWT MEM scoring:\n{}",
+        projected_gaf
+    );
 
     let target_range = format!(
         "sampleRef#0#chr1:{}-{}",


### PR DESCRIPTION
## Summary
- add a syng GBWT MEM wrapper over signed syncmer walks with bp offsets
- emit query syncmer positions in GAF/projection output via qp:B:I
- use GBWT MEMs for infer read-walk evidence while scoring exact local candidate overlaps

## Tests
- cargo test