### PR TITLE
Extract backend-neutral cosine genotype scorer

### DIFF
--- a/src/commands/genotype.rs
+++ b/src/commands/genotype.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::io::{self, Write};
 
 use crate::commands::partition;
-use crate::genotyping::{FeatureSpace, ScoringMethod};
+use crate::genotyping::{self, FeatureSpace, ScoringMethod};
 use crate::pack;
 use crate::syng;
 
@@ -42,15 +42,7 @@ struct SyngCandidateGroup {
     anchors: Vec<syng::Anchor>,
 }
 
-#[derive(Debug)]
-pub struct CosigtResult {
-    pub combination: Vec<usize>,
-    pub similarity: f64,
-    pub qv: f64,
-    pub dot: f64,
-    pub sample_norm: f64,
-    pub genotype_norm: f64,
-}
+pub type CosigtResult = genotyping::CombinationScore;
 
 pub struct SyngCosigtConfig<'a> {
     pub syng_prefix: &'a str,
@@ -271,147 +263,6 @@ fn collect_syng_candidates(
     Ok(candidates)
 }
 
-fn locus_features(candidates: &[HaplotypeCandidate]) -> Vec<u32> {
-    let mut seen: FxHashMap<u32, ()> = FxHashMap::default();
-    for candidate in candidates {
-        for &(feature_id, _) in &candidate.features {
-            seen.insert(feature_id, ());
-        }
-    }
-    let mut features: Vec<u32> = seen.into_keys().collect();
-    features.sort_unstable();
-    features
-}
-
-fn sample_norm_sq_for_features(sample_counts: &FxHashMap<u32, u64>, features: &[u32]) -> f64 {
-    features
-        .iter()
-        .map(|feature_id| sample_counts.get(feature_id).copied().unwrap_or(0) as f64)
-        .map(|v| v * v)
-        .sum()
-}
-
-fn cosine_for_candidate_features(
-    candidate_features: &[(u32, u64)],
-    sample_counts: &FxHashMap<u32, u64>,
-    sample_norm_sq: f64,
-) -> f64 {
-    if sample_norm_sq == 0.0 {
-        return 0.0;
-    }
-    let mut dot = 0.0;
-    let mut genotype_norm_sq = 0.0;
-    for &(feature_id, count) in candidate_features {
-        let g = count as f64;
-        genotype_norm_sq += g * g;
-        dot += g * sample_counts.get(&feature_id).copied().unwrap_or(0) as f64;
-    }
-    if genotype_norm_sq == 0.0 {
-        0.0
-    } else {
-        dot / (sample_norm_sq.sqrt() * genotype_norm_sq.sqrt())
-    }
-}
-
-fn score_combination(
-    combination: &[usize],
-    candidates: &[HaplotypeCandidate],
-    sample_counts: &FxHashMap<u32, u64>,
-    sample_norm_sq: f64,
-) -> CosigtResult {
-    let mut genotype_counts: FxHashMap<u32, u64> = FxHashMap::default();
-    for &idx in combination {
-        for &(feature_id, count) in &candidates[idx].features {
-            *genotype_counts.entry(feature_id).or_insert(0) += count;
-        }
-    }
-
-    let mut dot = 0.0;
-    let mut genotype_norm_sq = 0.0;
-    for (feature_id, count) in genotype_counts {
-        let g = count as f64;
-        genotype_norm_sq += g * g;
-        dot += g * sample_counts.get(&feature_id).copied().unwrap_or(0) as f64;
-    }
-
-    let sample_norm = sample_norm_sq.sqrt();
-    let genotype_norm = genotype_norm_sq.sqrt();
-    let similarity = if sample_norm == 0.0 || genotype_norm == 0.0 {
-        0.0
-    } else {
-        dot / (sample_norm * genotype_norm)
-    };
-    let qv = if similarity >= 1.0 {
-        999.0
-    } else if similarity <= 0.0 {
-        0.0
-    } else {
-        -10.0 * (1.0 - similarity).log10()
-    };
-
-    CosigtResult {
-        combination: combination.to_vec(),
-        similarity,
-        qv,
-        dot,
-        sample_norm,
-        genotype_norm,
-    }
-}
-
-struct CosigtSearch<'a> {
-    candidates: &'a [HaplotypeCandidate],
-    sample_counts: &'a FxHashMap<u32, u64>,
-    sample_norm_sq: f64,
-    ploidy: usize,
-    max_combinations: u64,
-    visited: u64,
-    results: Vec<CosigtResult>,
-}
-
-impl CosigtSearch<'_> {
-    fn run(mut self) -> io::Result<Vec<CosigtResult>> {
-        let mut current = Vec::with_capacity(self.ploidy);
-        self.visit(0, &mut current)?;
-        self.results.sort_by(|a, b| {
-            b.similarity
-                .total_cmp(&a.similarity)
-                .then_with(|| b.dot.total_cmp(&a.dot))
-                .then_with(|| a.combination.cmp(&b.combination))
-        });
-        Ok(self.results)
-    }
-
-    fn visit(&mut self, start: usize, current: &mut Vec<usize>) -> io::Result<()> {
-        if current.len() == self.ploidy {
-            self.visited += 1;
-            if self.visited > self.max_combinations {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!(
-                        "genotype combination search exceeded --max-combinations ({})",
-                        self.max_combinations
-                    ),
-                ));
-            }
-            self.results.push(score_combination(
-                current,
-                self.candidates,
-                self.sample_counts,
-                self.sample_norm_sq,
-            ));
-            return Ok(());
-        }
-
-        for idx in start..self.candidates.len() {
-            current.push(idx);
-            self.visit(idx, current)?;
-            current.pop();
-        }
-        Ok(())
-    }
-}
-
 fn rank_cosigt(
     candidates: &mut Vec<HaplotypeCandidate>,
     sample_counts: &FxHashMap<u32, u64>,
@@ -420,11 +271,19 @@ fn rank_cosigt(
     candidate_top_k: usize,
     max_combinations: u64,
 ) -> io::Result<(Vec<CosigtResult>, Vec<u32>)> {
-    let all_locus_features = locus_features(candidates);
-    let all_sample_norm_sq = sample_norm_sq_for_features(sample_counts, &all_locus_features);
+    let all_locus_features = genotyping::feature_universe(
+        candidates
+            .iter()
+            .map(|candidate| candidate.features.as_slice()),
+    );
+    let all_sample_norm_sq =
+        genotyping::sample_norm_sq_for_features(sample_counts, &all_locus_features);
     for candidate in candidates.iter_mut() {
-        candidate.single_similarity =
-            cosine_for_candidate_features(&candidate.features, sample_counts, all_sample_norm_sq);
+        candidate.single_similarity = genotyping::cosine_for_feature_counts(
+            &candidate.features,
+            sample_counts,
+            all_sample_norm_sq,
+        );
     }
     candidates.sort_by(|a, b| {
         b.single_similarity
@@ -437,8 +296,12 @@ fn rank_cosigt(
         candidates.truncate(candidate_top_k);
     }
 
-    let selected_features = locus_features(candidates);
-    let sample_norm_sq = sample_norm_sq_for_features(sample_counts, &selected_features);
+    let selected_features = genotyping::feature_universe(
+        candidates
+            .iter()
+            .map(|candidate| candidate.features.as_slice()),
+    );
+    let sample_norm_sq = genotyping::sample_norm_sq_for_features(sample_counts, &selected_features);
     if sample_norm_sq == 0.0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -446,16 +309,17 @@ fn rank_cosigt(
         ));
     }
 
-    let search = CosigtSearch {
-        candidates,
+    let candidate_features: Vec<&[(u32, u64)]> = candidates
+        .iter()
+        .map(|candidate| candidate.features.as_slice())
+        .collect();
+    let mut results = genotyping::run_cosine_combination_search(
+        &candidate_features,
         sample_counts,
         sample_norm_sq,
         ploidy,
         max_combinations,
-        visited: 0,
-        results: Vec::new(),
-    };
-    let mut results = search.run()?;
+    )?;
     results.truncate(top_n);
     Ok((results, selected_features))
 }

--- a/src/genotyping.rs
+++ b/src/genotyping.rs
@@ -5,6 +5,9 @@
 //! scoring methods. These enums keep user-visible metadata stable while giving
 //! future backends a common language.
 
+use rustc_hash::FxHashMap;
+use std::io;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeatureSpace {
     SyngSyncmerNode,
@@ -80,6 +83,179 @@ impl ScoringMethod {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct CombinationScore {
+    pub combination: Vec<usize>,
+    pub similarity: f64,
+    pub qv: f64,
+    pub dot: f64,
+    pub sample_norm: f64,
+    pub genotype_norm: f64,
+}
+
+pub fn feature_universe<'a, I>(candidate_features: I) -> Vec<u32>
+where
+    I: IntoIterator<Item = &'a [(u32, u64)]>,
+{
+    let mut seen: FxHashMap<u32, ()> = FxHashMap::default();
+    for features in candidate_features {
+        for &(feature_id, _) in features {
+            seen.insert(feature_id, ());
+        }
+    }
+    let mut features: Vec<u32> = seen.into_keys().collect();
+    features.sort_unstable();
+    features
+}
+
+pub fn sample_norm_sq_for_features(sample_counts: &FxHashMap<u32, u64>, features: &[u32]) -> f64 {
+    features
+        .iter()
+        .map(|feature_id| sample_counts.get(feature_id).copied().unwrap_or(0) as f64)
+        .map(|v| v * v)
+        .sum()
+}
+
+pub fn cosine_for_feature_counts(
+    candidate_features: &[(u32, u64)],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+) -> f64 {
+    if sample_norm_sq == 0.0 {
+        return 0.0;
+    }
+    let mut dot = 0.0;
+    let mut genotype_norm_sq = 0.0;
+    for &(feature_id, count) in candidate_features {
+        let g = count as f64;
+        genotype_norm_sq += g * g;
+        dot += g * sample_counts.get(&feature_id).copied().unwrap_or(0) as f64;
+    }
+    if genotype_norm_sq == 0.0 {
+        0.0
+    } else {
+        dot / (sample_norm_sq.sqrt() * genotype_norm_sq.sqrt())
+    }
+}
+
+pub fn score_cosine_combination(
+    combination: &[usize],
+    candidate_features: &[&[(u32, u64)]],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+) -> CombinationScore {
+    let mut genotype_counts: FxHashMap<u32, u64> = FxHashMap::default();
+    for &idx in combination {
+        for &(feature_id, count) in candidate_features[idx] {
+            *genotype_counts.entry(feature_id).or_insert(0) += count;
+        }
+    }
+
+    let mut dot = 0.0;
+    let mut genotype_norm_sq = 0.0;
+    for (feature_id, count) in genotype_counts {
+        let g = count as f64;
+        genotype_norm_sq += g * g;
+        dot += g * sample_counts.get(&feature_id).copied().unwrap_or(0) as f64;
+    }
+
+    let sample_norm = sample_norm_sq.sqrt();
+    let genotype_norm = genotype_norm_sq.sqrt();
+    let similarity = if sample_norm == 0.0 || genotype_norm == 0.0 {
+        0.0
+    } else {
+        dot / (sample_norm * genotype_norm)
+    };
+    let qv = if similarity >= 1.0 {
+        999.0
+    } else if similarity <= 0.0 {
+        0.0
+    } else {
+        -10.0 * (1.0 - similarity).log10()
+    };
+
+    CombinationScore {
+        combination: combination.to_vec(),
+        similarity,
+        qv,
+        dot,
+        sample_norm,
+        genotype_norm,
+    }
+}
+
+struct CosineCombinationSearch<'a> {
+    candidate_features: &'a [&'a [(u32, u64)]],
+    sample_counts: &'a FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+    ploidy: usize,
+    max_combinations: u64,
+    visited: u64,
+    results: Vec<CombinationScore>,
+}
+
+impl CosineCombinationSearch<'_> {
+    fn run(mut self) -> io::Result<Vec<CombinationScore>> {
+        let mut current = Vec::with_capacity(self.ploidy);
+        self.visit(0, &mut current)?;
+        self.results.sort_by(|a, b| {
+            b.similarity
+                .total_cmp(&a.similarity)
+                .then_with(|| b.dot.total_cmp(&a.dot))
+                .then_with(|| a.combination.cmp(&b.combination))
+        });
+        Ok(self.results)
+    }
+
+    fn visit(&mut self, start: usize, current: &mut Vec<usize>) -> io::Result<()> {
+        if current.len() == self.ploidy {
+            self.visited += 1;
+            if self.visited > self.max_combinations {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "genotype combination search exceeded --max-combinations ({})",
+                        self.max_combinations
+                    ),
+                ));
+            }
+            self.results.push(score_cosine_combination(
+                current,
+                self.candidate_features,
+                self.sample_counts,
+                self.sample_norm_sq,
+            ));
+            return Ok(());
+        }
+
+        for idx in start..self.candidate_features.len() {
+            current.push(idx);
+            self.visit(idx, current)?;
+            current.pop();
+        }
+        Ok(())
+    }
+}
+
+pub fn run_cosine_combination_search(
+    candidate_features: &[&[(u32, u64)]],
+    sample_counts: &FxHashMap<u32, u64>,
+    sample_norm_sq: f64,
+    ploidy: usize,
+    max_combinations: u64,
+) -> io::Result<Vec<CombinationScore>> {
+    CosineCombinationSearch {
+        candidate_features,
+        sample_counts,
+        sample_norm_sq,
+        ploidy,
+        max_combinations,
+        visited: 0,
+        results: Vec::new(),
+    }
+    .run()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,5 +266,44 @@ mod tests {
         assert_eq!(EvidenceBackend::Pack.as_str(), "pack");
         assert_eq!(ScoringMethod::Cos.as_str(), "cos");
         assert_eq!(ScoringMethod::Cos.metric_str(), "cosine");
+    }
+
+    #[test]
+    fn cosine_combination_search_ranks_with_replacement_genotypes() {
+        let candidate_a = vec![(1, 1)];
+        let candidate_b = vec![(2, 1)];
+        let candidates = vec![candidate_a.as_slice(), candidate_b.as_slice()];
+        let mut sample = FxHashMap::default();
+        sample.insert(1, 2);
+        let features = feature_universe(candidates.iter().copied());
+        assert_eq!(features, vec![1, 2]);
+        let sample_norm_sq = sample_norm_sq_for_features(&sample, &features);
+
+        let results =
+            run_cosine_combination_search(&candidates, &sample, sample_norm_sq, 2, 10).unwrap();
+
+        assert_eq!(results[0].combination, vec![0, 0]);
+        assert!((results[0].similarity - 1.0).abs() < 1e-9);
+        assert!(results[1].similarity < results[0].similarity);
+    }
+
+    #[test]
+    fn cosine_combination_search_enforces_budget() {
+        let candidate_a = vec![(1, 1)];
+        let candidate_b = vec![(2, 1)];
+        let candidates = vec![candidate_a.as_slice(), candidate_b.as_slice()];
+        let mut sample = FxHashMap::default();
+        sample.insert(1, 1);
+        sample.insert(2, 1);
+        let features = feature_universe(candidates.iter().copied());
+        let sample_norm_sq = sample_norm_sq_for_features(&sample, &features);
+
+        let err =
+            run_cosine_combination_search(&candidates, &sample, sample_norm_sq, 2, 2).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err
+            .to_string()
+            .contains("genotype combination search exceeded --max-combinations"));
     }
 }


### PR DESCRIPTION
## Summary
- move cosine feature-universe construction and combination scoring into src/genotyping.rs
- keep syng genotype/infer TSV behavior wired through the shared scorer
- add unit coverage for with-replacement genotype ranking and max-combination budget errors

## Tests
- cargo check
- cargo test genotyping::tests -- --nocapture
- cargo test --test test_syng_integration test_syng_genotype_cos_cli_permutations -- --nocapture
- cargo test --test test_syng_integration test_syng_genotype_cos_short_read_simulation_calls_heterozygote -- --nocapture
- cargo test --test test_syng_integration test_syng_infer_pack_partitions_and_discovery -- --nocapture
- cargo test