### PR TITLE
Use query merge distance during syng transitive search

### DIFF
--- a/scripts/hprcv2-syng-smoke.py
+++ b/scripts/hprcv2-syng-smoke.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Run a syng query smoke panel against the local HPRCv2 index.
+
+The panel is intentionally mixed: short windows, ordinary genic windows,
+SV-rich immune/CNV loci, subtelomeric windows, and small satellite-proximal
+windows. The goal is not truth-set validation; it is a broad "do not drop
+everything, do not explode, do not run forever" smoke test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_PREFIX = "HPRC_r2_assemblies_0.6.1.syng"
+DEFAULT_AGC = "HPRC_r2_assemblies_0.6.1.agc"
+
+
+PANEL = [
+    ("boring_chr1_100kb", "boring", "CHM13", "chr1", 100_000_000, 100_100_000),
+    ("boring_chr6_100kb", "boring", "CHM13", "chr6", 50_000_000, 50_100_000),
+    ("short_chr1_250bp", "short", "CHM13", "chr1", 100_000_000, 100_000_250),
+    ("short_chr1_1kb", "short", "CHM13", "chr1", 100_000_000, 100_001_000),
+    ("c4_grch38_53kb", "c4_rccx", "GRCh38", "chr6", 31_982_056, 32_035_418),
+    ("c4_chm13_83kb", "c4_rccx", "CHM13", "chr6", 31_972_057, 32_055_418),
+    ("c4_rccx_400kb", "c4_rccx", "CHM13", "chr6", 31_850_000, 32_250_000),
+    ("mhc_class_i_100kb", "immune", "CHM13", "chr6", 30_000_000, 30_100_000),
+    ("hla_dq_100kb", "immune", "CHM13", "chr6", 33_500_000, 33_600_000),
+    ("lpa_100kb", "cnv_vntr", "CHM13", "chr6", 160_450_000, 160_550_000),
+    ("amy_100kb", "cnv", "CHM13", "chr1", 103_500_000, 103_600_000),
+    ("fcgr_100kb", "immune_cnv", "CHM13", "chr1", 161_450_000, 161_550_000),
+    ("rhd_rhce_100kb", "immune_sv", "CHM13", "chr1", 25_200_000, 25_300_000),
+    ("kir_100kb", "immune_cnv", "CHM13", "chr19", 54_500_000, 54_600_000),
+    ("mapt_17q21_100kb", "inversion", "CHM13", "chr17", 45_000_000, 45_100_000),
+    ("chr8p23_100kb", "inversion", "CHM13", "chr8", 12_000_000, 12_100_000),
+    ("subtel_chr1_p_50kb", "subtelomere", "CHM13", "chr1", 10_000, 60_000),
+    ("subtel_chr1_q_50kb", "subtelomere", "CHM13", "chr1", 248_300_000, 248_350_000),
+    ("peri_cen_chr1_50kb", "pericentromere", "CHM13", "chr1", 130_000_000, 130_050_000),
+    ("peri_cen_chr6_50kb", "pericentromere", "CHM13", "chr6", 60_000_000, 60_050_000),
+    ("sat_chr8_10kb", "satellite", "CHM13", "chr8", 45_000_000, 45_010_000),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hprcv2-dir", default="/home/erikg/hprcv2")
+    parser.add_argument("--prefix", default=DEFAULT_PREFIX)
+    parser.add_argument("--agc", default=DEFAULT_AGC)
+    parser.add_argument("--impg", default=str(Path.home() / ".cargo/bin/impg"))
+    parser.add_argument("--out-dir", default="/home/erikg/hprcv2/smoke/syng_query_panel")
+    parser.add_argument("--timeout", type=int, default=3600)
+    parser.add_argument("--merge-distance", type=int, default=10_000)
+    parser.add_argument("--syng-extension", type=int, default=0)
+    parser.add_argument("--syng-extend-budget", type=int, default=1_000)
+    parser.add_argument("--syng-seed-walk-anchors", type=int, default=5)
+    parser.add_argument("--syng-min-chain-fraction", type=float, default=0.5)
+    parser.add_argument("--limit", type=int, default=0, help="Run only the first N panel rows")
+    parser.add_argument("--raw", action="store_true", help="Use --syng-raw")
+    return parser.parse_args()
+
+
+def load_pansn_name_map(names_path: Path) -> dict[tuple[str, str], str]:
+    mapping: dict[tuple[str, str], str] = {}
+    with names_path.open() as handle:
+        for line in handle:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            full = parts[1]
+            short = full.split(" ", 1)[0]
+            pansn = short.split("#", 2)
+            if len(pansn) == 3:
+                sample, _hap, chrom = pansn
+                mapping[(sample, chrom)] = full
+    return mapping
+
+
+def quantile(values: list[int], frac: float) -> int:
+    if not values:
+        return 0
+    idx = int((len(values) - 1) * frac)
+    return values[idx]
+
+
+def parse_bed(output_bed: Path) -> dict[str, list[tuple[str, int]]]:
+    by_label: dict[str, list[tuple[str, int]]] = {}
+    with output_bed.open() as handle:
+        for line in handle:
+            if not line.strip() or line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 4:
+                by_label.setdefault("__malformed__", []).append((line.rstrip("\n"), 0))
+                continue
+            try:
+                start = int(fields[1])
+                end = int(fields[2])
+            except ValueError:
+                by_label.setdefault("__malformed__", []).append((line.rstrip("\n"), 0))
+                continue
+            by_label.setdefault(fields[3], []).append((fields[0], max(0, end - start)))
+    return by_label
+
+
+def parse_profiles(stderr_path: Path) -> dict[str, dict[str, str]]:
+    profiles: dict[str, dict[str, str]] = {}
+    current = None
+    key_value = re.compile(r"([a-zA-Z_]+)=([^ )]+)")
+    with stderr_path.open() as handle:
+        for line in handle:
+            if "Syng query:" in line:
+                current = line.split("Syng query:", 1)[1].split(" (", 1)[0].strip()
+                profiles.setdefault(current, {})
+            elif current and ("EMITPROF" in line or "PROF chain_anchors" in line):
+                bucket = profiles.setdefault(current, {})
+                for key, value in key_value.findall(line):
+                    bucket[key] = value
+    return profiles
+
+
+def main() -> int:
+    args = parse_args()
+    hprcv2 = Path(args.hprcv2_dir)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    prefix = hprcv2 / args.prefix
+    agc = hprcv2 / args.agc
+    names_path = hprcv2 / f"{args.prefix}.names"
+    if not names_path.exists():
+        print(f"missing names file: {names_path}", file=sys.stderr)
+        return 2
+
+    name_map = load_pansn_name_map(names_path)
+    rows = PANEL[: args.limit] if args.limit else PANEL
+    panel_bed = out_dir / "panel.bed"
+    panel_meta = out_dir / "panel.meta.tsv"
+    with panel_bed.open("w") as bed, panel_meta.open("w") as meta:
+        meta.write("label\tcategory\tsample\tchrom\tstart\tend\tquery_len\tfull_name\n")
+        for label, category, sample, chrom, start, end in rows:
+            full = name_map.get((sample, chrom))
+            if full is None:
+                raise RuntimeError(f"No syng name found for {sample} {chrom}")
+            bed.write(f"{full}\t{start}\t{end}\t{label}\n")
+            meta.write(
+                f"{label}\t{category}\t{sample}\t{chrom}\t{start}\t{end}\t{end-start}\t{full}\n"
+            )
+
+    output_bed = out_dir / ("panel.raw.bed" if args.raw else "panel.refined.bed")
+    stderr_log = out_dir / ("panel.raw.stderr" if args.raw else "panel.refined.stderr")
+    summary_tsv = out_dir / ("panel.raw.summary.tsv" if args.raw else "panel.refined.summary.tsv")
+
+    cmd = [
+        args.impg,
+        "query",
+        "-a",
+        str(prefix),
+        "-b",
+        str(panel_bed),
+        "--sequence-files",
+        str(agc),
+        "-o",
+        "bed",
+        "-d",
+        str(args.merge_distance),
+        "--syng-extension",
+        str(args.syng_extension),
+        "--syng-extend-budget",
+        str(args.syng_extend_budget),
+        "--syng-seed-walk-anchors",
+        str(args.syng_seed_walk_anchors),
+        "--syng-min-chain-fraction",
+        str(args.syng_min_chain_fraction),
+    ]
+    if args.raw:
+        cmd.append("--syng-raw")
+
+    env = os.environ.copy()
+    env["SYNG_PROFILE"] = "1"
+    env["SYNG_EMIT_PROFILE"] = "1"
+    started = time.time()
+    with output_bed.open("w") as stdout, stderr_log.open("w") as stderr:
+        proc = subprocess.run(
+            cmd,
+            cwd=hprcv2,
+            env=env,
+            stdout=stdout,
+            stderr=stderr,
+            timeout=args.timeout,
+            check=False,
+            text=True,
+        )
+    elapsed = time.time() - started
+    if proc.returncode != 0:
+        print(f"query failed with exit code {proc.returncode}; see {stderr_log}", file=sys.stderr)
+        return proc.returncode
+
+    by_label = parse_bed(output_bed)
+    profiles = parse_profiles(stderr_log)
+    stdout_has_diag = "read GBWT" in output_bed.read_text(errors="replace")
+    with summary_tsv.open("w") as out:
+        out.write(
+            "label\tcategory\tquery_len\tn\tunique_targets\tmin\tp05\tmedian\tp95\tmax\tmean"
+            "\tseeds\tlocated_hits\tchains\tafter_filter\tspan_cap\tstdout_has_diag\n"
+        )
+        for label, category, _sample, _chrom, start, end in rows:
+            hits = by_label.get(label, [])
+            lengths = sorted(length for _target, length in hits)
+            targets = {target for target, _length in hits}
+            prof = profiles.get(label, {})
+            mean = f"{statistics.fmean(lengths):.2f}" if lengths else "0"
+            out.write(
+                f"{label}\t{category}\t{end-start}\t{len(lengths)}\t{len(targets)}"
+                f"\t{lengths[0] if lengths else 0}"
+                f"\t{quantile(lengths, 0.05)}"
+                f"\t{quantile(lengths, 0.50)}"
+                f"\t{quantile(lengths, 0.95)}"
+                f"\t{lengths[-1] if lengths else 0}"
+                f"\t{mean}"
+                f"\t{prof.get('seeds', '')}"
+                f"\t{prof.get('located_hits', '')}"
+                f"\t{prof.get('chains', '')}"
+                f"\t{prof.get('after_filter', '')}"
+                f"\t{prof.get('span_cap', '')}"
+                f"\t{int(stdout_has_diag)}\n"
+            )
+
+    print(f"elapsed_seconds\t{elapsed:.2f}")
+    print(f"panel_bed\t{panel_bed}")
+    print(f"output_bed\t{output_bed}")
+    print(f"stderr_log\t{stderr_log}")
+    print(f"summary_tsv\t{summary_tsv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main.rs
+++ b/src/main.rs
@@ -4198,6 +4198,7 @@ fn run() -> io::Result<()> {
                                     syng_min_chain_anchors,
                                     syng_min_chain_fraction,
                                     syng_seed_filter,
+                                    query.effective_merge_distance(),
                                     sequence_index.as_ref().unwrap(),
                                 )?
                             } else {
@@ -4276,6 +4277,7 @@ fn run() -> io::Result<()> {
                                             syng_min_chain_anchors,
                                             syng_min_chain_fraction,
                                             syng_seed_filter,
+                                            query.effective_merge_distance(),
                                             sequence_index.as_ref().unwrap(),
                                         )?
                                     } else {
@@ -4330,6 +4332,7 @@ fn run() -> io::Result<()> {
                                         syng_min_chain_anchors,
                                         syng_min_chain_fraction,
                                         syng_seed_filter,
+                                        query.effective_merge_distance(),
                                         sequence_index.as_ref().unwrap(),
                                     )?
                                 } else {
@@ -4375,6 +4378,7 @@ fn run() -> io::Result<()> {
                                     syng_min_chain_anchors,
                                     syng_min_chain_fraction,
                                     syng_seed_filter,
+                                    query.effective_merge_distance(),
                                     seq_idx,
                                 )?
                             } else {
@@ -4403,6 +4407,7 @@ fn run() -> io::Result<()> {
                                     syng_min_chain_anchors,
                                     syng_min_chain_fraction,
                                     syng_seed_filter,
+                                    query.effective_merge_distance(),
                                     seq_idx,
                                 )?
                             } else {

--- a/src/syng_transitive.rs
+++ b/src/syng_transitive.rs
@@ -236,6 +236,38 @@ pub fn chain_anchors_with_limits(
     out
 }
 
+fn query_scaled_chain_limits(
+    query_range_len: u64,
+    extend_budget: u64,
+    syncmer_len: u64,
+    merge_distance: i32,
+) -> (u64, u64, u64) {
+    let merge_gap = merge_distance.max(0) as u64;
+    let chain_slop = extend_budget.max(merge_gap);
+    let chain_gap = query_range_len
+        .saturating_add(chain_slop)
+        .max(extend_budget.saturating_mul(3))
+        .max(syncmer_len);
+    let drift_budget = query_range_len
+        .saturating_add(chain_slop)
+        .max(chain_slop)
+        .max(syncmer_len);
+    // Boundary realignment budget is not an SV-size budget. Keep the target
+    // span cap query-scaled so large insertions, deletions, and local copy
+    // changes can survive chaining. The user merge distance is also part of
+    // the same semantic gap model, so it participates here before refinement
+    // and before the next transitive hop.
+    let sv_span_slop = query_range_len
+        .saturating_mul(3)
+        .max(50_000)
+        .max(extend_budget.saturating_mul(10))
+        .max(merge_gap);
+    let target_span_cap = query_range_len
+        .saturating_add(sv_span_slop)
+        .max(syncmer_len);
+    (chain_gap, drift_budget, target_span_cap)
+}
+
 /// Linear projection from an anchor to a query position — coordinate
 /// arithmetic only. Used as a fallback when pairwise alignment is
 /// unavailable.
@@ -817,6 +849,7 @@ pub fn one_hop_ext_visited(
         min_chain_fraction,
         visited_nodes,
         SyngSeedFilter::default(),
+        -1,
         sequence_index,
     )
 }
@@ -835,6 +868,7 @@ pub fn one_hop_ext_visited_with_seed_filter(
     min_chain_fraction: f64,
     visited_nodes: Option<&mut FxHashSet<u32>>,
     seed_filter: SyngSeedFilter,
+    merge_distance: i32,
     sequence_index: &UnifiedSequenceIndex,
 ) -> io::Result<Vec<HomologousInterval>> {
     use std::time::Instant;
@@ -860,17 +894,8 @@ pub fn one_hop_ext_visited_with_seed_filter(
     let query_range_len = query_end.saturating_sub(query_start);
     let t1 = Instant::now();
     let total_anchors: usize = hits.iter().map(|h| h.anchors.len()).sum();
-    let chain_gap = query_range_len
-        .saturating_add(extend_budget)
-        .max(extend_budget.saturating_mul(3))
-        .max(syncmer_len);
-    let drift_budget = query_range_len
-        .saturating_add(extend_budget)
-        .max(extend_budget);
-    let target_span_cap = query_range_len
-        .saturating_add(extend_budget.saturating_mul(2))
-        .max(extend_budget.saturating_mul(10))
-        .max(syncmer_len);
+    let (chain_gap, drift_budget, target_span_cap) =
+        query_scaled_chain_limits(query_range_len, extend_budget, syncmer_len, merge_distance);
     let hits = chain_anchors_with_limits(
         hits,
         syncmer_len,
@@ -1189,6 +1214,7 @@ pub fn query_transitive_ext(
         min_chain_anchors,
         min_chain_fraction,
         SyngSeedFilter::default(),
+        -1,
         sequence_index,
     )
 }
@@ -1208,6 +1234,7 @@ pub fn query_transitive_ext_with_seed_filter(
     min_chain_anchors: usize,
     min_chain_fraction: f64,
     seed_filter: SyngSeedFilter,
+    merge_distance: i32,
     sequence_index: &UnifiedSequenceIndex,
 ) -> io::Result<Vec<HomologousInterval>> {
     let mut visited: FxHashSet<(String, u64, u64, char)> = FxHashSet::default();
@@ -1243,6 +1270,7 @@ pub fn query_transitive_ext_with_seed_filter(
                 min_chain_fraction,
                 Some(&mut visited_nodes),
                 seed_filter,
+                merge_distance,
                 sequence_index,
             ) {
                 Ok(h) => h,
@@ -1254,6 +1282,7 @@ pub fn query_transitive_ext_with_seed_filter(
                     continue;
                 }
             };
+            let hits = merge_nearby_on_same_path(hits, merge_distance);
             for hit in hits {
                 let key = (hit.genome.clone(), hit.start, hit.end, hit.strand);
                 if visited.insert(key) {
@@ -1265,18 +1294,27 @@ pub fn query_transitive_ext_with_seed_filter(
         frontier = next_frontier;
     }
 
-    Ok(merge_overlapping_on_same_path(all_hits))
+    Ok(merge_nearby_on_same_path(all_hits, merge_distance))
 }
 
-/// Collapse strictly overlapping intervals that share the same
+/// Collapse nearby intervals that share the same
 /// `(genome, strand)`. Different transitive paths can reach the same
 /// homolog and produce intervals that differ by a few bp at the boundaries
 /// (BiWFA refinement is not idempotent across hop depths), leaving tens of
-/// near-duplicate rows per haplotype for a single query. Strictly touching
-/// or gapped intervals are *not* merged — those represent genuinely adjacent
-/// homologs (e.g. tandem arrays) that should stay separate.
-fn merge_overlapping_on_same_path(hits: Vec<HomologousInterval>) -> Vec<HomologousInterval> {
+/// near-duplicate rows per haplotype for a single query.
+///
+/// `merge_distance` is the user's `-d` query gap model. With `-d >= 0`, merge
+/// same-path intervals separated by at most that many bp before the next
+/// transitive hop. With `--no-merge` (`merge_distance < 0`), preserve the
+/// historical strict-overlap collapse used only to remove duplicate hits.
+fn merge_nearby_on_same_path(
+    hits: Vec<HomologousInterval>,
+    merge_distance: i32,
+) -> Vec<HomologousInterval> {
     use std::collections::HashMap;
+    let prof = std::env::var("SYNG_PROFILE").is_ok();
+    let input_count = hits.len();
+    let gap = merge_distance.max(0) as u64;
     // Merging loses CIGAR alignment context since merged coordinates
     // don't map back to either source CIGAR. Group by (genome, strand)
     // with (start, end, cigar); if exactly one entry ends up unmerged
@@ -1289,15 +1327,32 @@ fn merge_overlapping_on_same_path(hits: Vec<HomologousInterval>) -> Vec<Homologo
             .push((h.start, h.end, h.cigar));
     }
     let mut out: Vec<HomologousInterval> = Vec::new();
+    let mut merged_groups = 0usize;
+    let mut merge_examples: Vec<String> = Vec::new();
     for ((genome, strand), mut ivs) in groups {
+        let group_input_count = ivs.len();
         ivs.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
         let mut iter = ivs.into_iter();
         let Some(mut cur) = iter.next() else {
             continue;
         };
+        let mut group_output_count = 0usize;
         let mut cur_merged = false;
+        let mut group_example_parts: Vec<String> = if prof && group_input_count > 1 {
+            vec![format!("{}({}):", genome, strand)]
+        } else {
+            Vec::new()
+        };
         for next in iter {
-            if next.0 < cur.1 {
+            let should_merge = if merge_distance >= 0 {
+                next.0 <= cur.1.saturating_add(gap)
+            } else {
+                next.0 < cur.1
+            };
+            if should_merge {
+                if prof && merge_examples.len() < 20 {
+                    group_example_parts.push(format!("{}-{}~{}-{}", cur.0, cur.1, next.0, next.1));
+                }
                 if next.1 > cur.1 {
                     cur.1 = next.1;
                 }
@@ -1310,6 +1365,7 @@ fn merge_overlapping_on_same_path(hits: Vec<HomologousInterval>) -> Vec<Homologo
                     strand,
                     cigar: if cur_merged { None } else { cur.2.take() },
                 });
+                group_output_count += 1;
                 cur = next;
                 cur_merged = false;
             }
@@ -1321,6 +1377,13 @@ fn merge_overlapping_on_same_path(hits: Vec<HomologousInterval>) -> Vec<Homologo
             strand,
             cigar: if cur_merged { None } else { cur.2 },
         });
+        group_output_count += 1;
+        if group_output_count < group_input_count {
+            merged_groups += 1;
+            if prof && merge_examples.len() < 20 {
+                merge_examples.push(group_example_parts.join(" "));
+            }
+        }
     }
     out.sort_by(|a, b| {
         a.genome
@@ -1329,6 +1392,16 @@ fn merge_overlapping_on_same_path(hits: Vec<HomologousInterval>) -> Vec<Homologo
             .then(a.end.cmp(&b.end))
             .then(a.strand.cmp(&b.strand))
     });
+    if prof {
+        eprintln!(
+            "PROF merge_same_path input={} output={} merged_groups={} gap={} examples={}",
+            input_count,
+            out.len(),
+            merged_groups,
+            merge_distance,
+            merge_examples.join(" | ")
+        );
+    }
     out
 }
 
@@ -1471,6 +1544,109 @@ mod tests {
         assert_eq!(out[0].anchors.len(), 2);
         assert_eq!(out[0].start, 0);
         assert_eq!(out[0].end, 80_000 + TEST_SYNCMER_LEN);
+    }
+
+    #[test]
+    fn query_scaled_chain_limits_do_not_treat_alignment_budget_as_sv_budget() {
+        let query_len = 83_361;
+        let extend_budget = 1_000;
+        let (_gap, _drift, span_cap) =
+            query_scaled_chain_limits(query_len, extend_budget, TEST_SYNCMER_LEN, 10_000);
+        assert!(
+            span_cap > query_len + 100_000,
+            "C4-scale queries need enough target span to retain local CNV/SV alleles"
+        );
+        assert!(
+            span_cap > query_len + extend_budget * 2,
+            "the boundary realignment budget must not cap target SV span"
+        );
+    }
+
+    #[test]
+    fn query_scaled_chain_limits_use_merge_distance_before_refinement() {
+        let query_len = 1_000;
+        let extend_budget = 100;
+        let merge_distance = 10_000;
+        let (gap, drift, span_cap) = query_scaled_chain_limits(
+            query_len,
+            extend_budget,
+            TEST_SYNCMER_LEN,
+            merge_distance,
+        );
+        assert!(
+            gap >= query_len + merge_distance as u64,
+            "-d should widen the pre-refinement chain gap"
+        );
+        assert!(
+            drift >= query_len + merge_distance as u64,
+            "-d should widen the pre-refinement drift budget"
+        );
+        assert!(
+            span_cap >= query_len + merge_distance as u64,
+            "-d should contribute to the pre-refinement target span cap"
+        );
+    }
+
+    #[test]
+    fn merge_nearby_on_same_path_uses_user_gap_distance() {
+        let hits = vec![
+            HomologousInterval {
+                genome: "g".into(),
+                start: 0,
+                end: 100,
+                strand: '+',
+                cigar: None,
+            },
+            HomologousInterval {
+                genome: "g".into(),
+                start: 150,
+                end: 220,
+                strand: '+',
+                cigar: None,
+            },
+            HomologousInterval {
+                genome: "g".into(),
+                start: 400,
+                end: 500,
+                strand: '+',
+                cigar: None,
+            },
+        ];
+        let out = merge_nearby_on_same_path(hits, 50);
+        assert_eq!(out.len(), 2);
+        assert_eq!((out[0].start, out[0].end), (0, 220));
+        assert_eq!((out[1].start, out[1].end), (400, 500));
+    }
+
+    #[test]
+    fn merge_nearby_on_same_path_no_merge_keeps_gapped_intervals() {
+        let hits = vec![
+            HomologousInterval {
+                genome: "g".into(),
+                start: 0,
+                end: 100,
+                strand: '+',
+                cigar: None,
+            },
+            HomologousInterval {
+                genome: "g".into(),
+                start: 100,
+                end: 200,
+                strand: '+',
+                cigar: None,
+            },
+            HomologousInterval {
+                genome: "g".into(),
+                start: 190,
+                end: 250,
+                strand: '+',
+                cigar: None,
+            },
+        ];
+        let out = merge_nearby_on_same_path(hits, -1);
+        assert_eq!(out.len(), 2);
+        assert_eq!((out[0].start, out[0].end), (0, 100));
+        assert_eq!((out[1].start, out[1].end), (100, 250));
     }
 
     #[test]


### PR DESCRIPTION
This wires the required query merge distance (`-d`) into syng transitive search instead of leaving it only for final output merging.

Changes:
- Uses `-d` in per-hop syng chain gap/drift/span limits, keeping `--syng-extend-budget` as a local boundary refinement budget.
- Merges same-path syng intervals by `-d` inside the transitive BFS before expanding the next frontier.
- Adds focused tests for pre-refinement chain limits and same-path gap merging.
- Adds an HPRCv2 smoke-panel script with boring, short, and SV-rich regions, including the GRCh38 C4 interval that exposes recurrent C4/RCCX length spread.

Local validation:
- `cargo test -- --nocapture`
- `cargo build --release`
- `cargo install --path .`
- HPRCv2 GRCh38 C4 query with `-d 10000`: 468 intervals over 466 target paths; median 57.4 kb; p95 90.0 kb; max 129.2 kb; profile shows `chain_gap=63362`, `drift=63362`, and `merge_same_path ... gap=10000`.
- `scripts/hprcv2-syng-smoke.py --limit 5 --out-dir /home/erikg/hprcv2/smoke/syng_query_panel_limit5_d10k` with installed `impg`.