### PR TITLE
Consume syng render bundles in genotype and infer

### DIFF
--- a/docs/render-gbz-translation-design.md
+++ b/docs/render-gbz-translation-design.md
@@ -226,6 +226,24 @@ separate pending step; the rendered FASTA path names and translation tables are
 already organized so that GBWT path IDs can be attached without changing the
 source namespace model.
 
+Syng-native bundles can be used as local genotyping views by mapping reads to
+the bundle's `paths` syng index and passing the bundle to `genotype cos`:
+
+```bash
+impg map -a c4.syng-native.impg-gbz/paths -q reads.fq.gz -o pack \
+  -O c4.local.pack
+impg genotype cos --render-bundle c4.syng-native.impg-gbz --pack c4.local.pack
+impg infer --render-bundle c4.syng-native.impg-gbz --pack c4.local.pack
+```
+
+When `-r/--target-range` is omitted, `genotype cos` and `infer` use the source
+target from the render manifest and project it onto the containing rendered path.
+A different source-coordinate subrange can be supplied with `-r`; it is
+projected through the same translation table before scoring. `infer
+--render-bundle` currently supports this single-target mode; BED and partition
+inputs should be projected through the bundle as a deliberate batch operation in
+a later slice.
+
 ### Whole-Genome Render
 
 Whole-genome rendering should be tiled:

--- a/src/main.rs
+++ b/src/main.rs
@@ -2581,8 +2581,12 @@ enum GenotypeCommand {
     #[command(alias = "cosigt")]
     Cos {
         /// Syng index prefix or .1khash/.1gbwt/.spos/.pstep/.names/.meta path
-        #[clap(short = 'a', long, value_parser)]
-        index: String,
+        #[clap(short = 'a', long, value_parser, required_unless_present = "render_bundle")]
+        index: Option<String>,
+
+        /// Render bundle directory produced by `impg render --engine syng-native`
+        #[clap(long = "render-bundle", value_parser, conflicts_with = "index")]
+        render_bundle: Option<String>,
 
         /// Sample support vector produced by `impg map -o pack`
         #[clap(short = 'p', long, value_parser)]
@@ -2593,8 +2597,8 @@ enum GenotypeCommand {
         proj: Option<String>,
 
         /// Reference path range to genotype, in the format `seq_name:start-end`
-        #[clap(short = 'r', long, value_parser)]
-        target_range: String,
+        #[clap(short = 'r', long, value_parser, required_unless_present = "render_bundle")]
+        target_range: Option<String>,
 
         /// Candidate extraction mode
         #[clap(long, value_enum, default_value_t = genotype::CandidateMode::Spanning)]
@@ -3131,8 +3135,12 @@ enum Args {
     /// Infer allele calls across ranges or partitions from graph-derived evidence
     Infer {
         /// Syng index prefix or .1khash/.1gbwt/.spos/.pstep/.names/.meta path
-        #[clap(short = 'a', long, value_parser)]
-        index: String,
+        #[clap(short = 'a', long, value_parser, required_unless_present = "render_bundle")]
+        index: Option<String>,
+
+        /// Render bundle directory produced by `impg render --engine syng-native`
+        #[clap(long = "render-bundle", value_parser, conflicts_with = "index")]
+        render_bundle: Option<String>,
 
         /// Sample support vector produced by `impg map -o pack`
         #[clap(short = 'p', long, value_parser)]
@@ -5135,6 +5143,7 @@ fn run() -> io::Result<()> {
         Args::Genotype { command } => match command {
             GenotypeCommand::Cos {
                 index,
+                render_bundle,
                 pack,
                 proj,
                 target_range,
@@ -5151,7 +5160,39 @@ fn run() -> io::Result<()> {
                 common,
             } => {
                 initialize_threads_and_log(&common);
-                let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+                let loaded_render_bundle = render_bundle
+                    .as_deref()
+                    .map(impg::render_bundle::load_bundle)
+                    .transpose()?;
+                let (syng_prefix, target_range) = if let Some(bundle) = &loaded_render_bundle {
+                    if bundle.manifest.feature_space != "syng-syncmer-node" {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!(
+                                "impg genotype cos can consume syng-native render bundles; bundle feature_space is '{}'",
+                                bundle.manifest.feature_space
+                            ),
+                        ));
+                    }
+                    (
+                        bundle.syng_prefix_path()?.to_string_lossy().to_string(),
+                        bundle.rendered_target_range(target_range.as_deref())?,
+                    )
+                } else {
+                    let index = index.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "impg genotype cos requires --index or --render-bundle",
+                        )
+                    })?;
+                    let target_range = target_range.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "impg genotype cos requires --target-range or --render-bundle",
+                        )
+                    })?;
+                    (detect_syng_prefix(&index).unwrap_or(index), target_range)
+                };
                 let projection = if let Some(path) = proj.as_deref() {
                     Some(impg::projection::load(path)?)
                 } else {
@@ -5224,6 +5265,7 @@ fn run() -> io::Result<()> {
         },
         Args::Infer {
             index,
+            render_bundle,
             pack,
             proj,
             gaf,
@@ -5266,6 +5308,10 @@ fn run() -> io::Result<()> {
             common,
         } => {
             initialize_threads_and_log(&common);
+            let loaded_render_bundle = render_bundle
+                .as_deref()
+                .map(impg::render_bundle::load_bundle)
+                .transpose()?;
             if score != "cos" {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -5279,7 +5325,31 @@ fn run() -> io::Result<()> {
                 ));
             }
 
-            let targets = if let Some(range) = target_range {
+            let targets = if let Some(bundle) = &loaded_render_bundle {
+                if bundle.manifest.feature_space != "syng-syncmer-node" {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "impg infer can consume syng-native render bundles; bundle feature_space is '{}'",
+                            bundle.manifest.feature_space
+                        ),
+                    ));
+                }
+                if target_bed.is_some() || partitions.is_some() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "impg infer --render-bundle currently supports one source target range; omit -r to use the bundle target or provide -r",
+                    ));
+                }
+                if emit_fasta.is_some() || emit_gfa.is_some() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "impg infer --render-bundle does not yet support --emit-fasta/--emit-gfa",
+                    ));
+                }
+                let local_range = bundle.rendered_target_range(target_range.as_deref())?;
+                vec![infer::parse_target_range(&local_range)?]
+            } else if let Some(range) = target_range {
                 vec![infer::parse_target_range(&range)?]
             } else if let Some(path) = target_bed {
                 infer::parse_target_bed(&path)?
@@ -5319,7 +5389,17 @@ fn run() -> io::Result<()> {
                 None
             };
 
-            let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
+            let syng_prefix = if let Some(bundle) = &loaded_render_bundle {
+                bundle.syng_prefix_path()?.to_string_lossy().to_string()
+            } else {
+                let index = index.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "impg infer requires --index or --render-bundle",
+                    )
+                })?;
+                detect_syng_prefix(&index).unwrap_or(index)
+            };
             let projection = if let Some(path) = proj.as_deref() {
                 Some(impg::projection::load(path)?)
             } else {

--- a/src/render_bundle.rs
+++ b/src/render_bundle.rs
@@ -147,6 +147,110 @@ impl RenderBundlePaths {
     }
 }
 
+impl LoadedRenderBundle {
+    pub fn syng_prefix_path(&self) -> io::Result<PathBuf> {
+        let syng_prefix = self.manifest.syng_prefix.as_deref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "render bundle does not contain a syng prefix",
+            )
+        })?;
+        Ok(resolve_bundle_path(&self.root, syng_prefix))
+    }
+
+    pub fn rendered_target_range(&self, source_range: Option<&str>) -> io::Result<String> {
+        let source_range = source_range.unwrap_or(&self.manifest.target_range);
+        let (source_name, source_start, source_end) = parse_source_range(source_range)?;
+        let source = self
+            .tables
+            .namespace
+            .get_by_name(&source_name)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("source range references unknown sequence '{source_name}'"),
+                )
+            })?;
+
+        let mut best = None;
+        for path in &self.tables.rendered_paths {
+            let interval = &path.source_interval;
+            if interval.source_sequence_id != source.id {
+                continue;
+            }
+            if interval.start > source_start || interval.end < source_end {
+                continue;
+            }
+            let span = interval.end.saturating_sub(interval.start);
+            if best
+                .as_ref()
+                .map(|(_, best_span)| span < *best_span)
+                .unwrap_or(true)
+            {
+                best = Some((path, span));
+            }
+        }
+
+        let (path, _) = best.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("render bundle has no path containing source range '{source_range}'"),
+            )
+        })?;
+        let (local_start, local_end) = match path.source_interval.strand {
+            '+' => (
+                source_start - path.source_interval.start,
+                source_end - path.source_interval.start,
+            ),
+            '-' => (
+                path.source_interval.end - source_end,
+                path.source_interval.end - source_start,
+            ),
+            strand => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("rendered path has invalid strand '{strand}'"),
+                ));
+            }
+        };
+        Ok(format!("{}:{}-{}", path.rendered_name, local_start, local_end))
+    }
+}
+
+fn parse_source_range(range: &str) -> io::Result<(String, u64, u64)> {
+    let (name, coords) = range.rsplit_once(':').ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid source range '{range}'; expected NAME:START-END"),
+        )
+    })?;
+    let (start, end) = coords.split_once('-').ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid source range '{range}'; expected NAME:START-END"),
+        )
+    })?;
+    let start = start.parse::<u64>().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid start coordinate in source range '{range}'"),
+        )
+    })?;
+    let end = end.parse::<u64>().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid end coordinate in source range '{range}'"),
+        )
+    })?;
+    if end <= start {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid source range '{range}': end must be greater than start"),
+        ));
+    }
+    Ok((name.to_string(), start, end))
+}
+
 pub fn write_manifest(path: &Path, manifest: &RenderManifest) -> io::Result<()> {
     let file = File::create(path)?;
     serde_json::to_writer_pretty(file, manifest).map_err(io::Error::other)
@@ -402,5 +506,55 @@ mod tests {
         assert_eq!(loaded.tables.rendered_paths[0].rendered_name, "HG002#1#chr6:10-100");
         assert_eq!(loaded.tables.step_samples[0].source_bp, 10);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rendered_target_range_projects_source_coordinates() {
+        let mut namespace = SequenceNamespace::new();
+        let source_id = namespace.add_sequence("HG002#1#chr6", 1000);
+        let root = PathBuf::from("/tmp/render-test");
+        let paths = RenderBundlePaths::new(&root);
+        let tables = RenderTranslationTables {
+            namespace,
+            rendered_paths: vec![
+                RenderedPathRecord {
+                    rendered_path_id: 0,
+                    rendered_name: "HG002#1#chr6:100-500(+)".to_string(),
+                    source_interval: SourceInterval::new(source_id, 100, 500, '+').unwrap(),
+                    gbwt_path_id: Some(0),
+                },
+                RenderedPathRecord {
+                    rendered_path_id: 1,
+                    rendered_name: "HG002#1#chr6:100-500(-)".to_string(),
+                    source_interval: SourceInterval::new(source_id, 100, 500, '-').unwrap(),
+                    gbwt_path_id: Some(1),
+                },
+            ],
+            step_samples: Vec::new(),
+        };
+        let bundle = LoadedRenderBundle {
+            root,
+            manifest: RenderManifest::new_syng_native(
+                "panel.syng".to_string(),
+                "HG002#1#chr6:150-250".to_string(),
+                &paths,
+                true,
+                tables.namespace.sequences.len(),
+                tables.rendered_paths.len(),
+                tables.step_samples.len(),
+            ),
+            tables,
+        };
+
+        assert_eq!(
+            bundle.rendered_target_range(None).unwrap(),
+            "HG002#1#chr6:100-500(+):50-150"
+        );
+        assert_eq!(
+            bundle
+                .rendered_target_range(Some("HG002#1#chr6:200-300"))
+                .unwrap(),
+            "HG002#1#chr6:100-500(+):100-200"
+        );
     }
 }

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -324,6 +324,90 @@ fn test_syng_render_bundle_preserves_source_namespace() {
     assert!(gfa.contains("\nS\t"), "{}", gfa);
     assert!(gfa.contains("\nP\t"), "{}", gfa);
 
+    let local_pack = dir.join("render.pack");
+    let map_local_pack = Command::new(&bin)
+        .args([
+            "map",
+            "-a",
+            bundle.join("paths").to_str().unwrap(),
+            "-q",
+            bundle.join("rendered.fa").to_str().unwrap(),
+            "-o",
+            "pack",
+            "-O",
+            local_pack.to_str().unwrap(),
+            "--min-anchors",
+            "1",
+        ])
+        .output()
+        .expect("failed to run impg map on rendered syng bundle");
+    assert!(
+        map_local_pack.status.success(),
+        "impg map on rendered syng bundle failed: {}",
+        String::from_utf8_lossy(&map_local_pack.stderr)
+    );
+    let genotype_bundle = Command::new(&bin)
+        .args([
+            "genotype",
+            "cos",
+            "--render-bundle",
+            bundle.to_str().unwrap(),
+            "--pack",
+            local_pack.to_str().unwrap(),
+            "--ploidy",
+            "1",
+            "--top-n",
+            "1",
+            "--min-anchors",
+            "1",
+            "--min-span-fraction",
+            "0",
+        ])
+        .output()
+        .expect("failed to run impg genotype cos --render-bundle");
+    assert!(
+        genotype_bundle.status.success(),
+        "impg genotype cos --render-bundle failed: {}",
+        String::from_utf8_lossy(&genotype_bundle.stderr)
+    );
+    let genotype_stdout = String::from_utf8_lossy(&genotype_bundle.stdout);
+    assert!(genotype_stdout.contains("#impg genotype cos"), "{}", genotype_stdout);
+    assert!(
+        genotype_stdout.contains("sampleA#0#chr1"),
+        "bundle genotype should report rendered paths with source names:\n{}",
+        genotype_stdout
+    );
+    let infer_bundle = Command::new(&bin)
+        .args([
+            "infer",
+            "--render-bundle",
+            bundle.to_str().unwrap(),
+            "--pack",
+            local_pack.to_str().unwrap(),
+            "--ploidy",
+            "1",
+            "--top-n",
+            "1",
+            "--min-anchors",
+            "1",
+            "--min-span-fraction",
+            "0",
+        ])
+        .output()
+        .expect("failed to run impg infer --render-bundle");
+    assert!(
+        infer_bundle.status.success(),
+        "impg infer --render-bundle failed: {}",
+        String::from_utf8_lossy(&infer_bundle.stderr)
+    );
+    let infer_stdout = String::from_utf8_lossy(&infer_bundle.stdout);
+    assert!(infer_stdout.contains("#impg infer"), "{}", infer_stdout);
+    assert!(
+        infer_stdout.contains("sampleA#0#chr1"),
+        "bundle infer should report rendered paths with source names:\n{}",
+        infer_stdout
+    );
+
     let poa_bundle = dir.join("render.poa.impg-gbz");
     let render_poa = Command::new(&bin)
         .args([


### PR DESCRIPTION
## Summary
- add render bundle helpers to resolve local syng prefixes and project source ranges onto rendered paths
- let `genotype cos --render-bundle` use a syng-native render bundle without `-a`/`-r`
- let `infer --render-bundle` use the same single-target syng-native bundle path
- extend the render integration test through local mapping, genotype, and infer
- document the local bundle workflow

## Tests
- `cargo test`
- `cargo check`
- `cargo test --test test_syng_integration test_syng_render_bundle_preserves_source_namespace -- --nocapture`
- `cargo test render_bundle::tests -- --nocapture`
- `git diff --check`