### PR TITLE
Add local graph render bundles

### DIFF
--- a/docs/render-gbz-translation-design.md
+++ b/docs/render-gbz-translation-design.md
@@ -203,11 +203,28 @@ syng query target
   -> fetch interval DNA from AGC/FASTA
   -> pggb/seqwish/internal graph build
   -> thread input haplotypes as graph paths
-  -> build local GBWT
-  -> write translation tables
+  -> write graph-step translation tables
 ```
 
 This is the first target for C4/C4A/C4B-like loci.
+
+Implemented local render engines:
+
+```bash
+impg render -a panel.syng -r sample#0#chr6:31972057-32055418 \
+  --sequence-files panel.fa -O c4.poa.impg-gbz --engine poa
+impg render -a panel.syng -r sample#0#chr6:31972057-32055418 \
+  --sequence-files panel.fa -O c4.seqwish.impg-gbz --engine seqwish
+impg render -a panel.syng -r sample#0#chr6:31972057-32055418 \
+  --sequence-files panel.fa -O c4.pggb.impg-gbz --engine pggb
+```
+
+The current local graph bundle writes `rendered.fa`, `graph.gfa`,
+`namespace.json`, `translation.bin`, and `translation.tsv`. Its feature space is
+`gfa-segment`. A true local GBWT over the explicit graph paths is still a
+separate pending step; the rendered FASTA path names and translation tables are
+already organized so that GBWT path IDs can be attached without changing the
+source namespace model.
 
 ### Whole-Genome Render
 
@@ -303,11 +320,12 @@ only when a locus needs that representation.
    sequences, not as a requirement for membership in the namespace.
 3. Define render bundle manifest and succinct translation table schemas.
 4. Implement regional syng-native render with translation tables.
-5. Implement regional local sequence graph render using seqwish or pggb first,
-   with threaded input haplotype paths and local GBWT.
+5. Implement regional local sequence graph render using POA, seqwish, and pggb,
+   with threaded input haplotype paths and graph-step translation tables.
 6. Teach `genotype`/`infer` to consume render bundles as a backend.
 7. Add tiled render and merge.
 8. Add true GBZ-compatible packaging if needed for interoperability.
+9. Add local GBWT construction for explicit graph paths.
 
 ## Tests
 

--- a/src/commands/render.rs
+++ b/src/commands/render.rs
@@ -1,4 +1,4 @@
-use crate::commands::{partition, syng2gfa};
+use crate::commands::{graph, partition, syng2gfa};
 use crate::graph::reverse_complement;
 use crate::render_bundle::{
     self, RenderBundlePaths, RenderManifest, RenderTranslationTables, RenderedPathRecord,
@@ -8,9 +8,9 @@ use crate::sequence_index::{SequenceIndex, UnifiedSequenceIndex};
 use crate::sequence_namespace::{SequenceNamespace, SourceInterval};
 use crate::syng::{self, SyngIndex};
 use log::{info, warn};
-use std::collections::BTreeSet;
-use std::fs;
-use std::io;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs::{self, File};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
 #[derive(Debug, Clone)]
@@ -24,6 +24,7 @@ pub struct RenderConfig<'a> {
     pub syng_extension: u64,
     pub emit_gfa: bool,
     pub keep_existing: bool,
+    pub threads: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -34,12 +35,21 @@ struct RenderInterval {
     strand: char,
 }
 
+struct RenderInputs {
+    namespace: SequenceNamespace,
+    rendered_paths: Vec<RenderedPathRecord>,
+    fetched: Vec<(String, Vec<u8>)>,
+}
+
 pub fn run(config: &RenderConfig<'_>) -> io::Result<()> {
-    match config.engine {
+    match normalize_render_engine(config.engine).as_str() {
         "syng-native" => render_syng_native(config),
+        "poa" | "seqwish" | "pggb" => render_local_graph(config),
         other => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("unsupported render engine '{other}'; currently expected 'syng-native'"),
+            format!(
+                "unsupported render engine '{other}'; expected one of: syng-native, poa, seqwish, pggb"
+            ),
         )),
     }
 }
@@ -58,78 +68,14 @@ fn render_syng_native(config: &RenderConfig<'_>) -> io::Result<()> {
     info!("Loading syng index from prefix: {}", config.syng_prefix);
     let index = SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
 
-    info!(
-        "Building sequence index for {} source file(s)",
-        config.sequence_files.len()
-    );
-    let sequence_index = UnifiedSequenceIndex::from_files(config.sequence_files)?;
-
-    let intervals = collect_render_intervals(
-        &index,
-        config.target_range,
-        config.syng_padding,
-        config.syng_extension,
-    )?;
-    if intervals.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "no source intervals found for render target",
-        ));
+    let mut inputs = collect_render_inputs(&index, config)?;
+    for (path_idx, rendered_path) in inputs.rendered_paths.iter_mut().enumerate() {
+        rendered_path.gbwt_path_id = Some(path_idx as u32);
     }
+    write_rendered_fasta(&paths.rendered_fasta, &inputs.fetched)?;
 
-    let mut namespace = SequenceNamespace::new();
-    for (name, &length) in index
-        .name_map
-        .path_to_name
-        .iter()
-        .zip(index.name_map.path_to_length.iter())
-    {
-        namespace.add_sequence(name.clone(), length);
-    }
-
-    let mut fetched = Vec::with_capacity(intervals.len());
-    let mut rendered_paths = Vec::with_capacity(intervals.len());
-    for interval in &intervals {
-        let source = namespace
-            .get_by_name(&interval.source_name)
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "source '{}' is missing from namespace",
-                        interval.source_name
-                    ),
-                )
-            })?;
-        let mut seq = fetch_source_interval(
-            &sequence_index,
-            &interval.source_name,
-            interval.start,
-            interval.end,
-        )?;
-        if interval.strand == '-' {
-            seq = reverse_complement(&seq);
-        }
-        let rendered_path_id = rendered_paths.len() as u32;
-        let rendered_name = format!(
-            "{}:{}-{}({})",
-            interval.source_name, interval.start, interval.end, interval.strand
-        );
-        rendered_paths.push(RenderedPathRecord {
-            rendered_path_id,
-            rendered_name: rendered_name.clone(),
-            source_interval: SourceInterval::new(
-                source.id,
-                interval.start,
-                interval.end,
-                interval.strand,
-            )?,
-            gbwt_path_id: Some(rendered_path_id),
-        });
-        fetched.push((rendered_name, seq));
-    }
-
-    let fetched_refs: Vec<(String, &[u8])> = fetched
+    let fetched_refs: Vec<(String, &[u8])> = inputs
+        .fetched
         .iter()
         .map(|(name, seq)| (name.clone(), seq.as_slice()))
         .collect();
@@ -138,10 +84,10 @@ fn render_syng_native(config: &RenderConfig<'_>) -> io::Result<()> {
     render_index.build_region_gbwt(&fetched_refs, &syng_prefix)?;
 
     let region_index = SyngIndex::load(&syng_prefix, syng::SyncmerParams::default())?;
-    let step_samples = collect_region_step_samples(&region_index, &rendered_paths)?;
+    let step_samples = collect_region_step_samples(&region_index, &inputs.rendered_paths)?;
     let tables = RenderTranslationTables {
-        namespace,
-        rendered_paths,
+        namespace: inputs.namespace,
+        rendered_paths: inputs.rendered_paths,
         step_samples,
     };
 
@@ -181,6 +127,61 @@ fn render_syng_native(config: &RenderConfig<'_>) -> io::Result<()> {
     Ok(())
 }
 
+fn render_local_graph(config: &RenderConfig<'_>) -> io::Result<()> {
+    if config.sequence_files.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "impg render local graph engines require --sequence-files or --sequence-list",
+        ));
+    }
+    if !config.emit_gfa {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--no-gfa is not supported with local graph render engines",
+        ));
+    }
+
+    let engine = normalize_render_engine(config.engine);
+    let paths = RenderBundlePaths::new(config.output);
+    prepare_bundle_dir(&paths.root, config.keep_existing)?;
+
+    info!("Loading syng index from prefix: {}", config.syng_prefix);
+    let index = SyngIndex::load(config.syng_prefix, syng::SyncmerParams::default())?;
+    let inputs = collect_render_inputs(&index, config)?;
+    write_rendered_fasta(&paths.rendered_fasta, &inputs.fetched)?;
+    build_local_graph(&engine, &paths.rendered_fasta, &paths.graph_gfa, config.threads)?;
+    let step_samples = collect_gfa_step_samples(&paths.graph_gfa, &inputs.rendered_paths)?;
+
+    let tables = RenderTranslationTables {
+        namespace: inputs.namespace,
+        rendered_paths: inputs.rendered_paths,
+        step_samples,
+    };
+    render_bundle::write_namespace(&paths.namespace, &tables.namespace)?;
+    render_bundle::write_translation_binary(&paths.translation, &tables)?;
+    render_bundle::write_translation_tsv(&paths.translation_tsv, &tables)?;
+
+    let manifest = RenderManifest::new_local_graph(
+        engine,
+        config.syng_prefix.to_string(),
+        config.target_range.to_string(),
+        &paths,
+        tables.namespace.sequences.len(),
+        tables.rendered_paths.len(),
+        tables.step_samples.len(),
+    );
+    render_bundle::write_manifest(&paths.manifest, &manifest)?;
+
+    info!(
+        "Wrote local graph render bundle to {}: {} source sequences, {} rendered paths, {} step samples",
+        paths.root.display(),
+        manifest.source_sequences,
+        manifest.rendered_paths,
+        manifest.step_samples
+    );
+    Ok(())
+}
+
 fn prepare_bundle_dir(root: &Path, keep_existing: bool) -> io::Result<()> {
     if root.exists() {
         if !keep_existing {
@@ -209,6 +210,139 @@ fn prepare_bundle_dir(root: &Path, keep_existing: bool) -> io::Result<()> {
         fs::create_dir_all(root)?;
     }
     Ok(())
+}
+
+fn normalize_render_engine(engine: &str) -> String {
+    match engine.trim().replace('_', "-").as_str() {
+        "syng" | "syng-native" => "syng-native".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn collect_render_inputs(index: &SyngIndex, config: &RenderConfig<'_>) -> io::Result<RenderInputs> {
+    info!(
+        "Building sequence index for {} source file(s)",
+        config.sequence_files.len()
+    );
+    let sequence_index = UnifiedSequenceIndex::from_files(config.sequence_files)?;
+
+    let intervals = collect_render_intervals(
+        index,
+        config.target_range,
+        config.syng_padding,
+        config.syng_extension,
+    )?;
+    if intervals.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "no source intervals found for render target",
+        ));
+    }
+
+    let mut namespace = SequenceNamespace::new();
+    for (name, &length) in index
+        .name_map
+        .path_to_name
+        .iter()
+        .zip(index.name_map.path_to_length.iter())
+    {
+        namespace.add_sequence(name.clone(), length);
+    }
+
+    let mut fetched = Vec::with_capacity(intervals.len());
+    let mut rendered_paths = Vec::with_capacity(intervals.len());
+    for interval in &intervals {
+        let source = namespace
+            .get_by_name(&interval.source_name)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("source '{}' is missing from namespace", interval.source_name),
+                )
+            })?;
+        let mut seq = fetch_source_interval(
+            &sequence_index,
+            &interval.source_name,
+            interval.start,
+            interval.end,
+        )?;
+        if interval.strand == '-' {
+            seq = reverse_complement(&seq);
+        }
+        let rendered_path_id = rendered_paths.len() as u32;
+        let rendered_name = format!(
+            "{}:{}-{}({})",
+            interval.source_name, interval.start, interval.end, interval.strand
+        );
+        rendered_paths.push(RenderedPathRecord {
+            rendered_path_id,
+            rendered_name: rendered_name.clone(),
+            source_interval: SourceInterval::new(
+                source.id,
+                interval.start,
+                interval.end,
+                interval.strand,
+            )?,
+            gbwt_path_id: None,
+        });
+        fetched.push((rendered_name, seq));
+    }
+
+    Ok(RenderInputs {
+        namespace,
+        rendered_paths,
+        fetched,
+    })
+}
+
+fn write_rendered_fasta(path: &Path, sequences: &[(String, Vec<u8>)]) -> io::Result<()> {
+    let mut writer = BufWriter::new(File::create(path)?);
+    for (name, seq) in sequences {
+        writeln!(writer, ">{name}")?;
+        for chunk in seq.chunks(80) {
+            writer.write_all(chunk)?;
+            writer.write_all(b"\n")?;
+        }
+    }
+    writer.flush()
+}
+
+fn build_local_graph(engine: &str, fasta: &Path, gfa: &Path, threads: usize) -> io::Result<()> {
+    let fasta_files = vec![fasta.to_string_lossy().to_string()];
+    let mut config = graph::GraphBuildConfig::default();
+    config.num_threads = threads.max(1);
+    config.show_progress = false;
+
+    match engine {
+        "poa" => {
+            let mut writer = BufWriter::new(File::create(gfa)?);
+            graph::run_graph_build_poa(
+                fasta_files,
+                &mut writer,
+                (5, 4, 6, 2, 24, 1),
+                &config,
+            )
+        }
+        "seqwish" => {
+            let gfa_path = gfa.to_string_lossy().to_string();
+            graph::run_graph_build(fasta_files, &gfa_path, config)
+        }
+        "pggb" => {
+            let mut writer = BufWriter::new(File::create(gfa)?);
+            graph::run_graph_build_pggb(
+                fasta_files,
+                &mut writer,
+                &config,
+                vec![700, 1100],
+                100,
+                0.001,
+            )
+        }
+        other => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("unsupported local graph render engine '{other}'"),
+        )),
+    }
 }
 
 fn collect_render_intervals(
@@ -308,4 +442,162 @@ fn collect_region_step_samples(
         }
     }
     Ok(records)
+}
+
+fn collect_gfa_step_samples(
+    gfa: &Path,
+    rendered_paths: &[RenderedPathRecord],
+) -> io::Result<Vec<StepTranslationRecord>> {
+    let mut segment_lengths = HashMap::new();
+    let mut path_walks: BTreeMap<String, Vec<(u32, char)>> = BTreeMap::new();
+    let reader = BufReader::new(File::open(gfa)?);
+    for line in reader.lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        match fields.first().copied() {
+            Some("S") if fields.len() >= 3 => {
+                let segment_id = parse_gfa_segment_id(fields[1])?;
+                segment_lengths.insert(segment_id, fields[2].len() as u64);
+            }
+            Some("P") if fields.len() >= 3 => {
+                let walk = parse_gfa_p_walk(fields[2])?;
+                path_walks.insert(fields[1].to_string(), walk);
+            }
+            Some("W") if fields.len() >= 7 => {
+                let path_name = format!(
+                    "{}#{}#{}:{}-{}(+)",
+                    fields[1], fields[2], fields[3], fields[4], fields[5]
+                );
+                let walk = parse_gfa_w_walk(fields[6])?;
+                path_walks.insert(path_name, walk);
+            }
+            _ => {}
+        }
+    }
+
+    let mut records = Vec::new();
+    for rendered_path in rendered_paths {
+        let walk = find_gfa_path_walk(&path_walks, &rendered_path.rendered_name)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "GFA graph '{}' has no path for rendered interval '{}'",
+                        gfa.display(),
+                        rendered_path.rendered_name
+                    ),
+                )
+            })?;
+        let mut rendered_offset = 0u64;
+        for (rendered_step, (feature_id, orientation)) in walk.iter().copied().enumerate() {
+            let segment_len = *segment_lengths.get(&feature_id).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("GFA path references missing segment {feature_id}"),
+                )
+            })?;
+            let source_bp = match rendered_path.source_interval.strand {
+                '+' => rendered_path
+                    .source_interval
+                    .start
+                    .saturating_add(rendered_offset),
+                '-' => rendered_path
+                    .source_interval
+                    .end
+                    .saturating_sub(rendered_offset.saturating_add(segment_len)),
+                _ => rendered_offset,
+            };
+            records.push(StepTranslationRecord {
+                rendered_path_id: rendered_path.rendered_path_id,
+                rendered_step: rendered_step as u32,
+                source_bp,
+                feature_id,
+                orientation,
+            });
+            rendered_offset = rendered_offset.saturating_add(segment_len);
+        }
+    }
+    Ok(records)
+}
+
+fn find_gfa_path_walk<'a>(
+    path_walks: &'a BTreeMap<String, Vec<(u32, char)>>,
+    rendered_name: &str,
+) -> Option<&'a Vec<(u32, char)>> {
+    if let Some(walk) = path_walks.get(rendered_name) {
+        return Some(walk);
+    }
+
+    let metadata_prefix = format!("{rendered_name}:");
+    let mut matches = path_walks
+        .range(metadata_prefix.clone()..)
+        .take_while(|(name, _)| name.starts_with(&metadata_prefix))
+        .map(|(_, walk)| walk);
+    let first = matches.next()?;
+    if matches.next().is_none() {
+        Some(first)
+    } else {
+        None
+    }
+}
+
+fn parse_gfa_p_walk(walk: &str) -> io::Result<Vec<(u32, char)>> {
+    if walk == "*" || walk.is_empty() {
+        return Ok(Vec::new());
+    }
+    walk.split(',')
+        .map(|step| {
+            let (id, orientation) = step.split_at(step.len().saturating_sub(1));
+            let orientation = match orientation {
+                "+" => '+',
+                "-" => '-',
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid GFA P-line step orientation in '{step}'"),
+                    ));
+                }
+            };
+            Ok((parse_gfa_segment_id(id)?, orientation))
+        })
+        .collect()
+}
+
+fn parse_gfa_w_walk(walk: &str) -> io::Result<Vec<(u32, char)>> {
+    let mut steps = Vec::new();
+    let mut orientation = None;
+    let mut start = 0usize;
+    for (idx, ch) in walk.char_indices() {
+        if ch == '>' || ch == '<' {
+            if let Some(prev_orientation) = orientation {
+                let id = &walk[start..idx];
+                if !id.is_empty() {
+                    steps.push((parse_gfa_segment_id(id)?, prev_orientation));
+                }
+            }
+            orientation = Some(if ch == '>' { '+' } else { '-' });
+            start = idx + ch.len_utf8();
+        }
+    }
+    if let Some(prev_orientation) = orientation {
+        let id = &walk[start..];
+        if !id.is_empty() {
+            steps.push((parse_gfa_segment_id(id)?, prev_orientation));
+        }
+    }
+    Ok(steps)
+}
+
+fn parse_gfa_segment_id(id: &str) -> io::Result<u32> {
+    id.parse::<u32>().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "GFA segment id '{id}' is not a u32; render translation currently requires numeric segment ids"
+            ),
+        )
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5639,6 +5639,7 @@ fn run() -> io::Result<()> {
                 syng_extension,
                 emit_gfa: !no_gfa,
                 keep_existing,
+                threads: common.threads.get(),
             };
             render::run(&config)?;
         }

--- a/src/render_bundle.rs
+++ b/src/render_bundle.rs
@@ -1,7 +1,7 @@
 use crate::sequence_namespace::{SequenceNamespace, SourceInterval};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{self, BufWriter, Write};
+use std::io::{self, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 pub const RENDER_FORMAT: &str = "impg-render-bundle";
@@ -20,6 +20,7 @@ pub struct RenderManifest {
     pub namespace: String,
     pub translation: String,
     pub translation_tsv: Option<String>,
+    pub rendered_fasta: Option<String>,
     pub graph_gfa: Option<String>,
     pub syng_prefix: Option<String>,
     pub source_sequences: usize,
@@ -58,8 +59,16 @@ pub struct RenderBundlePaths {
     pub namespace: PathBuf,
     pub translation: PathBuf,
     pub translation_tsv: PathBuf,
+    pub rendered_fasta: PathBuf,
     pub graph_gfa: PathBuf,
     pub syng_prefix: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedRenderBundle {
+    pub root: PathBuf,
+    pub manifest: RenderManifest,
+    pub tables: RenderTranslationTables,
 }
 
 impl RenderManifest {
@@ -83,8 +92,38 @@ impl RenderManifest {
             namespace: relative_file(&paths.root, &paths.namespace),
             translation: relative_file(&paths.root, &paths.translation),
             translation_tsv: Some(relative_file(&paths.root, &paths.translation_tsv)),
+            rendered_fasta: Some(relative_file(&paths.root, &paths.rendered_fasta)),
             graph_gfa: include_gfa.then(|| relative_file(&paths.root, &paths.graph_gfa)),
             syng_prefix: Some(relative_file(&paths.root, &paths.syng_prefix)),
+            source_sequences,
+            rendered_paths,
+            step_samples,
+        }
+    }
+
+    pub fn new_local_graph(
+        engine: String,
+        source_index: String,
+        target_range: String,
+        paths: &RenderBundlePaths,
+        source_sequences: usize,
+        rendered_paths: usize,
+        step_samples: usize,
+    ) -> Self {
+        Self {
+            format: RENDER_FORMAT.to_string(),
+            version: RENDER_VERSION,
+            engine,
+            graph_kind: "local-sequence-graph".to_string(),
+            source_index,
+            target_range,
+            feature_space: "gfa-segment".to_string(),
+            namespace: relative_file(&paths.root, &paths.namespace),
+            translation: relative_file(&paths.root, &paths.translation),
+            translation_tsv: Some(relative_file(&paths.root, &paths.translation_tsv)),
+            rendered_fasta: Some(relative_file(&paths.root, &paths.rendered_fasta)),
+            graph_gfa: Some(relative_file(&paths.root, &paths.graph_gfa)),
+            syng_prefix: None,
             source_sequences,
             rendered_paths,
             step_samples,
@@ -100,6 +139,7 @@ impl RenderBundlePaths {
             namespace: root.join("namespace.json"),
             translation: root.join("translation.bin"),
             translation_tsv: root.join("translation.tsv"),
+            rendered_fasta: root.join("rendered.fa"),
             graph_gfa: root.join("graph.gfa"),
             syng_prefix: root.join("paths"),
             root,
@@ -110,6 +150,62 @@ impl RenderBundlePaths {
 pub fn write_manifest(path: &Path, manifest: &RenderManifest) -> io::Result<()> {
     let file = File::create(path)?;
     serde_json::to_writer_pretty(file, manifest).map_err(io::Error::other)
+}
+
+pub fn read_manifest(path: &Path) -> io::Result<RenderManifest> {
+    let file = File::open(path)?;
+    let manifest: RenderManifest = serde_json::from_reader(file).map_err(io::Error::other)?;
+    validate_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+pub fn load_bundle(root: impl AsRef<Path>) -> io::Result<LoadedRenderBundle> {
+    let root = root.as_ref().to_path_buf();
+    let manifest = read_manifest(&root.join("manifest.json"))?;
+    let translation = resolve_bundle_path(&root, &manifest.translation);
+    let tables = read_translation_binary(&translation)?;
+    Ok(LoadedRenderBundle {
+        root,
+        manifest,
+        tables,
+    })
+}
+
+pub fn resolve_bundle_path(root: &Path, relative_or_absolute: &str) -> PathBuf {
+    let path = Path::new(relative_or_absolute);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn validate_manifest(manifest: &RenderManifest) -> io::Result<()> {
+    if manifest.format != RENDER_FORMAT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "render manifest has format '{}', expected '{}'",
+                manifest.format, RENDER_FORMAT
+            ),
+        ));
+    }
+    if manifest.version != RENDER_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "render manifest has version {}, expected {}",
+                manifest.version, RENDER_VERSION
+            ),
+        ));
+    }
+    if manifest.namespace.is_empty() || manifest.translation.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "render manifest is missing namespace or translation path",
+        ));
+    }
+    Ok(())
 }
 
 pub fn write_namespace(path: &Path, namespace: &SequenceNamespace) -> io::Result<()> {
@@ -128,7 +224,7 @@ pub fn write_translation_binary(path: &Path, tables: &RenderTranslationTables) -
 pub fn read_translation_binary(path: &Path) -> io::Result<RenderTranslationTables> {
     let mut reader = std::io::BufReader::new(File::open(path)?);
     let mut magic = [0u8; 8];
-    std::io::Read::read_exact(&mut reader, &mut magic)?;
+    reader.read_exact(&mut magic)?;
     if &magic != TRANSLATION_MAGIC {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -260,6 +356,51 @@ mod tests {
             "HG002#1#chr6:10-100"
         );
         assert_eq!(decoded.step_samples[0].feature_id, 42);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn bundle_loader_validates_manifest_and_translation() {
+        let dir = std::env::temp_dir().join("impg_test_render_bundle_loader");
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let paths = RenderBundlePaths::new(&dir);
+
+        let mut namespace = SequenceNamespace::new();
+        let source_id = namespace.add_sequence("HG002#1#chr6", 1000);
+        let tables = RenderTranslationTables {
+            namespace,
+            rendered_paths: vec![RenderedPathRecord {
+                rendered_path_id: 0,
+                rendered_name: "HG002#1#chr6:10-100".to_string(),
+                source_interval: SourceInterval::new(source_id, 10, 100, '+').unwrap(),
+                gbwt_path_id: Some(0),
+            }],
+            step_samples: vec![StepTranslationRecord {
+                rendered_path_id: 0,
+                rendered_step: 0,
+                source_bp: 10,
+                feature_id: 42,
+                orientation: '+',
+            }],
+        };
+        let manifest = RenderManifest::new_local_graph(
+            "poa".to_string(),
+            "panel.syng".to_string(),
+            "HG002#1#chr6:10-100".to_string(),
+            &paths,
+            tables.namespace.sequences.len(),
+            tables.rendered_paths.len(),
+            tables.step_samples.len(),
+        );
+
+        write_manifest(&paths.manifest, &manifest).unwrap();
+        write_translation_binary(&paths.translation, &tables).unwrap();
+        let loaded = load_bundle(&dir).unwrap();
+
+        assert_eq!(loaded.manifest.engine, "poa");
+        assert_eq!(loaded.tables.rendered_paths[0].rendered_name, "HG002#1#chr6:10-100");
+        assert_eq!(loaded.tables.step_samples[0].source_bp, 10);
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -284,6 +284,7 @@ fn test_syng_render_bundle_preserves_source_namespace() {
         "namespace.json",
         "translation.bin",
         "translation.tsv",
+        "rendered.fa",
         "graph.gfa",
         "paths.1gbwt",
         "paths.1khash",
@@ -322,6 +323,45 @@ fn test_syng_render_bundle_preserves_source_namespace() {
     assert!(gfa.starts_with("H\tVN:Z:1.0\n"), "{}", gfa);
     assert!(gfa.contains("\nS\t"), "{}", gfa);
     assert!(gfa.contains("\nP\t"), "{}", gfa);
+
+    let poa_bundle = dir.join("render.poa.impg-gbz");
+    let render_poa = Command::new(&bin)
+        .args([
+            "render",
+            "-a",
+            prefix.to_str().unwrap(),
+            "-r",
+            "sampleA#0#chr1:100-1000",
+            "--sequence-files",
+            fasta.to_str().unwrap(),
+            "-O",
+            poa_bundle.to_str().unwrap(),
+            "--engine",
+            "poa",
+            "-t",
+            "2",
+        ])
+        .output()
+        .expect("failed to run impg render --engine poa");
+    assert!(
+        render_poa.status.success(),
+        "impg render --engine poa failed: {}",
+        String::from_utf8_lossy(&render_poa.stderr)
+    );
+    let poa_manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(poa_bundle.join("manifest.json")).unwrap())
+            .unwrap();
+    assert_eq!(poa_manifest["engine"], "poa");
+    assert_eq!(poa_manifest["graph_kind"], "local-sequence-graph");
+    assert_eq!(poa_manifest["feature_space"], "gfa-segment");
+    assert!(poa_manifest["syng_prefix"].is_null());
+    assert!(poa_manifest["step_samples"].as_u64().unwrap() > 0);
+    assert!(poa_bundle.join("rendered.fa").exists());
+    let poa_translation = std::fs::read_to_string(poa_bundle.join("translation.tsv")).unwrap();
+    assert!(poa_translation.contains("\nstep\t"), "{}", poa_translation);
+    let poa_gfa = std::fs::read_to_string(poa_bundle.join("graph.gfa")).unwrap();
+    assert!(poa_gfa.contains("\nS\t"), "{}", poa_gfa);
+    assert!(poa_gfa.contains("\nP\t"), "{}", poa_gfa);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add local graph render engines for `impg render --engine poa|seqwish|pggb`
- write `rendered.fa` alongside manifest, namespace, binary translation, TSV, and graph GFA
- derive graph-step to source-coordinate translation from GFA path walks
- add render bundle manifest/translation loader for future consumers
- document current local graph render state and explicit-graph GBWT as pending

## Tests
- `cargo test`
- `cargo check`
- `cargo test --test test_syng_integration test_syng_render_bundle_preserves_source_namespace -- --nocapture`
- `cargo test render_bundle::tests -- --nocapture`
- `git diff --check`