### PR TITLE
Use bounded syng walk seeds for query

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,11 +405,13 @@ Default query mode runs BiWFA boundary refinement and so requires
 `--sequence-files`. Pass `--syng-raw` for the raw syncmer-resolution
 pass-through. Tune via `--syng-padding`, `--syng-min-chain-anchors`
 (lower -> more paralog hits; default `2` is conservative on duplicated
-loci like C4), `--syng-min-chain-fraction`, and the seed-frequency
-filters `--syng-seed-max-occurrences` / `--syng-seed-drop-top-fraction`.
+loci like C4), `--syng-min-chain-fraction` (default `0.5`; set `0` for
+exploratory local-chain discovery), and the seed-frequency filters
+`--syng-seed-max-occurrences` / `--syng-seed-drop-top-fraction`.
 By default syng query drops the top 0.05% most frequent query-local seed
-syncmers, seeds ranges from ordered GBWT MEMs when available, and does not
-use a fixed absolute occurrence cap; set
+syncmers, seeds ranges from bounded exact GBWT walk seeds of five
+syncmers (`--syng-seed-walk-anchors`; set `3` for more sensitive seeds),
+and does not use a fixed absolute occurrence cap; set
 `--syng-seed-max-occurrences` only when a hard panel-specific ceiling is
 desired. High-frequency syncmers are ignored only while seeding candidate
 ranges; once a range survives, downstream scoring can still recover all

--- a/src/main.rs
+++ b/src/main.rs
@@ -2990,13 +2990,11 @@ enum Args {
         /// Minimum chain query-extent as a fraction of the queried
         /// range (0.0 to 1.0). Chains whose anchor span on the query
         /// axis covers less than `fraction × query_range_len` are
-        /// dropped. Default 0.0 keeps every chain (maximum paralog
-        /// discovery). Set 0.5 to keep only chains covering at least
-        /// half the query (good for partitioning — filters out
-        /// fragment chains in repeat regions and speeds up hard tiles
-        /// dramatically).
+        /// dropped. Default 0.5 keeps locus-scale chains and prevents
+        /// isolated local homologies from being projected to the full
+        /// query. Set 0.0 for exploratory local-chain discovery.
         #[arg(help_heading = "Syng input")]
-        #[clap(long, value_parser, default_value_t = 0.0)]
+        #[clap(long, value_parser, default_value_t = 0.5)]
         syng_min_chain_fraction: f64,
 
         /// Drop this fraction of the query syncmer seed nodes with the
@@ -3016,6 +3014,14 @@ enum Args {
         #[arg(help_heading = "Syng input")]
         #[clap(long, value_parser, default_value_t = 0)]
         syng_seed_max_occurrences: u32,
+
+        /// Consecutive syncmers per bounded exact GBWT walk seed. Default
+        /// 5 prevents isolated high-copy syncmers from seeding ranges
+        /// while preserving sensitivity across divergent homologs. Set 3
+        /// for more sensitive, higher-volume seeds.
+        #[arg(help_heading = "Syng input")]
+        #[clap(long, value_parser, default_value_t = impg::syng::DEFAULT_WALK_SEED_ANCHORS)]
+        syng_seed_walk_anchors: usize,
 
         /// Debug-only: skip boundary realignment and emit raw syncmer-resolution
         /// intervals from syng's query_region. The default syng path runs
@@ -3975,6 +3981,7 @@ fn run() -> io::Result<()> {
             syng_min_chain_fraction,
             syng_seed_drop_top_fraction,
             syng_seed_max_occurrences,
+            syng_seed_walk_anchors,
             syng_raw,
             query,
             output_format,
@@ -4061,6 +4068,7 @@ fn run() -> io::Result<()> {
                     max_occurrences: (syng_seed_max_occurrences > 0)
                         .then_some(syng_seed_max_occurrences),
                     drop_top_fraction: syng_seed_drop_top_fraction,
+                    walk_anchors: syng_seed_walk_anchors.max(1),
                 };
 
                 // Parse target ranges

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -103,7 +103,7 @@ pub struct SampledPositionBuildStats {
 }
 
 pub const DEFAULT_POSITION_SAMPLE_RATE: u32 = 256;
-const DEFAULT_MEM_SEED_MIN_ANCHORS: usize = 2;
+pub const DEFAULT_WALK_SEED_ANCHORS: usize = 5;
 
 fn syng_sidecar_path(prefix: &str, suffix: &str) -> String {
     if prefix.ends_with(".syng") {
@@ -1482,6 +1482,11 @@ pub struct SyngSeedFilter {
     /// occurrence counts. Uses `floor(n * fraction)`, so small queries
     /// are not affected by tiny defaults such as 0.0005.
     pub drop_top_fraction: f64,
+    /// Number of consecutive query syncmers in each bounded exact GBWT
+    /// walk seed. Values >1 prevent single high-copy syncmers from
+    /// seeding candidate ranges while still allowing divergent homologs
+    /// to chain through short exact walks.
+    pub walk_anchors: usize,
 }
 
 impl Default for SyngSeedFilter {
@@ -1489,13 +1494,14 @@ impl Default for SyngSeedFilter {
         Self {
             max_occurrences: None,
             drop_top_fraction: 0.0,
+            walk_anchors: 1,
         }
     }
 }
 
 impl SyngSeedFilter {
     pub fn enabled(self) -> bool {
-        self.max_occurrences.is_some() || self.drop_top_fraction > 0.0
+        self.max_occurrences.is_some() || self.drop_top_fraction > 0.0 || self.walk_anchors > 1
     }
 }
 
@@ -4272,7 +4278,7 @@ impl SyngIndex {
         if seed_filter.enabled() && !unvisited_nodes.is_empty() {
             let mut occurrence_counts = Vec::with_capacity(unvisited_nodes.len());
             for &node in &unvisited_nodes {
-                let occurrences = self.syncmer_node_occurrence_count(node)?;
+                let occurrences = self.syncmer_node_orientation_counts(node)?.total();
                 max_seed_occurrences = max_seed_occurrences.max(occurrences);
                 occurrence_counts.push((node, occurrences));
             }
@@ -4315,7 +4321,8 @@ impl SyngIndex {
 
         let kept_seed_nodes = input_seed_nodes.saturating_sub(skipped_frequency);
         let kept_steps: usize = runs.iter().map(Vec::len).sum();
-        if kept_steps < DEFAULT_MEM_SEED_MIN_ANCHORS {
+        let walk_anchors = seed_filter.walk_anchors.max(1);
+        if kept_steps < walk_anchors {
             let mut query_node_positions: FxHashMap<u32, Vec<(u64, u8)>> = FxHashMap::default();
             for run in runs {
                 for step in run {
@@ -4337,29 +4344,31 @@ impl SyngIndex {
         let locate_start = std::time::Instant::now();
         let mut per_path: FxHashMap<(usize, char), Vec<HomologousIntervalWithAnchors>> =
             FxHashMap::default();
-        let mut mems_seen = 0u64;
-        let mut mems_kept = 0u64;
+        let mut seeds_seen = 0u64;
+        let mut seeds_kept = 0u64;
         let mut located_hits = 0u64;
         let mut emitted_anchors = 0u64;
         for run in &runs {
-            self.collect_mem_seed_hits_from_run(
+            self.collect_walk_seed_hits_from_run(
                 run,
                 '+',
                 padding,
+                walk_anchors,
                 &mut per_path,
-                &mut mems_seen,
-                &mut mems_kept,
+                &mut seeds_seen,
+                &mut seeds_kept,
                 &mut located_hits,
                 &mut emitted_anchors,
             )?;
             let reverse_run = self.reverse_query_run(run);
-            self.collect_mem_seed_hits_from_run(
+            self.collect_walk_seed_hits_from_run(
                 &reverse_run,
                 '-',
                 padding,
+                walk_anchors,
                 &mut per_path,
-                &mut mems_seen,
-                &mut mems_kept,
+                &mut seeds_seen,
+                &mut seeds_kept,
                 &mut located_hits,
                 &mut emitted_anchors,
             )?;
@@ -4380,16 +4389,17 @@ impl SyngIndex {
         });
         if emit_prof {
             eprintln!(
-                "EMITPROF mode=mem seed_nodes={} kept_seed_nodes={} skipped_visited={} skipped_frequency={} top_drop={} max_seed_occurrences={} runs={} mems={} kept_mems={} located_hits={} emit_anchors={} count={:.2}s locate={:.2}s lookup={:.2}s merge_sort={:.2}s",
+                "EMITPROF mode=bounded-mem seed_nodes={} kept_seed_nodes={} skipped_visited={} skipped_frequency={} top_drop={} max_seed_occurrences={} walk_anchors={} runs={} seeds={} kept_seeds={} located_hits={} emit_anchors={} count={:.2}s locate={:.2}s lookup={:.2}s merge_sort={:.2}s",
                 input_seed_nodes,
                 kept_seed_nodes,
                 skipped_visited,
                 skipped_frequency,
                 top_drop_count,
                 max_seed_occurrences,
+                walk_anchors,
                 runs.len(),
-                mems_seen,
-                mems_kept,
+                seeds_seen,
+                seeds_kept,
                 located_hits,
                 emitted_anchors,
                 count_elapsed.as_secs_f64(),
@@ -4420,50 +4430,76 @@ impl SyngIndex {
             .collect()
     }
 
+    fn match_walk_seed(&self, walk: &[SyngWalkStep]) -> io::Result<Option<(i32, u32, u32)>> {
+        let Some(first) = walk.first().copied() else {
+            return Ok(None);
+        };
+        let Some((sbp, mut low, mut high)) = self.start_gbwt_match(first.signed_node)? else {
+            return Ok(None);
+        };
+        for idx in 1..walk.len() {
+            let Some(offset) = Self::walk_step_offset(walk[idx - 1], walk[idx]) else {
+                unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+                return Ok(None);
+            };
+            if !self.advance_gbwt_match(sbp, &mut low, &mut high, walk[idx].signed_node, offset) {
+                unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+                return Ok(None);
+            }
+        }
+        unsafe { syng_ffi::syngBWTpathDestroy(sbp) };
+        Ok(Some((walk.last().unwrap().signed_node, low, high)))
+    }
+
     #[allow(clippy::too_many_arguments)]
-    fn collect_mem_seed_hits_from_run(
+    fn collect_walk_seed_hits_from_run(
         &self,
         run: &[QueryWalkStep],
         strand: char,
         padding: u64,
+        walk_anchors: usize,
         per_path: &mut FxHashMap<(usize, char), Vec<HomologousIntervalWithAnchors>>,
-        mems_seen: &mut u64,
-        mems_kept: &mut u64,
+        seeds_seen: &mut u64,
+        seeds_kept: &mut u64,
         located_hits: &mut u64,
         emitted_anchors: &mut u64,
     ) -> io::Result<()> {
-        if run.len() < DEFAULT_MEM_SEED_MIN_ANCHORS {
+        if run.len() < walk_anchors {
             return Ok(());
         }
         let syncmer_len = self.syncmer_length_bp() as u64;
-        let walk: Vec<SyngWalkStep> = run
-            .iter()
-            .map(|step| SyngWalkStep {
-                signed_node: step.signed_node,
-                bp_pos: step.bp_pos,
-            })
-            .collect();
-        let mems = self.gbwt_mems_for_walk(&walk)?;
-        *mems_seen += mems.len() as u64;
-        for mem in mems {
-            if mem.anchors < DEFAULT_MEM_SEED_MIN_ANCHORS {
+        for seed_start in (0..=run.len() - walk_anchors).step_by(walk_anchors) {
+            let seed_end = seed_start + walk_anchors;
+            *seeds_seen += 1;
+            let walk: Vec<SyngWalkStep> = run[seed_start..seed_end]
+                .iter()
+                .map(|step| SyngWalkStep {
+                    signed_node: step.signed_node,
+                    bp_pos: step.bp_pos,
+                })
+                .collect();
+            let Some((match_signed_node, match_low, match_high)) = self.match_walk_seed(&walk)?
+            else {
+                continue;
+            };
+            if match_low >= match_high {
                 continue;
             }
-            *mems_kept += 1;
+            *seeds_kept += 1;
             let hits = self.locate_signed_node_occurrence_range(
-                mem.match_signed_node,
-                mem.match_low,
-                mem.match_high,
+                match_signed_node,
+                match_low,
+                match_high,
             )?;
-            let first_step = &run[mem.step_start];
-            let last_step = &run[mem.step_end - 1];
-            let mem_span = last_step.bp_pos.saturating_sub(first_step.bp_pos);
+            let first_step = &run[seed_start];
+            let last_step = &run[seed_end - 1];
+            let seed_span = last_step.bp_pos.saturating_sub(first_step.bp_pos);
             for hit in hits {
                 *located_hits += 1;
                 if hit.path_idx >= self.name_map.path_to_name.len() {
                     continue;
                 }
-                let Some(target_start) = hit.target_pos.checked_sub(mem_span) else {
+                let Some(target_start) = hit.target_pos.checked_sub(seed_span) else {
                     continue;
                 };
                 let genome_len = self.name_map.path_to_length[hit.path_idx];
@@ -4473,8 +4509,8 @@ impl SyngIndex {
                 if padded_start >= padded_end {
                     continue;
                 }
-                let mut anchors = Vec::with_capacity(mem.anchors);
-                for step in &run[mem.step_start..mem.step_end] {
+                let mut anchors = Vec::with_capacity(walk_anchors);
+                for step in &run[seed_start..seed_end] {
                     let rel = step.bp_pos.saturating_sub(first_step.bp_pos);
                     anchors.push(Anchor {
                         query_pos: step.query_pos,
@@ -5114,6 +5150,67 @@ mod tests {
                 .all(|mem| mem.step_start != 0 || mem.step_end != shifted.len()),
             "changing a syncmer offset must break the full-length GBWT MEM: {:?}",
             shifted_mems
+        );
+    }
+
+    #[test]
+    fn test_bounded_walk_seeds_recover_divergent_homolog_under_long_self_mem() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let seq_a = make_test_sequence(6000, 91);
+        let mut seq_b = seq_a.clone();
+        for pos in (300..5700).step_by(600) {
+            seq_b[pos] = match seq_b[pos] {
+                b'A' => b'C',
+                b'C' => b'G',
+                b'G' => b'T',
+                b'T' => b'A',
+                other => other,
+            };
+        }
+        let index = SyngIndex::build(
+            params,
+            vec![
+                ("genome_a".to_string(), seq_a.clone()),
+                ("genome_b".to_string(), seq_b),
+            ]
+            .into_iter(),
+        );
+
+        let mut matches = index.matched_syncmers_in_sequence(&seq_a);
+        matches.sort_unstable_by_key(|sm| sm.query_pos);
+        let walk: Vec<_> = matches
+            .iter()
+            .map(|sm| SyngWalkStep {
+                signed_node: sm.signed_node,
+                bp_pos: sm.query_pos,
+            })
+            .collect();
+        let mems = index.gbwt_mems_for_walk(&walk).unwrap();
+        assert!(
+            mems.iter().any(|mem| mem.step_start == 0 && mem.step_end == walk.len()),
+            "self path should produce a long maximal MEM that would hide shorter homolog seeds: {:?}",
+            mems
+        );
+
+        let hits = index
+            .query_region_with_anchors_ext_seed_filtered(
+                "genome_a",
+                0,
+                seq_a.len() as u64,
+                0,
+                0,
+                SyngSeedFilter {
+                    max_occurrences: None,
+                    drop_top_fraction: 0.0005,
+                    walk_anchors: 3,
+                },
+            )
+            .unwrap();
+        assert!(
+            hits.iter().any(|hit| hit.genome == "genome_b"),
+            "bounded 3-syncmer walk seeds should recover the divergent homolog; hits: {:?}",
+            hits
         );
     }
 
@@ -7241,6 +7338,11 @@ mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let lines: Vec<&str> = stdout.lines().collect();
         assert!(!lines.is_empty(), "BED output should not be empty");
+        assert!(
+            lines.iter().all(|line| line.split('\t').count() >= 6),
+            "BED stdout should contain only BED records, not native diagnostics. Got:\n{}",
+            stdout
+        );
 
         // Should find genome_b in the output
         let has_genome_b = lines.iter().any(|l| l.starts_with("genome_b\t"));

--- a/src/syng_transitive.rs
+++ b/src/syng_transitive.rs
@@ -77,15 +77,35 @@ where
 ///
 /// Replaces the older O(N²) mutual-best-buddy + union-find pipeline.
 /// Algorithmic budget per bucket: O(N × active_chains). On realistic
-/// inputs, active_chains stays bounded (tens to low hundreds even in
-/// repeat-dense regions), so the effective cost is O(N × small).
-///
-/// Caps are derived from `extend_budget` only — tile size does not
-/// leak into chain shape or projection endpoints.
 pub fn chain_anchors(
     hits: Vec<HomologousIntervalWithAnchors>,
     extend_budget: u64,
     syncmer_len: u64,
+) -> Vec<HomologousIntervalWithAnchors> {
+    let max_query_hop = extend_budget.saturating_mul(3).max(extend_budget);
+    let drift_per_hop = extend_budget;
+    let max_chain_span = extend_budget.saturating_mul(10).max(extend_budget);
+    chain_anchors_with_limits(
+        hits,
+        syncmer_len,
+        max_query_hop,
+        drift_per_hop,
+        max_chain_span,
+    )
+}
+
+/// Collinear-chain shared syncmer anchors per `(target path, strand)`.
+///
+/// `max_query_hop` and `drift_per_hop` are deliberately explicit. Endpoint
+/// refinement budget and chain gap are different concepts: a query over a
+/// large bubble can need far-apart flanking anchors in the same chain while
+/// still using a much smaller base-alignment window at each boundary.
+pub fn chain_anchors_with_limits(
+    hits: Vec<HomologousIntervalWithAnchors>,
+    syncmer_len: u64,
+    max_query_hop: u64,
+    drift_per_hop: u64,
+    max_chain_span: u64,
 ) -> Vec<HomologousIntervalWithAnchors> {
     if hits.is_empty() {
         return hits;
@@ -100,17 +120,9 @@ pub fn chain_anchors(
             .extend(h.anchors.into_iter());
     }
 
-    // Per-hop signature drift tolerance: scaled to the extension
-    // budget. Absorbs real indels (incl. TE/MEI) up to this size in
-    // one hop. Cross-paralog jumps with period > budget stay distinct.
-    let drift_per_hop: i64 = extend_budget.min(i64::MAX as u64) as i64;
-    // Max query-axis hop between consecutive anchors in a chain:
-    // 3 × budget admits normal repeat density plus some slop. Beyond
-    // this, the chain is stale and gets finalized.
-    let max_hop = extend_budget.saturating_mul(3).max(extend_budget);
-    // Chain-total target span cap — same as before, ensures stacked
-    // small drifts don't assemble unbounded target extent.
-    let max_chain_span = extend_budget.saturating_mul(10).max(extend_budget);
+    let drift_per_hop: i64 = drift_per_hop.min(i64::MAX as u64) as i64;
+    let max_hop = max_query_hop.max(syncmer_len);
+    let max_chain_span = max_chain_span.max(syncmer_len);
 
     fn anchor_sig(a: &Anchor, strand: char) -> i64 {
         match strand {
@@ -848,7 +860,24 @@ pub fn one_hop_ext_visited_with_seed_filter(
     let query_range_len = query_end.saturating_sub(query_start);
     let t1 = Instant::now();
     let total_anchors: usize = hits.iter().map(|h| h.anchors.len()).sum();
-    let hits = chain_anchors(hits, extend_budget, syncmer_len);
+    let chain_gap = query_range_len
+        .saturating_add(extend_budget)
+        .max(extend_budget.saturating_mul(3))
+        .max(syncmer_len);
+    let drift_budget = query_range_len
+        .saturating_add(extend_budget)
+        .max(extend_budget);
+    let target_span_cap = query_range_len
+        .saturating_add(extend_budget.saturating_mul(2))
+        .max(extend_budget.saturating_mul(10))
+        .max(syncmer_len);
+    let hits = chain_anchors_with_limits(
+        hits,
+        syncmer_len,
+        chain_gap,
+        drift_budget,
+        target_span_cap,
+    );
     let pre_filter = hits.len();
     // Filter chains by anchor count. Default min=2 drops singletons
     // (one-anchor chains with no mutual-best colinear partner — mostly
@@ -888,7 +917,7 @@ pub fn one_hop_ext_visited_with_seed_filter(
         .collect();
     if prof {
         eprintln!(
-            "PROF chain_anchors={:?} total_anchors={} chains={} after_filter={} (min_anchors={} eff={} min_frac={} min_bp={})",
+            "PROF chain_anchors={:?} total_anchors={} chains={} after_filter={} (min_anchors={} eff={} min_frac={} min_bp={} chain_gap={} drift={} span_cap={})",
             t1.elapsed(),
             total_anchors,
             pre_filter,
@@ -897,6 +926,9 @@ pub fn one_hop_ext_visited_with_seed_filter(
             effective_min,
             min_chain_fraction,
             min_chain_extent_bp,
+            chain_gap,
+            drift_budget,
+            target_span_cap,
         );
     }
     let t2 = Instant::now();
@@ -1417,6 +1449,28 @@ mod tests {
         }];
         let out = chain_anchors(hits, 1_000, TEST_SYNCMER_LEN);
         assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn chain_anchors_with_limits_can_span_large_bubble_flanks() {
+        let hits = vec![HomologousIntervalWithAnchors {
+            genome: "g".into(),
+            start: 0,
+            end: 90_000,
+            strand: '+',
+            anchors: vec![mk_anchor(0, 0), mk_anchor(80_000, 80_000)],
+        }];
+        let out = chain_anchors_with_limits(
+            hits,
+            TEST_SYNCMER_LEN,
+            90_000,
+            90_000,
+            90_000,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].anchors.len(), 2);
+        assert_eq!(out[0].start, 0);
+        assert_eq!(out[0].end, 80_000 + TEST_SYNCMER_LEN);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace syng query's maximal-MEM-only seeding with bounded exact GBWT walk seeds (`--syng-seed-walk-anchors`, default 5)
- make syng query's default chain filter locus-scale (`--syng-min-chain-fraction 0.5`) so isolated local repeat hits do not project to the full query interval
- separate query-scale chain gap/drift/span limits from the boundary realignment extension budget
- move syng native GBWT load diagnostics to stderr and add a stdout-cleanliness regression for BED output
- advance the `vendor/syng` submodule to `68ac197` (`pangenome/syng:fix/gbwt-load-diagnostics-stderr`)

## Validation

- `cargo test --lib -- --nocapture` -> 197 passed
- `cargo test --test test_syng_integration -- --nocapture` -> 23 passed
- `cargo build --release`
- HPRCv2 C4A/C4B smoke query:
  - command used `SYNG_EMIT_PROFILE=1 SYNG_PROFILE=1 target/release/impg query -a HPRC_r2_assemblies_0.6.1.syng -r 'CHM13#0#chr6 CP068272.2 Homo sapiens isolate CHM13 chromosome 6:31972057-32055418' --sequence-files HPRC_r2_assemblies_0.6.1.agc -o bed -d 10000`
  - profile: 1,510 bounded seeds, 361,078 located hits, 1,805,390 anchors, 43,296 chains, 466 chains after chain-fraction filter, 466 refined intervals before final merge
  - final output: 465 merged intervals, 465 unique sequence names, mean length 83,354.93 bp, min 83,284, max 83,402
  - stdout contained no `read GBWT` native diagnostic
