### PR TITLE
Use relative syng seed filtering by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,11 +407,15 @@ pass-through. Tune via `--syng-padding`, `--syng-min-chain-anchors`
 (lower -> more paralog hits; default `2` is conservative on duplicated
 loci like C4), `--syng-min-chain-fraction`, and the seed-frequency
 filters `--syng-seed-max-occurrences` / `--syng-seed-drop-top-fraction`.
-High-frequency syncmers are ignored only while seeding candidate ranges;
-once a range survives, downstream scoring can still recover all syncmers by
-walking that path range. `query -o gbwt` emits a region-specific sub-GBWT.
-The syng prefix passed to `-a` is resolved relative to cwd, so either `cd`
-to the index directory or pass an absolute path.
+By default syng query drops the top 5% most frequent query-local seed
+syncmers and does not use a fixed absolute occurrence cap; set
+`--syng-seed-max-occurrences` only when a hard panel-specific ceiling is
+desired. High-frequency syncmers are ignored only while seeding candidate
+ranges; once a range survives, downstream scoring can still recover all
+syncmers by walking that path range. `query -o gbwt` emits a
+region-specific sub-GBWT. The syng prefix passed to `-a` is resolved
+relative to cwd, so either `cd` to the index directory or pass an absolute
+path.
 
 ## GFA engines
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3000,21 +3000,22 @@ enum Args {
         syng_min_chain_fraction: f64,
 
         /// Drop this fraction of the query syncmer seed nodes with the
-        /// highest GBWT occurrence counts before locating hits. Default
-        /// 0.0005 drops the top 0.05% of query seeds, minimizer-style,
-        /// so high-copy repeats do not seed chromosome-scale ranges.
+        /// highest GBWT occurrence counts before locating hits. This is
+        /// query-local, not an index-global minimizer frequency cutoff:
+        /// default 0.05 drops the top 5% most repetitive seeds in the
+        /// requested region, so high-copy repeats do not seed
+        /// chromosome-scale ranges.
         /// Set to 0 to disable.
         #[arg(help_heading = "Syng input")]
-        #[clap(long, value_parser, default_value_t = 0.0005)]
+        #[clap(long, value_parser, default_value_t = 0.05)]
         syng_seed_drop_top_fraction: f64,
 
         /// Drop syncmer seed nodes occurring more than this many times
-        /// across both GBWT orientations before locating hits. The
-        /// default 1000 removes very high-copy seeds in large pangenomes
-        /// while leaving the filter inactive on small test panels. Set
-        /// to 0 to disable the absolute cap.
+        /// across both GBWT orientations before locating hits. Default
+        /// 0 disables the absolute cap; use this only when you want a
+        /// hard occurrence ceiling for a specific panel size.
         #[arg(help_heading = "Syng input")]
-        #[clap(long, value_parser, default_value_t = 1000)]
+        #[clap(long, value_parser, default_value_t = 0)]
         syng_seed_max_occurrences: u32,
 
         /// Debug-only: skip boundary realignment and emit raw syncmer-resolution


### PR DESCRIPTION
## Summary
- disable the fixed absolute syng seed occurrence cap by default
- make the default query-local top-frequency seed drop 5%
- document why the absolute cap is panel-specific and opt-in

## Rationale
The previous default cap of 1000 was an empirical HPRCv2 C4 rescue threshold, but it does not scale with panel size. wfmash-style frequency filtering is not a tiny fixed count; it is relative to the index/query context. For syng query, the safer default is therefore relative filtering, with a hard count only when the user asks for it.

## Validation
- cargo check
- git diff --check
- cargo test syng::tests::test_top_frequency_seed_filter_drops_only_top_fraction -- --nocapture
- cargo test --test test_syng_integration test_syng_query_reconstructs_homology_with_diffs -- --nocapture
- cargo test --test test_syng_integration test_syng -- --nocapture
- HPRCv2 C4 raw, no cap/top 5%: 678 intervals, mean 57.5 kb, max 83.6 kb, no >1 Mb intervals
- HPRCv2 C4 refined default, no overrides: 467 intervals, mean 83.4 kb, max 83.4 kb, no >1 Mb intervals