### PR TITLE
Parallelize syng query locate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ dependencies = [
  "lib_wfa2",
  "libc",
  "log",
+ "memmap2",
  "nalgebra",
  "natord",
  "niffler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bluntg"
+version = "0.1.0"
+source = "git+https://github.com/pangenome/bluntg#21ed8bf76d9b26322adfb9a5ad24589a2c60cb23"
+dependencies = [
+ "flate2",
+]
+
+[[package]]
 name = "boomphf"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1356,7 @@ dependencies = [
  "ahash",
  "bincode 2.0.1",
  "bitvec",
+ "bluntg",
  "cc",
  "clap",
  "coitrees",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "povu-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/povu?branch=rust-native-gfa-vcf#a05c00071a31d14a0122c606a8da3a81f536998a"
+source = "git+https://github.com/pangenome/povu?branch=rust#857ae6ecb5d97272b51d676b25b4307ecb6c16e8"
 dependencies = [
  "bindgen 0.70.1",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1459,15 +1459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "povu-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/povu?branch=rust-native-gfa-vcf#02c18e56f7a029f0a07e08fd34864c5d75aaba27"
+source = "git+https://github.com/pangenome/povu?branch=rust-native-gfa-vcf#a05c00071a31d14a0122c606a8da3a81f536998a"
 dependencies = [
  "bindgen 0.70.1",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
  "noodles",
  "num_cpus",
  "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=38182c7acf7cccc53509176b1d11001ae6ff2642)",
+ "povu-rs",
  "ragc-core",
  "rayon",
  "regex",
@@ -2063,6 +2064,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "povu-rs"
+version = "0.1.0"
+source = "git+https://github.com/pangenome/povu?branch=rust-native-gfa-vcf#02c18e56f7a029f0a07e08fd34864c5d75aaba27"
+dependencies = [
+ "bindgen 0.70.1",
+ "cmake",
+ "libc",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -204,7 +204,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -603,7 +603,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -624,7 +624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1450,15 +1450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "povu-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/povu?branch=rust#857ae6ecb5d97272b51d676b25b4307ecb6c16e8"
+source = "git+https://github.com/pangenome/povu?rev=168167fd2a05b8f9fa4901a2aa0feb02bfc13ea5#168167fd2a05b8f9fa4901a2aa0feb02bfc13ea5"
 dependencies = [
  "bindgen 0.70.1",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
 bluntg = { git = "https://github.com/pangenome/bluntg" }
-povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", branch = "rust-native-gfa-vcf", default-features = false }
+povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", branch = "rust", default-features = false }
 
 [build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
 bluntg = { git = "https://github.com/pangenome/bluntg" }
-povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", branch = "rust", default-features = false }
+povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "168167fd2a05b8f9fa4901a2aa0feb02bfc13ea5", default-features = false }
 
 [build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ env_logger = "0.11"
 natord = "1.0"
 rustc-hash = "2.1"
 libc = "0.2"
+memmap2 = "0.9"
 indexmap = { version = "2", features = ["rayon"] }
 nalgebra = "0.33"
 indicatif = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
 bluntg = { git = "https://github.com/pangenome/bluntg" }
-povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", branch = "rust-native-gfa-vcf" }
+povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", branch = "rust-native-gfa-vcf", default-features = false }
 
 [build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
+bluntg = { git = "https://github.com/pangenome/bluntg" }
 
 [build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
 bluntg = { git = "https://github.com/pangenome/bluntg" }
+povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", branch = "rust-native-gfa-vcf" }
 
 [build-dependencies]
 cc = "1"

--- a/README.md
+++ b/README.md
@@ -282,13 +282,13 @@ impg stats -a f1.paf f2.1aln
 
 ### `syng` and `map` — alignment-free syncmer backend
 
-`impg syng` builds a [syng](https://github.com/richarddurbin/syng) index from FASTA or AGC. Six sidecars are written under one prefix (`<prefix>.1khash` dictionary, `.1gbwt` GBWT, `.syng.names`, `.syng.spos` sampled node positions, `.syng.pstep` sampled path-step checkpoints, `.syng.meta` parameters — auto-loaded on read). Any later `impg query` / `partition` / `map` can then point `-a` at the prefix (or any sidecar) and skip pairwise alignment. Exact target coordinates are located by walking GBWT occurrences forward to the next `.syng.pstep` checkpoint; `.syng.spos` is only a sampled sidecar, not the final query answer.
+`impg syng` builds a [syng](https://github.com/richarddurbin/syng) index from FASTA or AGC. Six sidecars are written under one prefix (`<prefix>.1khash` dictionary, `.1gbwt` GBWT, `.syng.names`, `.syng.pstep` sampled path-step checkpoints, `.syng.spos` sampled syncmer occurrence positions, `.syng.meta` parameters — auto-loaded on read). Any later `impg query` / `partition` / `map` can then point `-a` at the prefix (or any sidecar) and skip pairwise alignment. Exact target coordinates are located by walking GBWT occurrences forward to the next sampled checkpoint and resolving it through `.syng.spos`.
 
 Parameters follow the syng paper: `--smer-length` (`s`, default 8) and `--syncmer-length` (`k`, must be odd, default 63). Position sidecars use a regular per-path syncmer-step grid plus the terminal syncmer: `--position-sample-rate 256` samples steps `0, 256, 512, ...` and the final step on each path. `--parallel-dictionary` adds a deterministic prepass for large inputs.
 
 `impg map` projects FASTA/FASTQ queries onto a syng index via shared syncmers. The default output is GAF (per-read syncmer-node walks); pass `-o paf` for projected genome coordinates, `-o pack` for a compact binary node support vector, `-o pack-tsv` for a human-readable TSV support vector, or `-o proj` for a sample projection bundle containing both `sample.pack` and `reads.gaf.zst`. Text map output written with `-O` is compressed automatically when the filename ends in `.zst` or `.zstd`; `pack` uses internal block zstd compression for random access by node ID. `packbin` remains accepted as a compatibility alias for compact pack output.
 
-Use `impg syng-repair -a <prefix> --position-sample-rate <N> --force` to rebuild or resample `.syng.spos` and `.syng.pstep` from an existing `.1gbwt` / `.1khash` syng index without re-reading the original sequences.
+Use `impg syng-repair -a <prefix> --position-sample-rate <N> --force` to rebuild or resample `.syng.pstep` and `.syng.spos` from an existing `.1gbwt` / `.1khash` syng index without re-reading the original sequences.
 
 End-to-end walkthrough using ODGI's C4 test GFA (90 HPRC haplotypes, ~6.9 Mb total):
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,8 @@ ranges; once a range survives, downstream scoring can still recover all
 syncmers by walking that path range. `query -o gbwt` emits a
 region-specific sub-GBWT. The syng prefix passed to `-a` is resolved
 relative to cwd, so either `cd` to the index directory or pass an absolute
-path.
+path. For a focused syng-backed local GFA recipe, see
+[`docs/syng-gfa-query.md`](docs/syng-gfa-query.md).
 
 ## GFA engines
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ impg query -a aln.paf -r chr1:1000-2000 -d 100 -x -m 3
 # Many regions from a BED, mixed PAF + 1ALN
 impg query -a f1.paf f2.1aln -b regions.bed -d 100
 
-# Output formats: auto | bed | bedpe | paf | gfa | maf | fasta | fasta+paf | fasta-aln
+# Output formats: auto | bed | bedpe | paf | gfa | vcf | maf | fasta | fasta+paf | fasta-aln
 impg query -a aln.paf -r chr1:1000-2000 -d 100 -o bed
 impg query -a aln.paf -r chr1:1000-2000 -d 100 -o gfa --sequence-files genomes.fa
+impg query -a aln.paf -r chr1:1000-2000 -d 100 -o vcf --sequence-files genomes.fa
 impg query -a aln.1aln -r chr1:1000-2000 -d 100 -o fasta --sequence-files *.fa \
            --reverse-complement
 
@@ -438,6 +439,17 @@ For syng-index queries, `--gfa-engine syng` defaults to `syng:blunt`.
 The compact form `-o gfa:syng:blunt,k=63,s=8,seed=7` is accepted as
 shorthand for `-o gfa --gfa-engine syng:blunt,k=63,s=8,seed=7`; the
 `k/s/seed` tail is checked against the loaded syng index.
+
+The same shorthand works for the other engines: `-o gfa:pggb`,
+`-o gfa:seqwish`, `-o gfa:poa`, and `-o gfa:syng`. Alignment-backed graph
+builds may also include the aligner prefix, for example
+`-o gfa:wfmash:seqwish`, `-o gfa:fastga:pggb`, or
+`-o gfa:sweepga:seqwish`; this is equivalent to setting `--aligner` and
+`--gfa-engine` separately.
+
+VCF output uses the same graph engines and then converts the resulting local
+GFA through POVU. Use `-o vcf --gfa-engine <engine>` or the shorthand
+`-o vcf:<engine>`, for example `-o vcf:syng`.
 
 ### Partitioned mode
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ one set of engine implementations, selected via `--gfa-engine`:
 | `pggb` (default) | sweepga + seqwish + smoothxg-style smoothing + gfaffix | smoothed variation graphs |
 | `seqwish` | sweepga + seqwish + gfaffix | raw (unsmoothed) graphs |
 | `poa` | single-pass SPOA | small regions, quick MSA-based output |
+| `syng` / `syng:blunt` | regional syng syncmer graph + bluntg | syng-native zero-overlap graph output from syng indexes |
+| `syng:raw` | regional syng syncmer overlap graph | debugging native syncmer graph overlaps |
+
+For syng-index queries, `--gfa-engine syng` defaults to `syng:blunt`.
+The compact form `-o gfa:syng:blunt,k=63,s=8,seed=7` is accepted as
+shorthand for `-o gfa --gfa-engine syng:blunt,k=63,s=8,seed=7`; the
+`k/s/seed` tail is checked against the loaded syng index.
 
 ### Partitioned mode
 

--- a/docs/hierarchical-vcf-graph-resolution.md
+++ b/docs/hierarchical-vcf-graph-resolution.md
@@ -1,0 +1,597 @@
+# Hierarchical VCF And Graph Resolution
+
+IMPG can already build local sequence graphs from pangenome intervals, including
+syng-derived graphs, and route `query -o vcf` through POVU-style GFA-to-VCF
+conversion. The missing control surface is resolution: the same local graph may
+contain single-base substitutions, nested indels, multi-kilobase SVs, CNV
+structure, and repetitive tangles. A flat GFA-to-VCF pass tends to either emit
+too many small records or lose the structure needed to type larger sites.
+
+This note proposes a hierarchical bubble decomposition layer between local GFA
+construction and VCF/genotyping. The layer should identify fine bubbles,
+organize them into larger flubbles/sites, select representative traversals at
+configurable resolution, and preserve enough provenance to simplify graphs,
+emit VCF, and match sample evidence back to representative haplotypes.
+
+## Problem
+
+Current GFA-to-VCF conversion needs controllable clustering of variant graph
+structure, especially in large SV, CNV, and repetitive regions.
+
+The core issues are:
+
+- Local pangenome graphs are often nested: small variants sit inside insertion
+  alleles, repeat copies, or alternative structural haplotypes.
+- A "one record per smallest bubble" VCF is too fragmented for SV/CNV sites and
+  loses haplotype context across nearby dependent choices.
+- A "one record per graph component" VCF can become untypeable if it enumerates
+  every observed path in a repetitive or copy-variable locus.
+- Graph simplification and VCF emission need the same notion of resolution, or
+  the simplified graph and the VCF records will disagree.
+- Genotyping needs representative haplotypes that can explain read coverage and
+  linkage, not just syntactically valid VCF alleles.
+
+The desired behavior is a tunable path:
+
+```text
+local GFA
+  -> normalize/clean graph
+  -> detect atomic bubbles
+  -> cluster into hierarchical flubbles/sites
+  -> select representative traversals at requested resolution
+  -> emit VCF and optional simplified GFA
+  -> genotype/deconvolve sample evidence against representatives
+```
+
+## Goals
+
+- Support multiple resolution levels from atomic bubbles to large SV/CNV sites.
+- Keep source path identity and path intervals through every transformation.
+- Select representative traversals that cover common haplotype space while
+  bounding allele count.
+- Emit VCF records at the requested resolution with clear provenance back to
+  graph sites and lower-level bubbles.
+- Simplify or clean GFA graphs with the same site hierarchy used for VCF.
+- Expose representative haplotypes as feature vectors for genotyping,
+  deconvolution, and local haplotype inference.
+
+Non-goals for the first implementation:
+
+- Perfect decomposition of every cyclic assembly graph.
+- A new whole-genome variant caller independent of IMPG's local graph and pack
+  abstractions.
+- Replacing POVU immediately. The first target can wrap or preprocess GFA for
+  POVU and then progressively move more logic into IMPG.
+
+## Hierarchical Model
+
+Use a hierarchy of typed graph regions:
+
+```text
+level 0: atomic graph features
+  segment, oriented segment, edge, path step, syncmer node
+
+level 1: atomic bubbles
+  single-entry/single-exit alternative traversals, usually small variants
+
+level 2: compound flubbles / variant sites
+  adjacent, nested, or weakly interacting bubbles that should often be emitted
+  together, such as an insertion with internal SNPs or a deletion plus nearby
+  breakpoint polymorphism
+
+level 3: complex loci / blocks
+  large SV, CNV, duplicated, or repetitive regions where representative
+  traversal selection is required
+```
+
+"Bubble" should be reserved for clean source/sink subgraphs when possible.
+"Flubble" is useful for an almost-bubble: a local component with recognizable
+entry/exit anchors and path traversals, but with internal nesting, weak cycles,
+copy-number variation, or multiple plausible boundaries. VCF emission may use
+either, but the model should record boundary confidence and decomposition type.
+
+The hierarchy is usually a tree along a chosen reference path, but the data
+model should allow a DAG. Repetitive loci can cause one lower-level bubble to
+participate in multiple larger candidate sites, and a strict tree would force
+early arbitrary choices.
+
+## Proposed Data Model
+
+The decomposition layer should produce a portable sidecar object next to the
+GFA/VCF, even if the first implementation keeps it internal.
+
+```text
+GraphResolutionIndex
+  graph_id
+  graph_build_engine
+  reference_paths
+  feature_space
+  normalization_steps
+  sites[]
+  traversals[]
+  representatives[]
+  provenance_maps[]
+```
+
+Each site describes a graph region at one level:
+
+```text
+Site
+  id
+  level
+  kind = atomic_bubble | flubble | cnv_block | repeat_block | component
+  parent_ids
+  child_ids
+  entry_handles
+  exit_handles
+  node_set
+  edge_set
+  reference_path
+  reference_interval
+  boundary_confidence
+  acyclic
+  copy_variable
+  path_count
+  traversal_count
+  notes
+```
+
+Each traversal is an observed or inferred path through a site:
+
+```text
+Traversal
+  id
+  site_id
+  oriented_handles
+  sequence_hash
+  sequence_length
+  source_path_intervals
+  child_site_alleles
+  copy_number_vector
+  frequency_or_path_support
+  feature_vector_id
+```
+
+Each representative is a selected allele or polytype at a chosen resolution:
+
+```text
+Representative
+  id
+  site_id
+  level
+  method = exact | medoid | k_medoids | centroid | k_centroids | polytype | reference
+  member_traversal_ids
+  representative_traversal_id
+  assigned_weight
+  max_member_distance
+  feature_vector_id
+  emitted_allele_id
+  deconvolution_children
+```
+
+Important invariants:
+
+- A representative must map back to one or more graph traversals.
+- VCF alleles, simplified GFA paths, and genotype candidates must all reference
+  the same site and representative IDs.
+- The reference allele is explicit, even when it is not the most common
+  traversal.
+- Source path identity is never discarded. It may be summarized, but the full
+  path membership must remain recoverable for audit and training data.
+
+## Decomposition Algorithm
+
+The first implementation should be deterministic and conservative.
+
+1. Parse and normalize the GFA.
+
+   Build a handle graph view with segment lengths, edges, path walks, and path
+   step positions. Optionally compact linear chains, remove exact duplicate
+   segments, and annotate tips or low-support graph pieces, but keep a
+   provenance map from old handles to new handles.
+
+2. Choose anchor paths and coordinate frames.
+
+   Prefer the requested reference path/range when `query` has one. Also keep
+   all source paths from syng/Pan-SN metadata. Site coordinates should be
+   reported in reference coordinates when available and graph-local coordinates
+   otherwise.
+
+3. Detect atomic bubbles.
+
+   Start with superbubble-like detection on the directed bidirected graph after
+   orienting around the reference path. Boundaries should be graph handles with
+   multiple path-consistent traversals between them. Reject or downgrade sites
+   with ambiguous entry/exit, too many internal cycles, or insufficient path
+   support.
+
+4. Enumerate path-supported traversals.
+
+   Use existing graph paths as the default traversal source. Do not enumerate
+   all possible walks in a repetitive graph. For small acyclic bubbles, optional
+   recombination across child bubbles can be allowed, but it should be gated by
+   `--max-traversals` and clearly labeled as inferred rather than observed.
+
+5. Build larger flubbles/sites.
+
+   Cluster atomic bubbles when any of the following holds:
+
+   - nested containment in the graph
+   - adjacent reference spans within `--site-merge-distance`
+   - high path co-occurrence or linkage disequilibrium across source paths
+   - shared internal nodes or edges
+   - breakpoints of one SV overlap the reference span of another bubble
+   - copy-number traversals cannot be represented by independent child bubbles
+
+   Build candidate parents bottom-up, then score whether a parent should exist.
+   Useful parent scores include reference span, graph node count, path count,
+   entropy of child allele combinations, traversal count, and copy-number
+   dispersion.
+
+6. Assign resolution levels.
+
+   Each site can be emitted at multiple levels:
+
+   ```text
+   atomic       emit child bubbles independently
+   site         emit a compound flubble as one VCF record
+   representative emit only selected traversal representatives
+   block        emit a larger complex locus with symbolic alleles or sidecar
+   ```
+
+   The default should be conservative: atomic for simple sites, site-level for
+   obvious nested SV/indel structures, and representative mode only when allele
+   explosion would otherwise occur.
+
+7. Select representatives.
+
+   Collapse duplicate traversals first, then select exact or approximate
+   representatives according to the requested resolution and bounds.
+
+## Representative Traversals, Centroids, And Polytypes
+
+Representative selection should optimize coverage of common haplotype space
+under allele-count and divergence constraints.
+
+A practical objective:
+
+```text
+maximize covered_path_weight
+penalize representative_count
+penalize member_distance_to_representative
+penalize loss of copy-number-distinguishing features
+force include reference traversal
+force include long or high-impact outliers above distance threshold
+```
+
+Distance can start simple:
+
+- edit distance between traversal sequences for small sites
+- Jaccard or weighted cosine distance over graph feature vectors for large sites
+- child-allele Hamming distance for nested bubble vectors
+- copy-number vector distance for duplicated regions
+- breakpoint distance for SV alleles
+
+Representative modes:
+
+- `exact`: one allele per unique observed traversal sequence or child-allele
+  vector.
+- `medoid`: choose the observed traversal with minimum weighted distance to
+  all assigned traversals.
+- `k-medoids`: choose up to `k` observed traversals. This is safer than a true
+  centroid because every emitted allele exists in the graph.
+- `centroid` / `k-centroids`: compute one or more consensus traversals or
+  sequences. This is useful for graph cleaning but should be marked as
+  synthetic if emitted.
+- `polytype`: represent a repeated or CNV locus by a compact type vector, such
+  as copy count plus ordered or unordered child allele composition.
+
+Polytypes are important for CNV and repeats. A two-copy allele and a three-copy
+allele may share most nodes but imply different dosage and should not collapse
+unless the requested resolution explicitly allows it. A polytype should be able
+to say:
+
+```text
+site=C4_like_block
+copy_number=3
+copy_units=[A, B, B]
+representative_path=sample42#1#chr6:...
+assigned_paths=...
+```
+
+For VCF, exact and medoid representatives can usually become sequence alleles
+or symbolic alleles. Centroids and polytypes may require symbolic alleles plus
+sidecar annotations because standard VCF cannot fully encode arbitrary graph
+traversal structure.
+
+## VCF Emission At Chosen Resolution
+
+The VCF writer should consume the hierarchy instead of rediscovering variants
+from raw graph topology.
+
+Proposed modes:
+
+```text
+--vcf-resolution atomic
+  one record per atomic bubble when it can be linearized
+
+--vcf-resolution site
+  one record per selected flubble/site; alleles are observed traversals when
+  bounded and symbolic alleles otherwise
+
+--vcf-resolution representative
+  one record per selected site with representative traversal alleles only
+
+--vcf-resolution block
+  one record per complex locus, primarily symbolic, with sidecar traversal
+  metadata for downstream genotyping/deconvolution
+```
+
+For linearizable sites, emit ordinary REF/ALT sequences. For larger or
+ambiguous sites, use symbolic alleles and INFO fields:
+
+```text
+IMPG_SITE=site_id
+IMPG_LEVEL=2
+IMPG_KIND=flubble
+IMPG_CHILDREN=child_site_ids
+IMPG_REP=representative_ids
+IMPG_METHOD=k_medoids
+IMPG_MAX_DIST=...
+IMPG_PATH_SUPPORT=...
+IMPG_CN=...
+IMPG_GRAPH=graph_id
+```
+
+When a site cannot be represented honestly as one VCF record, the writer should
+split it at the highest safe level and record why:
+
+```text
+IMPG_SPLIT_REASON=cycle|too_many_alleles|ambiguous_boundary|missing_ref_path
+```
+
+VCF emission should be deterministic:
+
+- sort sites by reference path, start, end, level, and site ID
+- keep allele order stable: reference, exact high-support alleles, selected
+  representatives, then symbolic residual alleles
+- record all thresholds and versioned graph IDs in the header
+
+## Graph Simplification And Cleaning
+
+The hierarchy is also a graph simplification plan.
+
+At low resolution, simplification can:
+
+- compact linear chains that are not site boundaries
+- remove tips not supported by any source path or sample evidence
+- merge exact duplicate traversal sequences inside a site
+- annotate low-confidence segments without deleting them
+
+At representative resolution, simplification can:
+
+- replace each selected site with representative traversal paths
+- collapse member traversals onto their representative when allowed
+- preserve child site annotations as nested metadata
+- write a translation table from original handles/path steps to simplified
+  handles/path steps
+
+This is closely related to assembly graph simplification, but the objective is
+different. Assembly cleaning often tries to recover one assembly graph or remove
+errors. IMPG should preserve population alleles and source path identity while
+making the graph easier to emit, view, and genotype at a requested resolution.
+
+The simplifier should therefore have two classes of operations:
+
+```text
+lossless-ish normalization
+  compaction, duplicate collapse, path-preserving cleanup
+
+lossy resolution reduction
+  representative-only site replacement, rare traversal parking,
+  symbolic residual alleles
+```
+
+Lossy operations must require explicit resolution settings and must produce a
+provenance sidecar.
+
+## Genotyping And Deconvolution
+
+Representatives should become genotype candidates in the same feature-pack
+model used elsewhere in IMPG.
+
+For each representative:
+
+```text
+representative traversal -> graph feature vector
+sample reads/alignments   -> evidence feature vector
+genotype combination      -> sum of representative vectors
+score                     -> cosine, count likelihood, alignment likelihood,
+                             or learned local scorer
+```
+
+This fits the existing architecture:
+
+- syng packs can score representatives by syncmer-node support when the site is
+  derived from syng paths
+- local GFA/GBZ alignment can score representatives by graph-node or path-step
+  support
+- bubble-level feature packs can score by child allele support
+- read-walk evidence can disambiguate representatives with similar aggregate
+  coverage but different ordering or phase
+
+Deconvolution is the inverse view: after choosing a representative genotype,
+estimate which child bubbles or member traversals explain the evidence.
+
+Useful outputs:
+
+```text
+top representative genotype
+assigned child allele probabilities
+copy-number estimate per subsite
+residual unexplained evidence
+member traversal posterior weights
+read-link support between child choices
+```
+
+This matters when a VCF is emitted coarsely but downstream analysis still wants
+fine structure. A sample may genotype as representative `R3` for a large CNV
+site, while deconvolution reports that the evidence prefers child alleles
+`b1=A,b2=DEL,b3=copy2:B` inside that representative cluster.
+
+## CLI And Config Knobs
+
+The first user-facing knobs should be few and stable:
+
+```text
+impg query -o vcf:syng \
+  --vcf-resolution site \
+  --site-merge-distance 1000 \
+  --max-site-alleles 16 \
+  --representative-method k-medoids \
+  --representative-k 8 \
+  --emit-resolution-index out.resolution.json
+```
+
+Potential options:
+
+```text
+--vcf-resolution atomic|site|representative|block
+--bubble-min-anchor-bp N
+--bubble-max-span N
+--site-merge-distance N
+--site-max-span N
+--max-site-traversals N
+--max-site-alleles N
+--representative-method exact|medoid|k-medoids|centroid|k-centroids|polytype
+--representative-k N
+--representative-max-distance D
+--include-rare-long-alleles N
+--min-path-support N
+--preserve-reference yes|no
+--emit-simplified-gfa PATH
+--emit-resolution-index PATH
+--emit-traversal-fasta PATH
+```
+
+Defaults should favor auditability:
+
+- include the reference traversal
+- use observed traversals rather than synthetic centroids for VCF alleles
+- avoid lossy representative collapse unless allele/traversal limits are hit or
+  the user requests representative/block resolution
+- write clear warnings for ambiguous sites
+
+## Validation And Adversarial Tests
+
+Start with synthetic graph fixtures where the expected hierarchy is known.
+
+Tests should cover:
+
+- simple SNP/indel bubbles emitted identically at atomic and site resolution
+- adjacent independent SNPs that remain split unless merge distance or linkage
+  requires a parent site
+- insertion with internal SNPs, emitted as child bubbles at atomic resolution
+  and one insertion-site record at site resolution
+- nested deletion and inversion-like path where boundaries are ambiguous
+- tandem duplication with one-copy, two-copy, and three-copy traversals
+- paralogous swapped-copy haplotypes that have similar node coverage but
+  different ordered read-walk support
+- repeat tangle with too many possible walks, where only observed path
+  traversals are used
+- rare long insertion that must not be collapsed into a common short centroid
+- graph with unsupported tips, where cleanup removes or annotates tips only
+  under explicit settings
+- missing or multiple reference traversals, requiring symbolic output or split
+  records
+- deterministic output under path order permutations
+
+Validation metrics:
+
+```text
+site boundary precision/recall against hand-labeled fixtures
+allele reconstruction identity for emitted sequence alleles
+path coverage by representatives
+maximum and mean traversal-to-representative distance
+VCF record count versus resolution
+genotype accuracy under simulated reads
+copy-number accuracy under coverage gradients
+residual unexplained evidence after deconvolution
+runtime and memory on large local graphs
+```
+
+Real-data validation should use HPRC-like local regions and known difficult
+sites, but the adversarial synthetic set is more important for preventing
+regressions in decomposition logic.
+
+## Relation To Other Work Areas
+
+Assembly graph simplification:
+
+- shares graph cleanup operations such as tip trimming, chain compaction, and
+  duplicate path collapse
+- differs because IMPG must retain population alleles, source path membership,
+  and selectable resolution rather than producing one cleaned assembly
+
+Variant calling:
+
+- VCF emission becomes a view over graph hierarchy and representative traversal
+  choice
+- the same graph can emit fine small-variant records or coarse SV/CNV records
+  depending on analysis needs
+
+Local haplotype inference:
+
+- representative selection defines candidate local haplotypes
+- genotyping and deconvolution score those candidates against sample evidence
+- read linkage and panel path continuity can later stitch local calls into
+  phased mosaics
+
+Learned or simulation-trained scoring:
+
+- the hierarchy gives natural training labels: site boundaries, child allele
+  vectors, representative assignments, and genotype states
+- simulated reads over known traversals can train scoring functions to choose
+  the correct representative genotype and deconvolve child structure
+- learned scorers should remain optional and auditable, with deterministic
+  heuristic scoring as the baseline
+
+## Open Risks
+
+- Graph decomposition may be unstable in cyclic or highly repetitive regions.
+  The model needs explicit boundary confidence and safe fallback to block-level
+  symbolic output.
+- Representative collapse can hide rare clinically or functionally important
+  alleles. Long, high-impact, or high-distance outliers should force their own
+  representative by default.
+- VCF cannot faithfully encode all graph traversal structure. Sidecar metadata
+  is not optional for block/polytype mode.
+- Synthetic centroids may not correspond to real haplotypes. Prefer medoids for
+  emitted VCF alleles unless the user explicitly requests centroid consensus.
+- Coverage-only scoring can confuse paralogous copies with similar node
+  content. Read-walk order, edge support, and local realignment should be used
+  where available.
+- Source path and coordinate provenance can become large. The sidecar format
+  needs compression and stable IDs.
+- Resolution choices may affect downstream association or annotation. VCF
+  headers and sidecars must record all thresholds and assignment methods.
+
+## Suggested Implementation Phases
+
+1. Add an internal resolution index for local GFAs with atomic bubble detection,
+   path-supported traversal extraction, and JSON debug output.
+2. Add site clustering over adjacent/nested bubbles and deterministic site IDs.
+3. Add exact and medoid representative selection with feature vectors.
+4. Route `query -o vcf` through the hierarchy for `atomic` and `site` modes,
+   keeping POVU as the sequence-allele backend where possible.
+5. Add representative/block VCF modes with symbolic alleles and sidecar
+   traversal metadata.
+6. Add simplified GFA emission using the same hierarchy and provenance maps.
+7. Connect representatives to `genotype`/`infer` as candidate haplotypes in a
+   declared feature space.
+8. Add simulation-trained or learned scoring only after deterministic fixtures
+   and real-region validation are stable.
+
+The key design constraint is that resolution is not just a VCF formatting
+option. It is a shared graph model used by VCF emission, graph simplification,
+and sample evidence interpretation.

--- a/docs/read-syncmer-index-design.md
+++ b/docs/read-syncmer-index-design.md
@@ -23,6 +23,46 @@ syncmer node -> sorted read ordinals
 This is the standard inverted-index problem: a dictionary of terms
 syncmer nodes, each with a monotone posting list of document/read IDs.
 
+## Implementation Status
+
+As of May 2026, `impg read-index` has a builder for the first prototype:
+
+```text
+impg read-index -a panel.syng -q reads.fq.gz -o sample
+```
+
+This writes:
+
+```text
+sample.r2s.meta
+sample.r2s.sample
+sample.r2s.post
+```
+
+That prototype is a build artifact, not yet the production query format.
+It proves that node-major read postings can be built, but it has not
+fixed the fast-load / immediate-query problem yet:
+
+- there is no public `.r2s` query command yet;
+- there is no memory-mapped or zero-copy reader yet;
+- the builder still collects all `(syncmer_node, read_ordinal)` pairs and
+  sorts them before writing;
+- read IDs are still FASTQ-order ordinals, so posting-list deltas are
+  much less compressible than they should be;
+- the sparse `.r2s.sample` file can seek near a node block, but it is
+  not the final observed-node dictionary / offset table we want.
+
+So the correction we still need is `.r2s2`: an indexable, node-major
+posting-list format with a real loader/query path. The goal is that a
+subgraph query loads only metadata and small dictionaries up front, then
+decodes only the posting lists for requested syncmer nodes.
+
+This is separate from the syng positional sidecars (`.syng.spos` and
+`.syng.pstep`). Those sidecars already use the regular sampled
+path-step scheme and are used by syng query/partition/map. They solve
+path-coordinate lookup inside the panel index; they do not solve
+read-to-syncmer support lookup.
+
 ## Current Prototype
 
 The current `.r2s` prototype writes each node block as:

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -111,6 +111,11 @@ impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o gfa --gfa-engine syng \
   --sequence-files panel.agc --force-large-region -O c4.syng-blunt
 
+# VCF calls from the same local syng graph, using POVU
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o vcf:syng \
+  --sequence-files panel.agc --force-large-region -O c4.syng-blunt
+
 # Same thing with explicit mode and syncmer-parameter assertion
 impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o gfa:syng:blunt,k=63,s=8,seed=7 \
@@ -120,6 +125,10 @@ impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
 impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o gfa --gfa-engine syng:raw \
   --sequence-files panel.agc --force-large-region -O c4.syng-raw
+
+# Syng-native blunt graph for every discovered partition
+impg partition -a panel.syng -w 1m -d 50k -o gfa --gfa-engine syng \
+  --sequence-files panel.agc --separate-files --output-folder parts.syng-gfa
 ```
 
 Available engines:
@@ -133,6 +142,22 @@ syng          syng syncmer graph, defaults to syng:blunt
 syng:blunt    syng graph processed through pangenome/bluntg; links are 0M
 syng:raw      native syng overlap graph
 ```
+
+`query` and `partition` differ only in how they gather local intervals. Once
+the intervals are selected, both commands call the same GFA engine dispatcher.
+For `--gfa-engine syng`, the dispatcher extracts the selected source-forward
+strings, builds a regional syng index with the loaded syncmer parameters, then
+emits either `syng:blunt` or `syng:raw` GFA.
+
+The `-o gfa:<spec>` shorthand is generic. `-o gfa:pggb`, `-o gfa:seqwish`,
+`-o gfa:poa`, and `-o gfa:syng` are equivalent to `-o gfa --gfa-engine
+<engine>`. For alignment-backed engines, the spec can also name the alignment
+backend: `-o gfa:wfmash:seqwish`, `-o gfa:fastga:pggb`, or
+`-o gfa:sweepga:seqwish`.
+
+VCF output uses the same engine dispatch and passes the local GFA to POVU:
+`-o vcf:syng`, `-o vcf:pggb`, `-o vcf:seqwish`, and `-o vcf:poa` are
+equivalent to `-o vcf --gfa-engine <engine>`.
 
 ## Raw Syng Graph Dump
 

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -105,6 +105,21 @@ impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
 impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o gfa --gfa-engine pggb:10000 \
   --sequence-files panel.agc --force-large-region -O c4.partitioned
+
+# Syng-native blunt graph (default when selecting syng)
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa --gfa-engine syng \
+  --sequence-files panel.agc --force-large-region -O c4.syng-blunt
+
+# Same thing with explicit mode and syncmer-parameter assertion
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa:syng:blunt,k=63,s=8,seed=7 \
+  --sequence-files panel.agc --force-large-region -O c4.syng-blunt
+
+# Native syng overlap graph, for debugging
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa --gfa-engine syng:raw \
+  --sequence-files panel.agc --force-large-region -O c4.syng-raw
 ```
 
 Available engines:
@@ -114,6 +129,9 @@ pggb          default; sweepga + seqwish + smoothing + gfaffix
 seqwish       unsmoothed graph
 poa           small-region MSA graph
 pggb:10000    partitioned mode with 10 kb windows
+syng          syng syncmer graph, defaults to syng:blunt
+syng:blunt    syng graph processed through pangenome/bluntg; links are 0M
+syng:raw      native syng overlap graph
 ```
 
 ## Raw Syng Graph Dump
@@ -125,6 +143,7 @@ impg syng2gfa -a panel.syng --sequence-files panel.agc -o panel.syncmers.gfa
 ```
 
 This dumps the whole syng syncmer graph: one GFA segment per syncmer plus gap
-segments between syncmers. Use this when you want to inspect the syng graph
-itself. Use `impg query -o gfa` when you want a local variation graph for a
-genomic region.
+segments between syncmers. By default this writes blunt graph output via
+pangenome/bluntg. Use `--gfa-mode raw` when you want to inspect native syng
+overlaps. Use `impg query -o gfa` when you want a local graph for a genomic
+region.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -1,0 +1,130 @@
+# Querying a Syng Index to GFA
+
+This is the short path for making a local variation graph from an existing
+syng index.
+
+Use `impg query -a <syng-prefix> -o gfa`. The `-a` argument is the syng index
+prefix, not a GFA file, and `-o gfa` selects GFA output. There is no
+`impg query -g gfa`; `--gfa-engine` only chooses the GFA construction engine.
+`impg` uses the syng GBWT/syncmer index to find homologous intervals, fetches
+the matching sequences, and then builds a local GFA with the selected GFA
+engine.
+
+## Inputs
+
+You need:
+
+```text
+panel.syng.1gbwt
+panel.syng.1khash
+panel.syng.names
+panel.syng.spos
+panel.syng.pstep
+panel.syng.meta
+panel.fa or panel.agc
+```
+
+The sequence file is required for `-o gfa`, because the query finds intervals
+from syng but the GFA engine needs the actual DNA strings. Sequence names in
+the FASTA/AGC must match the path names stored in the syng index.
+
+## Single Region
+
+```bash
+impg query \
+  -a panel.syng \
+  -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k \
+  -x \
+  -o gfa \
+  --sequence-files panel.agc \
+  --force-large-region \
+  -O c4.query
+```
+
+This writes `c4.query.gfa`.
+
+Important flags:
+
+- `-d 50k` is required. It merges query-gathered ranges separated by at most
+  this distance and sets the largest one-hop gap/SV absorbed into one interval.
+- `-x` enables transitive query. For duplicated loci, this is usually what you
+  want.
+- `--sequence-files` can be FASTA or AGC.
+- `--force-large-region` is needed for large GFA/MAF requests.
+- `-O` is an output prefix; the `.gfa` suffix is added by `impg`.
+
+## BED Batch
+
+Batching is preferred when querying many regions because the syng index is
+loaded once.
+
+```bash
+impg query \
+  -a panel.syng \
+  -b regions.bed \
+  -d 50k \
+  -x \
+  -o gfa \
+  --sequence-files panel.agc \
+  --force-large-region \
+  -O regions
+```
+
+BED rows use the syng path name in column 1:
+
+```text
+GRCh38#0#chr6	31982056	32035418	C4
+```
+
+If a path name itself contains `:`, `-r` still works because `impg` splits
+target ranges on the last colon:
+
+```bash
+impg query \
+  -a c4.syng \
+  -r 'grch38#chr6:31972046-32055647:0-10000' \
+  -d 150 \
+  -o gfa \
+  --sequence-files chr6.C4.fa \
+  -O c4.10kb
+```
+
+## GFA Engine
+
+The default engine is `pggb`. You can choose another engine with
+`--gfa-engine`:
+
+```bash
+# Raw seqwish graph
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa --gfa-engine seqwish \
+  --sequence-files panel.agc --force-large-region -O c4.seqwish
+
+# Partitioned graph build, useful for broad regions
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa --gfa-engine pggb:10000 \
+  --sequence-files panel.agc --force-large-region -O c4.partitioned
+```
+
+Available engines:
+
+```text
+pggb          default; sweepga + seqwish + smoothing + gfaffix
+seqwish       unsmoothed graph
+poa           small-region MSA graph
+pggb:10000    partitioned mode with 10 kb windows
+```
+
+## Raw Syng Graph Dump
+
+`impg syng2gfa` is different from `impg query -o gfa`.
+
+```bash
+impg syng2gfa -a panel.syng --sequence-files panel.agc -o panel.syncmers.gfa
+```
+
+This dumps the whole syng syncmer graph: one GFA segment per syncmer plus gap
+segments between syncmers. Use this when you want to inspect the syng graph
+itself. Use `impg query -o gfa` when you want a local variation graph for a
+genomic region.

--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -63,7 +63,7 @@ The clean end-state is a two-pass parallel dictionary plus per-node reduce:
 5. For each shard, emit per-node occurrence records and regular-grid
    positional samples using global node ids and global path coordinates.
 6. Reduce per-node occurrence records into the final GBWT node structures.
-7. Sort/group sampled-position records and write `.syng.spos` plus `.syng.pstep`.
+7. Sort/group sampled-position records and write `.syng.spos` and `.syng.pstep`.
 
 Step 6 is the only part not exposed by the current syng C API. The existing
 API has one mutable `syngBWTpathAdd` stream, but no `syngBWTmerge` or builder
@@ -97,8 +97,8 @@ AGC inputs.
 - Positional sampling uses a regular per-path syncmer-step grid plus each
   path's terminal syncmer. For `sample_rate = r`, sampled steps are
   `0, r, 2*r, ...` plus the final syncmer step on each path.
-  `.syng.spos` stores sampled node-to-position records and `.syng.pstep`
-  stores the inverse path-position checkpoints for the same sampled steps.
+  `.syng.pstep` stores path-position checkpoints and `.syng.spos` stores
+  the occurrence-major syncmer-position lookup used by query.
 - FASTA/AGC sequence names use the primary defline token. Any description
   after the first whitespace is not part of the syng path key. For example,
   `GRCh38#0#chr6  AC:CM000668.2 ...` is stored as `GRCh38#0#chr6`.

--- a/docs/syng-parallel-construction.md
+++ b/docs/syng-parallel-construction.md
@@ -99,6 +99,11 @@ AGC inputs.
   `0, r, 2*r, ...` plus the final syncmer step on each path.
   `.syng.spos` stores sampled node-to-position records and `.syng.pstep`
   stores the inverse path-position checkpoints for the same sampled steps.
+- FASTA/AGC sequence names use the primary defline token. Any description
+  after the first whitespace is not part of the syng path key. For example,
+  `GRCh38#0#chr6  AC:CM000668.2 ...` is stored as `GRCh38#0#chr6`.
+  AGC readers still keep the full AGC contig name internally for sequence
+  retrieval.
 
 ## Next Step: True GBWT Reduce
 
@@ -116,3 +121,6 @@ simple-node / rskip representation currently produced incrementally by
 That reduce API should live below `SyngIndex`, ideally in C next to
 `syngbwt3.c`, because it needs to construct `NodeSide` / `Rskip` structures
 directly.
+
+For the remaining positional-query startup cost on human-scale graphs, see
+[`syng-position-query-index.md`](syng-position-query-index.md).

--- a/docs/syng-position-query-index.md
+++ b/docs/syng-position-query-index.md
@@ -1,0 +1,164 @@
+# Syng Position Query Index
+
+## Problem
+
+The current repaired HPRCv2 syng index has correct regular positional sidecars:
+
+```text
+HPRC_r2_assemblies_0.6.1.syng.spos
+HPRC_r2_assemblies_0.6.1.syng.pstep
+```
+
+Those sidecars fix query correctness for unsampled syncmer positions by
+walking the GBWT to the nearest sampled checkpoint. They do not yet make
+the first query as fast as it should be on a human-scale graph.
+
+There are two remaining latency costs:
+
+1. `SyngIndex::load` reads the multi-GB `.spos` and `.pstep` byte payloads
+   into memory.
+2. The first arbitrary target-position locate lazily builds an in-memory
+   checkpoint hash from every sampled `.pstep` checkpoint:
+
+```text
+(signed_syncmer_node, absolute_gbwt_occurrence_rank) -> (path_id, bp_pos)
+```
+
+On HPRCv2 this means hundreds of millions of checkpoints. Building that
+hash is the "materialize all positions" behavior that can dominate a
+small query.
+
+## Current Format
+
+`.syng.pstep` is path-major:
+
+```text
+path_id -> sampled checkpoints ordered by path bp position
+```
+
+This is good for jumping into one source path range, because the query
+path can binary-search or scan its own checkpoints and then walk forward
+through the GBWT.
+
+It is not good for target occurrence location. For a shared syncmer node,
+query needs to enumerate GBWT occurrences and repeatedly ask:
+
+```text
+does this current (signed_node, occurrence_rank) equal a sampled checkpoint?
+```
+
+Today that question is answered by building the whole in-memory hash.
+
+## Required Fix
+
+Add a persistent checkpoint lookup sidecar, built by `impg syng-repair`
+and by normal `impg syng` construction:
+
+```text
+{prefix}.syng.ckpt   # tentative name
+```
+
+The sidecar should be occurrence-major:
+
+```text
+signed_syncmer_node -> sorted occurrence_rank checkpoints
+                         -> path_id, bp_pos
+```
+
+At query time, lookup becomes:
+
+1. Memory-map `.syng.ckpt`.
+2. Find the signed-node group by binary search or a small resident
+   sampled dictionary.
+3. Binary-search the group's occurrence ranks.
+4. If present, return `(path_id, bp_pos)`.
+5. If absent, advance the GBWT by one step and try again, up to the
+   position sample rate.
+
+This preserves the current correctness model but removes the global
+first-query hash build.
+
+## File Layout Direction
+
+A simple v1 `.syng.ckpt` can be:
+
+```text
+header:
+  magic, version, sample_rate, checkpoint_count
+
+node table:
+  signed_node ids with at least one checkpoint
+  byte offsets or record offsets for each signed_node group
+
+payload:
+  per signed_node:
+    delta-coded occurrence_rank
+    delta-coded path_id or raw path_id
+    delta-coded bp_pos within path
+```
+
+This is already enough to be queryable without decoding unrelated nodes.
+The payload can later become block-compressed, Elias-Fano encoded, or
+partitioned by signed node. The important first step is the access shape:
+node-local lookup without whole-index materialization.
+
+## Load Behavior
+
+`SyngIndex::load` should stop eagerly reading all positional payloads:
+
+- load `.1gbwt`, `.1khash`, `.names`, and `.meta` as today;
+- load only small sidecar metadata immediately;
+- memory-map `.pstep`, `.spos`, and `.ckpt` payloads;
+- do not load `.spos` unless a command actually needs sampled
+  node-to-position records;
+- do not build the checkpoint hash at all when `.ckpt` is present.
+
+For exact syng query, `.pstep` and `.ckpt` are the critical pair.
+`.spos` is useful as a sampled node-to-position sidecar, but it is not the
+final answer for exact query positions.
+
+## Repair And Distribution
+
+The existing HPRCv2 repair does not need to be rerun for correctness, but
+it will need one more repair/build step after `.syng.ckpt` exists:
+
+```bash
+impg syng-repair -a HPRC_r2_assemblies_0.6.1.syng \
+  --position-sample-rate 256 \
+  --force \
+  -t 32
+```
+
+That repair should write `.spos`, `.pstep`, and `.ckpt` together. The
+three positional sidecars should then be uploaded together to S3 so other
+users do not pay the repair cost:
+
+```text
+HPRC_r2_assemblies_0.6.1.syng.spos
+HPRC_r2_assemblies_0.6.1.syng.pstep
+HPRC_r2_assemblies_0.6.1.syng.ckpt
+```
+
+Older `impg` binaries will not understand the new sidecar. The failure
+mode should be explicit: either ignore `.ckpt` and fall back to the old
+hash build, or error with a message asking the user to update `impg`.
+
+## Testing
+
+Correctness tests:
+
+- exact locate of sampled and unsampled syncmer occurrences;
+- query-region anchors match the old in-memory checkpoint hash;
+- reverse-complement occurrences resolve to the same coordinates and
+  correct strand semantics;
+- short paths still sample first and terminal syncmers;
+- missing `.ckpt` falls back or errors according to the chosen policy.
+
+Performance tests:
+
+- HPRCv2 tiny query should not build a hundreds-of-millions-entry hash;
+- first-query wall time should be dominated by GBWT/khash load, not
+  positional checkpoint materialization;
+- repeated query batches should not grow memory after the first query;
+- report load time, mmap setup time, and checkpoint lookup count under
+  `SYNG_EMIT_PROFILE=1`.

--- a/docs/syng-position-query-index.md
+++ b/docs/syng-position-query-index.md
@@ -13,9 +13,9 @@ Those sidecars fix query correctness for unsampled syncmer positions by
 walking the GBWT to the nearest sampled checkpoint. They do not yet make
 the first query as fast as it should be on a human-scale graph.
 
-There are two remaining latency costs:
+There were two remaining latency costs:
 
-1. `SyngIndex::load` reads the multi-GB `.spos` and `.pstep` byte payloads
+1. `SyngIndex::load` read the multi-GB `.pstep` payload
    into memory.
 2. The first arbitrary target-position locate lazily builds an in-memory
    checkpoint hash from every sampled `.pstep` checkpoint:
@@ -49,16 +49,16 @@ does this current (signed_node, occurrence_rank) equal a sampled checkpoint?
 
 Today that question is answered by building the whole in-memory hash.
 
-## Required Fix
+## Implemented Fix
 
-Add a persistent checkpoint lookup sidecar, built by `impg syng-repair`
-and by normal `impg syng` construction:
+`impg syng-repair` and normal `impg syng` construction now write
+`.syng.spos` as a persistent checkpoint lookup sidecar:
 
 ```text
-{prefix}.syng.ckpt   # tentative name
+{prefix}.syng.spos
 ```
 
-The sidecar should be occurrence-major:
+The sidecar is occurrence-major:
 
 ```text
 signed_syncmer_node -> sorted occurrence_rank checkpoints
@@ -67,7 +67,7 @@ signed_syncmer_node -> sorted occurrence_rank checkpoints
 
 At query time, lookup becomes:
 
-1. Memory-map `.syng.ckpt`.
+1. Memory-map `.syng.spos`.
 2. Find the signed-node group by binary search or a small resident
    sampled dictionary.
 3. Binary-search the group's occurrence ranks.
@@ -78,9 +78,9 @@ At query time, lookup becomes:
 This preserves the current correctness model but removes the global
 first-query hash build.
 
-## File Layout Direction
+## File Layout
 
-A simple v1 `.syng.ckpt` can be:
+The v1 `.syng.spos` layout is:
 
 ```text
 header:
@@ -92,35 +92,32 @@ node table:
 
 payload:
   per signed_node:
-    delta-coded occurrence_rank
-    delta-coded path_id or raw path_id
-    delta-coded bp_pos within path
+    fixed-width occurrence_rank, path_id, bp_pos records
 ```
 
-This is already enough to be queryable without decoding unrelated nodes.
-The payload can later become block-compressed, Elias-Fano encoded, or
-partitioned by signed node. The important first step is the access shape:
-node-local lookup without whole-index materialization.
+The fixed-width payload is intentionally simple: it can be memory-mapped
+and binary-searched directly by `(signed_node, occurrence_rank)` without
+decoding unrelated nodes or building a global hash. The payload can later
+be block-compressed or Elias-Fano encoded if disk footprint becomes the
+dominant concern.
 
 ## Load Behavior
 
-`SyngIndex::load` should stop eagerly reading all positional payloads:
+`SyngIndex::load` no longer eagerly reads all positional payloads:
 
 - load `.1gbwt`, `.1khash`, `.names`, and `.meta` as today;
-- load only small sidecar metadata immediately;
-- memory-map `.pstep`, `.spos`, and `.ckpt` payloads;
-- do not load `.spos` unless a command actually needs sampled
-  node-to-position records;
-- do not build the checkpoint hash at all when `.ckpt` is present.
+- memory-map `.pstep` and `.spos`;
+- do not build the checkpoint hash at all when `.spos` is present.
 
-For exact syng query, `.pstep` and `.ckpt` are the critical pair.
-`.spos` is useful as a sampled node-to-position sidecar, but it is not the
-final answer for exact query positions.
+For exact syng query, `.pstep` and `.spos` are the critical pair:
+`.pstep` enters a path by coordinate, and `.spos` resolves sampled syncmer
+occurrences to path coordinates.
 
 ## Repair And Distribution
 
 The existing HPRCv2 repair does not need to be rerun for correctness, but
-it will need one more repair/build step after `.syng.ckpt` exists:
+it needs one more repair/build step to rewrite `.syng.spos` into the new
+occurrence-major format:
 
 ```bash
 impg syng-repair -a HPRC_r2_assemblies_0.6.1.syng \
@@ -129,19 +126,18 @@ impg syng-repair -a HPRC_r2_assemblies_0.6.1.syng \
   -t 32
 ```
 
-That repair should write `.spos`, `.pstep`, and `.ckpt` together. The
-three positional sidecars should then be uploaded together to S3 so other
-users do not pay the repair cost:
+That repair writes `.pstep` and `.spos` together. The positional sidecars
+should then be uploaded together to S3 so other users do not pay the
+repair cost:
 
 ```text
 HPRC_r2_assemblies_0.6.1.syng.spos
 HPRC_r2_assemblies_0.6.1.syng.pstep
-HPRC_r2_assemblies_0.6.1.syng.ckpt
 ```
 
-Older `impg` binaries will not understand the new sidecar. The failure
-mode should be explicit: either ignore `.ckpt` and fall back to the old
-hash build, or error with a message asking the user to update `impg`.
+Older `impg` binaries will not understand the new `.spos` sidecar. The
+failure mode should be explicit: ask the user to update `impg` or rebuild
+sidecars with the current binary.
 
 ## Testing
 
@@ -152,7 +148,8 @@ Correctness tests:
 - reverse-complement occurrences resolve to the same coordinates and
   correct strand semantics;
 - short paths still sample first and terminal syncmers;
-- missing `.ckpt` falls back or errors according to the chosen policy.
+- normal query/partition/map loads require the new `.spos`; repair loads can
+  tolerate a missing or stale `.spos` and rebuild it from `.pstep`.
 
 Performance tests:
 

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -292,6 +292,8 @@ fn discover_partitions(
     };
     let engine_config = EngineOpts {
         engine: GfaEngine::Poa,
+        syng_gfa_mode: None,
+        syng_params: None,
         pipeline: graph::GraphBuildConfig::default(),
         target_poa_lengths: vec![700, 1100],
         max_node_length: 100,

--- a/src/commands/partition.rs
+++ b/src/commands/partition.rs
@@ -481,7 +481,7 @@ pub fn partition_alignments(
                                 None,
                             )?;
                         }
-                        "gfa" | "maf" => {
+                        "gfa" | "vcf" | "maf" => {
                             // Write temporary BED file with .tmp suffix
                             write_partition_bed(
                                 partition_num,
@@ -517,14 +517,14 @@ pub fn partition_alignments(
                             // Collect BED partitions
                             collected_partitions.push((partition_num, query_intervals.clone()));
                         }
-                        "gfa" if engine_config.partition_size.is_some() => {
+                        "gfa" | "vcf" if engine_config.partition_size.is_some() => {
                             // Partitioned GFA mode: collect intervals for later pipeline
                             collected_partitions.push((partition_num, query_intervals.clone()));
                         }
-                        "gfa" | "maf" | "fasta" => {
+                        "gfa" | "vcf" | "maf" | "fasta" => {
                             return Err(io::Error::new(
                                 io::ErrorKind::InvalidInput,
-                                "Single-file output is only supported for BED format. Use --separate-files for GFA, MAF, or FASTA formats.".to_string(),
+                                "Single-file output is only supported for BED format. Use --separate-files for GFA, VCF, MAF, or FASTA formats.".to_string(),
                             ));
                         }
                         _ => {
@@ -576,7 +576,7 @@ pub fn partition_alignments(
         //info!("  select_and_window_sequences={:?}", window_time);
     }
 
-    // Convert temporary BED files to GFA/MAF if needed
+    // Convert temporary BED files to graph/MAF if needed
     if !temp_bed_files.is_empty() {
         info!(
             "Converting {} temporary BED files to {} format",
@@ -637,8 +637,8 @@ pub fn partition_alignments(
 
     // Write collected partitions as single file if not using separate files
     if !separate_files && !collected_partitions.is_empty() {
-        if output_format == "gfa" && engine_config.partition_size.is_some() {
-            // Partitioned GFA mode: run the partitioned pipeline
+        if matches!(output_format, "gfa" | "vcf") && engine_config.partition_size.is_some() {
+            // Partitioned graph mode: run the partitioned pipeline
             info!(
                 "Running partitioned GFA pipeline with {} partitions",
                 collected_partitions.len()
@@ -646,7 +646,7 @@ pub fn partition_alignments(
             let seq_idx = sequence_index.ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "Sequence files required for partitioned GFA output",
+                    "Sequence files required for partitioned graph output",
                 )
             })?;
             // Strip the partition_num tags before handing to the pipeline.
@@ -664,11 +664,17 @@ pub fn partition_alignments(
                 engine_config,
             )?;
 
-            // Write to output file
-            let output_path = create_output_path(output_folder, "partitions.gfa")?;
+            let (output_path, output_text) = if output_format == "vcf" {
+                (
+                    create_output_path(output_folder, "partitions.vcf")?,
+                    crate::gfa_to_vcf_string(&final_gfa, &[])?,
+                )
+            } else {
+                (create_output_path(output_folder, "partitions.gfa")?, final_gfa)
+            };
             let mut out = std::io::BufWriter::new(File::create(&output_path)?);
-            out.write_all(final_gfa.as_bytes())?;
-            info!("Wrote partitioned GFA to {}", output_path);
+            out.write_all(output_text.as_bytes())?;
+            info!("Wrote partitioned {} to {}", output_format.to_uppercase(), output_path);
         } else {
             info!(
                 "Writing {} partitions to single {} file",
@@ -1428,6 +1434,23 @@ fn write_partition(
                 engine_config,
             )
         }
+        "vcf" => {
+            let sequence_index = sequence_index.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "FASTA index required for VCF output",
+                )
+            })?;
+            write_partition_vcf(
+                partition_num,
+                query_intervals,
+                impg,
+                output_folder,
+                sequence_index,
+                scoring_params,
+                engine_config,
+            )
+        }
         "maf" => {
             let sequence_index = sequence_index.ok_or_else(|| {
                 io::Error::new(
@@ -1533,6 +1556,34 @@ fn write_partition_gfa(
 
     // Write the GFA output to the file
     writeln!(writer, "{gfa_output}")?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn write_partition_vcf(
+    partition_num: usize,
+    query_intervals: &[Interval<u32>],
+    impg: &impl ImpgIndex,
+    output_folder: Option<&str>,
+    sequence_index: &UnifiedSequenceIndex,
+    scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
+    engine_config: &EngineOpts,
+) -> io::Result<()> {
+    let gfa_output = crate::dispatch_gfa_engine(
+        impg,
+        query_intervals,
+        sequence_index,
+        scoring_params,
+        engine_config,
+    )?;
+    let vcf_output = crate::gfa_to_vcf_string(&gfa_output, &[])?;
+
+    let filename = format!("partition{partition_num}.vcf");
+    let full_path = create_output_path(output_folder, &filename)?;
+    let file = File::create(full_path)?;
+    let mut writer = BufWriter::new(file);
+
+    writer.write_all(vcf_output.as_bytes())?;
     writer.flush()?;
     Ok(())
 }

--- a/src/commands/render.rs
+++ b/src/commands/render.rs
@@ -20,6 +20,7 @@ pub struct RenderConfig<'a> {
     pub output: &'a str,
     pub sequence_files: &'a [String],
     pub engine: &'a str,
+    pub syng_gfa_mode: syng2gfa::SyngGfaMode,
     pub syng_padding: u64,
     pub syng_extension: u64,
     pub emit_gfa: bool,
@@ -103,10 +104,11 @@ fn render_syng_native(config: &RenderConfig<'_>) -> io::Result<()> {
             })?,
             syng2gfa::GfaVersion::V1_0,
             &[],
+            config.syng_gfa_mode,
         )?;
     }
 
-    let manifest = RenderManifest::new_syng_native(
+    let mut manifest = RenderManifest::new_syng_native(
         config.syng_prefix.to_string(),
         config.target_range.to_string(),
         &paths,
@@ -115,6 +117,7 @@ fn render_syng_native(config: &RenderConfig<'_>) -> io::Result<()> {
         tables.rendered_paths.len(),
         tables.step_samples.len(),
     );
+    manifest.engine = format!("syng:{}", config.syng_gfa_mode.label());
     render_bundle::write_manifest(&paths.manifest, &manifest)?;
 
     info!(

--- a/src/commands/syng2gfa.rs
+++ b/src/commands/syng2gfa.rs
@@ -9,7 +9,9 @@
 //! provided, otherwise the gap is filled with `N`s and a warning is
 //! emitted. Each gap occurrence gets a fresh segment id (no
 //! cross-path dedup) so that orientation/dedup never silently mixes
-//! distinct DNA.
+//! distinct DNA. The CLI default is blunt mode (`pangenome/bluntg`),
+//! which converts native variable overlaps to 0M links; raw mode keeps
+//! syng's native overlap graph.
 
 use std::io::{self, BufWriter, Write};
 
@@ -19,6 +21,37 @@ use rustc_hash::FxHashSet;
 use crate::sequence_index::{SequenceIndex, UnifiedSequenceIndex};
 use crate::syng::{GbwtPathStart, SyngIndex};
 use crate::syng_ffi;
+
+/// Syng GFA graph shape.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SyngGfaMode {
+    /// Native syng overlap graph, preserving nonzero link overlaps.
+    Raw,
+    /// Blunt graph produced by pangenome/bluntg; all link/path overlaps become 0M.
+    Blunt,
+}
+
+impl SyngGfaMode {
+    pub fn parse(s: &str) -> io::Result<Self> {
+        match s.trim().replace('_', "-").to_ascii_lowercase().as_str() {
+            "raw" | "syng:raw" | "syng-raw" | "syng-native:raw" => Ok(Self::Raw),
+            "blunt" | "bluntg" | "syng" | "syng:blunt" | "syng:bluntg" | "syng-blunt"
+            | "syng-bluntg" | "syng-native" | "syng-native:blunt"
+            | "syng-native:bluntg" => Ok(Self::Blunt),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown syng GFA mode '{other}' (expected raw or blunt)"),
+            )),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Raw => "raw",
+            Self::Blunt => "blunt",
+        }
+    }
+}
 
 /// Which GFA spec version to emit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -360,6 +393,46 @@ pub fn write_gfa<W: Write>(
     ))
 }
 
+/// Write syng GFA in either native overlap form or bluntg-processed form.
+pub fn write_gfa_with_mode<W: Write>(
+    index: &SyngIndex,
+    writer: &mut W,
+    version: GfaVersion,
+    gap_fill: Option<&UnifiedSequenceIndex>,
+    mode: SyngGfaMode,
+) -> io::Result<(usize, usize, usize, usize, usize, u64)> {
+    match mode {
+        SyngGfaMode::Raw => write_gfa(index, writer, version, gap_fill),
+        SyngGfaMode::Blunt => {
+            let mut raw = Vec::new();
+            let stats = write_gfa(index, &mut raw, version, gap_fill)?;
+            let blunted = bluntify_gfa_bytes(&raw, version)?;
+            info!(
+                "[syng2gfa] bluntg processed {} raw GFA bytes into {} blunt GFA bytes",
+                raw.len(),
+                blunted.len()
+            );
+            writer.write_all(&blunted)?;
+            Ok(stats)
+        }
+    }
+}
+
+fn bluntify_gfa_bytes(raw: &[u8], version: GfaVersion) -> io::Result<Vec<u8>> {
+    if version != GfaVersion::V1_0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--gfa-mode blunt currently requires --gfa-version 1.0 because bluntg preserves P lines, not W lines",
+        ));
+    }
+
+    let gfa = bluntg::parse_gfa(raw);
+    let blunted = bluntg::bluntify_auto(gfa);
+    let mut out = Vec::new();
+    bluntg::write_gfa(&mut out, &blunted)?;
+    Ok(out)
+}
+
 /// Pull the DNA between two syncmers from a sequence index.
 fn fetch_gap_dna(
     seq_idx: &UnifiedSequenceIndex,
@@ -455,6 +528,7 @@ pub fn run(
     out_path: &str,
     version: GfaVersion,
     sequence_files: &[String],
+    mode: SyngGfaMode,
 ) -> io::Result<()> {
     info!("[syng2gfa] loading syng index from prefix '{}'", prefix);
     // SyncmerParams in load() is overridden by the .syng.meta sidecar, so any
@@ -490,16 +564,71 @@ pub fn run(
         let stdout = io::stdout();
         let mut w = BufWriter::new(stdout.lock());
         let (s, l, p, skipped, gaps, gap_bp) =
-            write_gfa(&index, &mut w, version, seq_idx.as_ref())?;
+            write_gfa_with_mode(&index, &mut w, version, seq_idx.as_ref(), mode)?;
         w.flush()?;
-        report(s, l, p, skipped, gaps, gap_bp, "stdout");
+        report(
+            s,
+            l,
+            p,
+            skipped,
+            gaps,
+            gap_bp,
+            &format!("stdout ({})", mode.label()),
+        );
     } else {
         let file = std::fs::File::create(out_path)?;
         let mut w = BufWriter::new(file);
         let (s, l, p, skipped, gaps, gap_bp) =
-            write_gfa(&index, &mut w, version, seq_idx.as_ref())?;
+            write_gfa_with_mode(&index, &mut w, version, seq_idx.as_ref(), mode)?;
         w.flush()?;
-        report(s, l, p, skipped, gaps, gap_bp, &format!("'{}'", out_path));
+        report(
+            s,
+            l,
+            p,
+            skipped,
+            gaps,
+            gap_bp,
+            &format!("'{}' ({})", out_path, mode.label()),
+        );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_syng_gfa_mode_parse_defaults_syng_to_blunt() {
+        assert_eq!(SyngGfaMode::parse("syng").unwrap(), SyngGfaMode::Blunt);
+        assert_eq!(
+            SyngGfaMode::parse("syng:blunt").unwrap(),
+            SyngGfaMode::Blunt
+        );
+        assert_eq!(SyngGfaMode::parse("bluntg").unwrap(), SyngGfaMode::Blunt);
+        assert_eq!(SyngGfaMode::parse("raw").unwrap(), SyngGfaMode::Raw);
+        assert_eq!(
+            SyngGfaMode::parse("syng:raw").unwrap(),
+            SyngGfaMode::Raw
+        );
+    }
+
+    #[test]
+    fn test_bluntify_gfa_bytes_handles_variable_overlaps() {
+        let raw = b"\
+H\tVN:Z:1.0\n\
+S\t1\tACGTAC\n\
+S\t2\tTACGGA\n\
+S\t3\tGGAACC\n\
+L\t1\t+\t2\t+\t3M\n\
+L\t2\t+\t3\t+\t1M\n\
+P\tp\t1+,2+,3+\t3M,1M\n";
+        let out = bluntify_gfa_bytes(raw, GfaVersion::V1_0).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.contains("L\t1\t+\t2\t+\t0M"), "{out}");
+        assert!(out.contains("L\t2\t+\t3\t+\t0M"), "{out}");
+        assert!(out.contains("P\tp\t1+,2+,3+\t0M,0M"), "{out}");
+        assert!(!out.contains("\t3M"), "{out}");
+        assert!(!out.contains("\t1M"), "{out}");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,10 @@ pub enum GfaEngine {
 /// Resolved engine configuration passed to subcommand functions.
 pub struct EngineOpts {
     pub engine: GfaEngine,
+    /// Syng GFA mode when `engine == GfaEngine::SyngNative`.
+    pub syng_gfa_mode: Option<commands::syng2gfa::SyngGfaMode>,
+    /// Optional assertion about the syncmer scheme of a syng input index.
+    pub syng_params: Option<syng::SyncmerParams>,
     pub pipeline: commands::graph::GraphBuildConfig,
     // Smoothxg-style smoothing parameters (pggb engine)
     /// Target POA length(s) per pass — one value per smoothing pass (default: [700, 1100]).
@@ -520,6 +524,12 @@ fn dispatch_gfa_engine_inner(
             }
         }
         GfaEngine::SyngNative => {
+            if engine_opts.syng_gfa_mode.is_some() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "--gfa-engine syng[:raw|:blunt] requires syng-index input; use `impg query -a <prefix>.syng -o gfa --gfa-engine syng` or `impg render --engine syng`",
+                ));
+            }
             // v2.3: if we have access to the underlying syng index,
             // re-query from the first interval as seed and use
             // anchor-seeded gap-only BiWFA for pairs that share anchors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,110 @@ pub fn dispatch_gfa_engine_with_seq_index(
     dispatch_gfa_engine(&wrapper, query_intervals, sequence_index, scoring_params, engine_opts)
 }
 
+fn format_syng_params(params: syng::SyncmerParams) -> String {
+    format!(
+        "k={},s={},seed={}",
+        params.k + params.w,
+        params.k,
+        params.seed
+    )
+}
+
+fn validate_syng_param_assertion(
+    actual: syng::SyncmerParams,
+    expected: Option<syng::SyncmerParams>,
+) -> std::io::Result<()> {
+    if let Some(expected) = expected {
+        if actual != expected {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "syng parameter assertion does not match index: requested {}, index has {}",
+                    format_syng_params(expected),
+                    format_syng_params(actual)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn write_fasta_records(
+    path: &std::path::Path,
+    records: &[(String, Vec<u8>)],
+) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut out = std::io::BufWriter::new(std::fs::File::create(path)?);
+    for (name, seq) in records {
+        writeln!(out, ">{name}")?;
+        out.write_all(seq)?;
+        writeln!(out)?;
+    }
+    out.flush()
+}
+
+pub fn write_syng_region_gfa_from_sequences<W: std::io::Write>(
+    source_index: &syng::SyngIndex,
+    sequences: &[(String, Vec<u8>)],
+    out: &mut W,
+    mode: commands::syng2gfa::SyngGfaMode,
+) -> std::io::Result<()> {
+    if sequences.is_empty() {
+        writeln!(out, "H\tVN:Z:1.0")?;
+        return Ok(());
+    }
+
+    let tempdir = tempfile::Builder::new()
+        .prefix("impg-syng-gfa-")
+        .tempdir()?;
+    let region_prefix_path = tempdir.path().join("region");
+    let region_prefix = region_prefix_path.to_str().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "region prefix is not UTF-8")
+    })?;
+    let seq_refs: Vec<(String, &[u8])> = sequences
+        .iter()
+        .map(|(name, seq)| (name.clone(), seq.as_slice()))
+        .collect();
+    source_index.build_region_gbwt(&seq_refs, region_prefix)?;
+
+    let fasta_path = tempdir.path().join("region.fa");
+    write_fasta_records(&fasta_path, sequences)?;
+    let sequence_files = vec![fasta_path.to_string_lossy().to_string()];
+    let sequence_index = sequence_index::UnifiedSequenceIndex::from_files(&sequence_files)?;
+    let region_index = syng::SyngIndex::load(region_prefix, source_index.params)?;
+
+    commands::syng2gfa::write_gfa_with_mode(
+        &region_index,
+        out,
+        commands::syng2gfa::GfaVersion::V1_0,
+        Some(&sequence_index),
+        mode,
+    )?;
+    Ok(())
+}
+
+fn build_syng_region_gfa_from_intervals(
+    syng_idx: &syng::SyngIndex,
+    impg: &impl impg_index::ImpgIndex,
+    query_intervals: &[coitrees::Interval<u32>],
+    sequence_index: &sequence_index::UnifiedSequenceIndex,
+    mode: commands::syng2gfa::SyngGfaMode,
+) -> std::io::Result<String> {
+    let sequences = graph::prepare_sequences(impg, query_intervals, sequence_index)?;
+    let fetched: Vec<(String, Vec<u8>)> = sequences
+        .into_iter()
+        .map(|(seq, meta)| (meta.path_name(), seq.into_bytes()))
+        .collect();
+    let mut out = Vec::new();
+    write_syng_region_gfa_from_sequences(syng_idx, &fetched, &mut out, mode)?;
+    String::from_utf8(out).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("regional syng GFA is not UTF-8: {e}"),
+        )
+    })
+}
+
 /// Dispatch GFA generation to the selected engine.
 ///
 /// Shared by `query -o gfa` and `partition -o gfa` so the engine match
@@ -428,6 +532,35 @@ pub fn dispatch_gfa_engine(
         scoring_params,
         engine_opts,
     )
+}
+
+/// Convert an in-memory GFA string to VCF using the native Rust POVU path.
+///
+/// `reference_names` are matched against full path names, sample names, or path
+/// prefixes by POVU; callers should pass the queried range name and the bare
+/// target sequence name when both are known.
+pub fn gfa_to_vcf_string(
+    gfa: &str,
+    reference_names: &[String],
+) -> std::io::Result<String> {
+    if !gfa.lines().any(|line| {
+        line.starts_with("P\t") || line.starts_with("W\t")
+    }) {
+        return povu::VcfDocument::new(Vec::<String>::new(), Vec::new())
+            .with_source("povu-rs-native")
+            .to_vcf_string()
+            .map_err(povu_to_io_error);
+    }
+
+    let graph = povu::NativeGfa::parse(gfa).map_err(povu_to_io_error)?;
+    let document = graph
+        .to_vcf_document(reference_names)
+        .map_err(povu_to_io_error)?;
+    document.to_vcf_string().map_err(povu_to_io_error)
+}
+
+fn povu_to_io_error(err: povu::Error) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
 }
 
 /// Dispatch that assumes `debug_dir` (if any) has already been created.
@@ -524,11 +657,21 @@ fn dispatch_gfa_engine_inner(
             }
         }
         GfaEngine::SyngNative => {
-            if engine_opts.syng_gfa_mode.is_some() {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "--gfa-engine syng[:raw|:blunt] requires syng-index input; use `impg query -a <prefix>.syng -o gfa --gfa-engine syng` or `impg render --engine syng`",
-                ));
+            if let Some(mode) = engine_opts.syng_gfa_mode {
+                let syng_idx = impg.syng_index_ref().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "--gfa-engine syng[:raw|:blunt] requires syng-index input; use `impg query -a <prefix>.syng -o gfa --gfa-engine syng` or `impg render --engine syng`",
+                    )
+                })?;
+                validate_syng_param_assertion(syng_idx.params, engine_opts.syng_params)?;
+                return build_syng_region_gfa_from_intervals(
+                    syng_idx,
+                    impg,
+                    query_intervals,
+                    sequence_index,
+                    mode,
+                );
             }
             // v2.3: if we have access to the underlying syng index,
             // re-query from the first interval as seed and use

--- a/src/main.rs
+++ b/src/main.rs
@@ -6978,10 +6978,8 @@ fn run() -> io::Result<()> {
             let position_start = Instant::now();
             if let Some(stats) = index.finalize_online_sampled_positions()? {
                 info!(
-                    "Regular sampled position sidecars compacted in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths (sample_rate={} syncmer steps) at +{}",
+                    "Regular sampled path-step grid compacted in {}: {} checkpoints across {} paths from {} walked paths (sample_rate={} syncmer steps) at +{}",
                     format_duration(position_start.elapsed()),
-                    stats.sampled_occurrences,
-                    stats.sampled_nodes,
                     stats.sampled_path_steps,
                     stats.sampled_step_paths,
                     stats.walked_paths,
@@ -7082,7 +7080,19 @@ fn run() -> io::Result<()> {
                 return Ok(());
             }
 
-            if !force && have_requested_spos {
+            if !force && have_requested_pstep {
+                info!(
+                    "Building occurrence-major syncmer-position sidecar from existing .pstep: {}",
+                    spos_path
+                );
+                let save_start = Instant::now();
+                syng_index.save_checkpoint_sidecar(&prefix)?;
+                info!(
+                    "Saved syncmer-position sidecar in {}: {}",
+                    format_duration(save_start.elapsed()),
+                    spos_path
+                );
+            } else {
                 info!(
                     "Rebuilding regular sampled path-step sidecar: every {} syncmer steps per path",
                     position_sample_rate,
@@ -7105,39 +7115,10 @@ fn run() -> io::Result<()> {
                 let save_start = Instant::now();
                 syng_index.save_path_step_sidecar(&prefix)?;
                 info!(
-                    "Saved path-step sidecar in {}: {}",
+                    "Saved position sidecars in {}: {}, {}",
                     format_duration(save_start.elapsed()),
-                    impg::syng::syng_pstep_path(&prefix)
-                );
-            } else {
-                info!(
-                    "Rebuilding regular sampled position sidecars: every {} syncmer steps per path",
-                    position_sample_rate,
-                );
-                let stats = if serial_position_sampling {
-                    syng_index.rebuild_sampled_position_indexes_from_gbwt(position_sample_rate)?
-                } else {
-                    syng_index.rebuild_sampled_position_indexes_from_gbwt_parallel(
-                        position_sample_rate,
-                        position_progress_interval,
-                    )?
-                };
-                info!(
-                    "Rebuilt sampled position sidecars in {}: {} node-position samples across {} nodes; {} path-step checkpoints across {} paths from {} walked paths",
-                    format_duration(rebuild_start.elapsed()),
-                    stats.sampled_occurrences,
-                    stats.sampled_nodes,
-                    stats.sampled_path_steps,
-                    stats.sampled_step_paths,
-                    stats.walked_paths
-                );
-                let save_start = Instant::now();
-                syng_index.save_position_sidecars(&prefix)?;
-                info!(
-                    "Saved positional sidecars in {}: {}, {}",
-                    format_duration(save_start.elapsed()),
-                    impg::syng::syng_spos_path(&prefix),
-                    impg::syng::syng_pstep_path(&prefix)
+                    impg::syng::syng_pstep_path(&prefix),
+                    impg::syng::syng_spos_path(&prefix)
                 );
             }
             info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,62 @@ fn resolve_syng_syncmer_params(
     })
 }
 
+fn parse_render_engine_spec(raw: &str) -> io::Result<(String, SyngGfaMode)> {
+    let mut parts = raw.split(',').map(str::trim).filter(|p| !p.is_empty());
+    let head = parts.next().unwrap_or("syng");
+    if parts.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "render --engine currently accepts syng:raw or syng:blunt; syncmer parameter assertions are supported on --gfa-engine",
+        ));
+    }
+
+    let (name, suffix) = head
+        .split_once(':')
+        .map_or((head, None), |(name, suffix)| (name, Some(suffix)));
+    let name = name.trim().replace('_', "-").to_ascii_lowercase();
+    match name.as_str() {
+        "syng" | "syng-native" => {
+            let mode = if let Some(suffix) = suffix {
+                SyngGfaMode::parse(&format!("syng:{suffix}"))?
+            } else {
+                SyngGfaMode::Blunt
+            };
+            Ok(("syng-native".to_string(), mode))
+        }
+        "poa" | "seqwish" | "pggb" => {
+            if suffix.is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("render --engine '{}' does not accept a ':' mode", raw),
+                ));
+            }
+            Ok((name, SyngGfaMode::Blunt))
+        }
+        other => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("unsupported render engine '{other}'; expected syng, poa, seqwish, or pggb"),
+        )),
+    }
+}
+
+fn apply_gfa_output_engine_shorthand(
+    output_format: String,
+    engine_cli: &mut EngineCliOpts,
+) -> io::Result<String> {
+    let Some(engine_spec) = output_format.strip_prefix("gfa:") else {
+        return Ok(output_format);
+    };
+    if engine_spec.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "-o gfa:<engine> requires an engine spec, e.g. -o gfa:syng:blunt",
+        ));
+    }
+    engine_cli.engine_raw = engine_spec.to_string();
+    Ok("gfa".to_string())
+}
+
 #[derive(Debug, Clone)]
 struct SyngAgcRecord {
     sample: String,
@@ -1339,6 +1395,85 @@ fn emit_syng_map_projection(
     Ok(())
 }
 
+fn format_syng_params(params: impg::syng::SyncmerParams) -> String {
+    format!(
+        "k={},s={},seed={}",
+        params.k + params.w,
+        params.k,
+        params.seed
+    )
+}
+
+fn validate_syng_param_assertion(
+    actual: impg::syng::SyncmerParams,
+    expected: Option<impg::syng::SyncmerParams>,
+) -> io::Result<()> {
+    if let Some(expected) = expected {
+        if actual != expected {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "syng parameter assertion does not match index: requested {}, index has {}",
+                    format_syng_params(expected),
+                    format_syng_params(actual)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn write_fasta_records(path: &Path, records: &[(String, Vec<u8>)]) -> io::Result<()> {
+    let mut out = BufWriter::new(File::create(path)?);
+    for (name, seq) in records {
+        writeln!(out, ">{name}")?;
+        out.write_all(seq)?;
+        writeln!(out)?;
+    }
+    out.flush()
+}
+
+fn emit_syng_region_gfa<W: Write>(
+    source_index: &impg::syng::SyngIndex,
+    fetched: &[(String, Vec<u8>)],
+    out: &mut W,
+    mode: SyngGfaMode,
+) -> io::Result<()> {
+    if fetched.is_empty() {
+        writeln!(out, "H\tVN:Z:1.0")?;
+        return Ok(());
+    }
+
+    let tempdir = tempfile::Builder::new()
+        .prefix("impg-syng-gfa-")
+        .tempdir()?;
+    let region_prefix_path = tempdir.path().join("region");
+    let region_prefix = region_prefix_path
+        .to_str()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "region prefix is not UTF-8"))?;
+    let seq_refs: Vec<(String, &[u8])> = fetched
+        .iter()
+        .map(|(name, seq)| (name.clone(), seq.as_slice()))
+        .collect();
+    source_index.build_region_gbwt(&seq_refs, region_prefix)?;
+
+    let fasta_path = tempdir.path().join("region.fa");
+    write_fasta_records(&fasta_path, fetched)?;
+    let sequence_files = vec![fasta_path.to_string_lossy().to_string()];
+    let sequence_index = UnifiedSequenceIndex::from_files(&sequence_files)?;
+    let region_index =
+        impg::syng::SyngIndex::load(region_prefix, source_index.params)?;
+
+    impg::commands::syng2gfa::write_gfa_with_mode(
+        &region_index,
+        out,
+        impg::commands::syng2gfa::GfaVersion::V1_0,
+        Some(&sequence_index),
+        mode,
+    )?;
+    Ok(())
+}
+
 const READ_SYNCMER_INDEX_VERSION: u32 = 1;
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -1871,6 +2006,7 @@ fn setup_temp_dir(temp_dir: &str) -> io::Result<()> {
     Ok(())
 }
 
+use impg::commands::syng2gfa::SyngGfaMode;
 use impg::{EngineOpts, GfaEngine};
 use sweepga::knn_graph::SparsificationStrategy;
 
@@ -1986,14 +2122,15 @@ impl SmoothOpts {
 /// Engine + graph-building options shared by query, partition, similarity, and graph.
 #[derive(Parser, Debug)]
 struct EngineCliOpts {
-    /// GFA engine: 'pggb' (default), 'seqwish', or 'poa'.
-    /// Append ':WINDOW' to enable partitioned mode, e.g. 'pggb:10000'
-    /// splits into 10kb windows, builds per-window, laces, and normalizes.
+    /// GFA engine: 'pggb' (default), 'seqwish', 'poa', or 'syng'.
+    /// Append ':WINDOW' to pggb/seqwish/poa for partitioned mode, e.g. 'pggb:10000'.
+    /// Syng modes are 'syng'/'syng:blunt' (default bluntg output) or 'syng:raw';
+    /// optional syng assertions use comma parameters, e.g. 'syng:blunt,k=63,s=8,seed=7'.
     #[arg(help_heading = "Output options")]
     #[clap(
         long = "gfa-engine",
         default_value = "pggb",
-        value_name = "ENGINE[:WINDOW]"
+        value_name = "ENGINE[:MODE|WINDOW][,key=value...]"
     )]
     engine_raw: String,
 
@@ -2016,32 +2153,43 @@ struct EngineCliOpts {
     debug_dir: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ParsedGfaEngine {
+    engine: GfaEngine,
+    partition_size: Option<usize>,
+    syng_gfa_mode: Option<SyngGfaMode>,
+    syng_params: Option<impg::syng::SyncmerParams>,
+}
+
 impl EngineCliOpts {
-    /// Parse `--gfa-engine` value into (GfaEngine, Option<partition_size>).
+    /// Parse `--gfa-engine`.
     ///
-    /// Accepted forms: `pggb`, `seqwish`, `poa`, `pggb:10000`, `seqwish:5000`, etc.
-    /// A bare colon (`pggb:`) is an error.
-    fn parse_engine(&self) -> io::Result<(GfaEngine, Option<usize>)> {
+    /// Accepted forms include:
+    /// - `pggb`, `seqwish`, `poa`
+    /// - `pggb:10000` or `pggb,window=10k`
+    /// - `syng`, `syng:blunt`, `syng:raw`
+    /// - `syng:blunt,k=63,s=8,seed=7` as an assertion about the input syng index.
+    fn parse_engine(&self) -> io::Result<ParsedGfaEngine> {
         let raw = self.engine_raw.trim();
-        let (name, partition_size) = if let Some(idx) = raw.find(':') {
-            let engine_str = &raw[..idx];
-            let ps_str = &raw[idx + 1..];
-            if ps_str.is_empty() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!(
-                        "Invalid --gfa-engine '{}': expected a window size after ':', e.g. '{}:10000'",
-                        raw, engine_str
-                    ),
-                ));
-            }
-            let ps: usize = ps_str.parse().map_err(|_| {
+        let mut parts = raw.split(',').map(str::trim).filter(|p| !p.is_empty());
+        let head = parts.next().unwrap_or("pggb");
+        let param_parts: Vec<&str> = parts.collect();
+        let (engine_name_raw, suffix) = head
+            .split_once(':')
+            .map_or((head, None), |(name, suffix)| (name, Some(suffix)));
+        let engine_name = engine_name_raw.trim().replace('_', "-").to_ascii_lowercase();
+
+        let parse_window = |value: &str| -> io::Result<usize> {
+            let parsed = parse_size(value).map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!(
-                        "Invalid --gfa-engine '{}': '{}' is not a valid window size (expected integer)",
-                        raw, ps_str
-                    ),
+                    format!("Invalid --gfa-engine '{}': {e}", raw),
+                )
+            })?;
+            let ps = usize::try_from(parsed).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Invalid --gfa-engine '{}': window size is too large", raw),
                 )
             })?;
             if ps < 1_000 {
@@ -2053,28 +2201,155 @@ impl EngineCliOpts {
                     ),
                 ));
             }
-            (engine_str, Some(ps))
-        } else {
-            (raw, None)
+            Ok(ps)
         };
 
-        let engine = match name {
+        let is_syng = matches!(engine_name.as_str(), "syng" | "syng-native");
+        let mut partition_size = None;
+        let mut syng_gfa_mode = None;
+
+        if let Some(suffix) = suffix {
+            let suffix = suffix.trim();
+            if suffix.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Invalid --gfa-engine '{}': empty value after ':'", raw),
+                ));
+            }
+            if is_syng {
+                syng_gfa_mode = Some(SyngGfaMode::parse(&format!("syng:{suffix}"))?);
+            } else {
+                partition_size = Some(parse_window(suffix)?);
+            }
+        }
+
+        let engine = match engine_name.as_str() {
             "pggb" => GfaEngine::Pggb,
             "seqwish" => GfaEngine::Seqwish,
             "poa" => GfaEngine::Poa,
-            "syng-native" | "syng_native" | "syng" => GfaEngine::SyngNative,
+            "syng" | "syng-native" => {
+                syng_gfa_mode.get_or_insert(SyngGfaMode::Blunt);
+                GfaEngine::SyngNative
+            }
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
-                        "Unknown GFA engine '{}'. Valid engines: pggb, seqwish, poa, syng-native",
-                        name
+                        "Unknown GFA engine '{}'. Valid engines: pggb, seqwish, poa, syng",
+                        engine_name_raw
                     ),
                 ));
             }
         };
 
-        Ok((engine, partition_size))
+        let mut syncmer_length: Option<u32> = None;
+        let mut smer_length: Option<u32> = None;
+        let mut syncmer_seed: Option<u32> = None;
+        let mut saw_syng_param = false;
+
+        for part in param_parts {
+            let (key, value) = part.split_once('=').ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Invalid --gfa-engine '{}': parameter '{}' must be key=value",
+                        raw, part
+                    ),
+                )
+            })?;
+            let key = key.trim().replace('_', "-").to_ascii_lowercase();
+            let value = value.trim();
+            match key.as_str() {
+                "window" | "window-size" => {
+                    if is_syng {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': syng GFA modes do not use window", raw),
+                        ));
+                    }
+                    partition_size = Some(parse_window(value)?);
+                }
+                "mode" => {
+                    if !is_syng {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': mode= is only valid for syng", raw),
+                        ));
+                    }
+                    syng_gfa_mode = Some(SyngGfaMode::parse(value)?);
+                }
+                "k" | "syncmer" | "syncmer-length" => {
+                    if !is_syng {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': k= is only valid for syng", raw),
+                        ));
+                    }
+                    saw_syng_param = true;
+                    syncmer_length = Some(value.parse::<u32>().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': k='{}' is not a u32", raw, value),
+                        )
+                    })?);
+                }
+                "s" | "smer" | "smer-length" => {
+                    if !is_syng {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': s= is only valid for syng", raw),
+                        ));
+                    }
+                    saw_syng_param = true;
+                    smer_length = Some(value.parse::<u32>().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': s='{}' is not a u32", raw, value),
+                        )
+                    })?);
+                }
+                "seed" => {
+                    if !is_syng {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': seed= is only valid for syng", raw),
+                        ));
+                    }
+                    saw_syng_param = true;
+                    syncmer_seed = Some(value.parse::<u32>().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': seed='{}' is not a u32", raw, value),
+                        )
+                    })?);
+                }
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Invalid --gfa-engine '{}': unknown parameter '{}'", raw, other),
+                    ));
+                }
+            }
+        }
+
+        let syng_params = if saw_syng_param {
+            Some(resolve_syng_syncmer_params(
+                None,
+                smer_length,
+                None,
+                syncmer_length,
+                syncmer_seed.unwrap_or(7),
+            )?)
+        } else {
+            None
+        };
+
+        Ok(ParsedGfaEngine {
+            engine,
+            partition_size,
+            syng_gfa_mode,
+            syng_params,
+        })
     }
 
     /// Parse POA scoring parameters.
@@ -2132,7 +2407,8 @@ impl EngineCliOpts {
 
     /// Resolve and build an `EngineOpts`.
     fn build(&self, num_threads: usize) -> io::Result<EngineOpts> {
-        let (engine, partition_size) = self.parse_engine()?;
+        let parsed = self.parse_engine()?;
+        let engine = parsed.engine;
         self.validate_engine_params(engine)?;
 
         let sparsify = self.aln.sw.sparsify.clone();
@@ -2152,7 +2428,9 @@ impl EngineCliOpts {
             &self.smooth,
             self.debug_dir.clone(),
             Some(temp_dir),
-            partition_size,
+            parsed.partition_size,
+            parsed.syng_gfa_mode,
+            parsed.syng_params,
         )
     }
 }
@@ -2961,9 +3239,10 @@ Output formats:
 Syng notes:
   With -a/--alignment pointing to a syng index, supported query outputs are
   bed, bedpe, gfa, fasta, and gbwt. Use -o gfa for a local sequence GFA from
-  query-selected intervals. Use `impg syng2gfa` to dump the whole syng
-  syncmer graph instead. `--gfa-engine` selects how -o gfa is built; it is not
-  the output-format flag.
+  query-selected intervals. `--gfa-engine syng` emits a syng syncmer GFA and
+  defaults to syng:blunt; use syng:raw to preserve native overlaps. The compact
+  form `-o gfa:syng:blunt,k=63,s=8,seed=7` is accepted as shorthand. Use
+  `impg syng2gfa` to dump the whole syng syncmer graph instead.
 ")]
     Query {
         // --- Input ---
@@ -3411,8 +3690,8 @@ Syng notes:
         #[clap(short = 'O', long, value_parser)]
         output: String,
 
-        /// Render engine
-        #[clap(long, value_parser, default_value = "syng-native")]
+        /// Render engine. `syng` defaults to `syng:blunt`; use `syng:raw` to keep native overlaps
+        #[clap(long, value_parser, default_value = "syng")]
         engine: String,
 
         /// Boundary padding in bp for syng candidate discovery
@@ -3609,7 +3888,9 @@ Syng notes:
     /// segment per syncmer plus one segment per inter-syncmer gap. Gaps
     /// are filled with real DNA when `--sequence-files` is provided
     /// (sequence names must match the syng path names); otherwise they
-    /// are filled with `N`s and a warning is emitted.
+    /// are filled with `N`s and a warning is emitted. Default mode is
+    /// `blunt`, which runs pangenome/bluntg; use `--gfa-mode raw` to keep
+    /// native syng link overlaps.
     Syng2gfa {
         /// Syng index prefix (the same prefix passed to `impg syng -o`).
         #[clap(short = 'a', long = "syng-prefix", value_parser)]
@@ -3622,6 +3903,10 @@ Syng notes:
         /// GFA spec version: `1.0` (P lines, default) or `1.1` (W lines, PanSN-parsed).
         #[clap(long, value_parser, default_value = "1.0")]
         gfa_version: String,
+
+        /// Syng GFA mode: `blunt` (default; zero-overlap blunt graph via bluntg) or `raw`
+        #[clap(long, value_parser, default_value = "blunt")]
+        gfa_mode: String,
 
         /// Sequence input for gap filling. Without these, gaps are filled with `N`s.
         #[clap(flatten)]
@@ -3813,6 +4098,8 @@ fn run() -> io::Result<()> {
             approximate,
         } => {
             initialize_threads_and_log(&common);
+            let mut engine_cli = engine_cli;
+            let output_format = apply_gfa_output_engine_shorthand(output_format, &mut engine_cli)?;
 
             let merge_distance = require_merge_distance("partition", merge_distance, no_merge)?;
 
@@ -3835,7 +4122,9 @@ fn run() -> io::Result<()> {
             }
 
             // Parse engine spec early (engine + optional partition size)
-            let (parsed_engine, parsed_partition_size) = engine_cli.parse_engine()?;
+            let parsed_gfa_engine = engine_cli.parse_engine()?;
+            let parsed_engine = parsed_gfa_engine.engine;
+            let parsed_partition_size = parsed_gfa_engine.partition_size;
 
             // Validate partitioned mode + --separate-files are mutually exclusive
             if parsed_partition_size.is_some() && separate_files {
@@ -4020,6 +4309,8 @@ fn run() -> io::Result<()> {
             engine_cli,
         } => {
             initialize_threads_and_log(&common);
+            let mut engine_cli = engine_cli;
+            let output_format = apply_gfa_output_engine_shorthand(output_format, &mut engine_cli)?;
             query.validate_merge_distance("query")?;
             if !syng_seed_drop_top_fraction.is_finite()
                 || !(0.0..1.0).contains(&syng_seed_drop_top_fraction)
@@ -4276,7 +4567,69 @@ fn run() -> io::Result<()> {
                         "gfa" => {
                             let engine_opts = engine_cli.build(common.threads.get())?;
 
-                            if let Some(partition_size) = engine_opts.partition_size {
+                            if engine_opts.engine == GfaEngine::SyngNative {
+                                validate_syng_param_assertion(
+                                    wrapper.syng_index().params,
+                                    engine_opts.syng_params,
+                                )?;
+                                if engine_opts.partition_size.is_some() {
+                                    return Err(io::Error::new(
+                                        io::ErrorKind::InvalidInput,
+                                        "--gfa-engine syng does not support partition windows; use syng:raw or syng:blunt",
+                                    ));
+                                }
+                                let mode = engine_opts
+                                    .syng_gfa_mode
+                                    .unwrap_or(SyngGfaMode::Blunt);
+                                let seq_idx = sequence_index.as_ref().unwrap();
+                                let intervals = if use_boundary_realign {
+                                    impg::syng_transitive::query_transitive_ext_with_seed_filter(
+                                        wrapper.syng_index(),
+                                        target_name,
+                                        *range_start as u64,
+                                        *range_end as u64,
+                                        syng_padding,
+                                        syng_max_depth,
+                                        syng_extension,
+                                        syng_extend_budget,
+                                        syng_min_chain_anchors,
+                                        syng_min_chain_fraction,
+                                        syng_seed_filter,
+                                        query.effective_merge_distance(),
+                                        seq_idx,
+                                    )?
+                                } else {
+                                    query_raw_syng(
+                                        target_name,
+                                        *range_start,
+                                        *range_end,
+                                        syng_padding,
+                                        syng_extension,
+                                    )?
+                                };
+                                let fetched: Vec<(String, Vec<u8>)> = intervals
+                                    .iter()
+                                    .map(|iv| {
+                                        let sequence = seq_idx.fetch_sequence(
+                                            &iv.genome,
+                                            iv.start as i32,
+                                            iv.end as i32,
+                                        )?;
+                                        let seq_name = format!(
+                                            "{}:{}-{}({})",
+                                            iv.genome, iv.start, iv.end, iv.strand
+                                        );
+                                        Ok((seq_name, sequence))
+                                    })
+                                    .collect::<io::Result<Vec<_>>>()?;
+                                let mut out = find_output_stream(&output_prefix, "gfa")?;
+                                emit_syng_region_gfa(
+                                    wrapper.syng_index(),
+                                    &fetched,
+                                    &mut out,
+                                    mode,
+                                )?;
+                            } else if let Some(partition_size) = engine_opts.partition_size {
                                 // ─── Sub-windowed path: syng-at-the-outer-level ───
                                 //
                                 // Split the query range into `partition_size`-bp
@@ -4512,7 +4865,9 @@ fn run() -> io::Result<()> {
             )?;
 
             // Parse engine spec early (engine + optional partition size)
-            let (parsed_engine, parsed_partition_size) = engine_cli.parse_engine()?;
+            let parsed_gfa_engine = engine_cli.parse_engine()?;
+            let parsed_engine = parsed_gfa_engine.engine;
+            let parsed_partition_size = parsed_gfa_engine.partition_size;
 
             // For size validation, flat POA on "gfa" needs the same limit as the old "gfa-poa"
             let size_check_format = if output_format == "gfa" && parsed_engine == GfaEngine::Poa {
@@ -5057,7 +5412,9 @@ fn run() -> io::Result<()> {
             }
 
             // Parse engine spec early
-            let (parsed_engine, parsed_partition_size) = engine_cli.parse_engine()?;
+            let parsed_gfa_engine = engine_cli.parse_engine()?;
+            let parsed_engine = parsed_gfa_engine.engine;
+            let parsed_partition_size = parsed_gfa_engine.partition_size;
 
             if parsed_partition_size.is_some() {
                 return Err(io::Error::new(
@@ -5641,7 +5998,9 @@ fn run() -> io::Result<()> {
             common,
         } => {
             initialize_threads_and_log(&common);
-            let (parsed_engine, parsed_partition_size) = engine_cli.parse_engine()?;
+            let parsed_gfa_engine = engine_cli.parse_engine()?;
+            let parsed_engine = parsed_gfa_engine.engine;
+            let parsed_partition_size = parsed_gfa_engine.partition_size;
             engine_cli.validate_engine_params(parsed_engine)?;
             let temp_dir = resolve_temp_dir(engine_cli.aln.sw.tempdir.clone())?;
             setup_temp_dir(&temp_dir)?;
@@ -5791,12 +6150,14 @@ fn run() -> io::Result<()> {
             initialize_threads_and_log(&common);
             let syng_prefix = detect_syng_prefix(&index).unwrap_or(index);
             let sequence_files = sequence.resolve_sequence_files()?;
+            let (render_engine, syng_gfa_mode) = parse_render_engine_spec(&engine)?;
             let config = render::RenderConfig {
                 syng_prefix: &syng_prefix,
                 target_range: &target_range,
                 output: &output,
                 sequence_files: &sequence_files,
-                engine: &engine,
+                engine: &render_engine,
+                syng_gfa_mode,
                 syng_padding,
                 syng_extension,
                 emit_gfa: !no_gfa,
@@ -6654,13 +7015,15 @@ fn run() -> io::Result<()> {
             syng_prefix,
             output,
             gfa_version,
+            gfa_mode,
             sequence,
             common,
         } => {
             initialize_threads_and_log(&common);
             let version = impg::commands::syng2gfa::GfaVersion::parse(&gfa_version)?;
+            let mode = SyngGfaMode::parse(&gfa_mode)?;
             let sequence_files = sequence.resolve_sequence_files()?;
-            impg::commands::syng2gfa::run(&syng_prefix, &output, version, &sequence_files)?;
+            impg::commands::syng2gfa::run(&syng_prefix, &output, version, &sequence_files, mode)?;
         }
         Args::SyngRepair {
             index,
@@ -6849,6 +7212,8 @@ fn build_engine_opts(
     debug_dir: Option<String>,
     temp_dir: Option<String>,
     partition_size: Option<usize>,
+    syng_gfa_mode: Option<SyngGfaMode>,
+    syng_params: Option<impg::syng::SyncmerParams>,
 ) -> io::Result<EngineOpts> {
     let pipeline = graph::GraphBuildConfig {
         num_threads,
@@ -6883,6 +7248,8 @@ fn build_engine_opts(
 
     Ok(EngineOpts {
         engine,
+        syng_gfa_mode,
+        syng_params,
         pipeline,
         partition_size,
         target_poa_lengths: smooth.parse_target_poa_lengths()?,
@@ -9350,13 +9717,97 @@ mod tests {
             "fasta+paf  FASTA sequences plus PAF-like interval mappings",
             "fasta-aln  FASTA alignment output",
             "gbwt       region-specific syng GBWT/khash output",
-            "Use `impg syng2gfa` to dump the whole syng",
-            "`--gfa-engine` selects how -o gfa is built",
+            "`--gfa-engine syng` emits a syng syncmer GFA",
+            "defaults to syng:blunt; use syng:raw",
+            "-o gfa:syng:blunt,k=63,s=8,seed=7",
+            "`impg syng2gfa` to dump the whole syng syncmer graph",
         ] {
             assert!(
                 help.contains(expected),
                 "query help missing expected text: {expected}"
             );
+        }
+    }
+
+    #[test]
+    fn test_gfa_engine_syng_defaults_to_blunt() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa",
+            "--gfa-engine",
+            "syng",
+        ])
+        .unwrap();
+        match args {
+            Args::Query { engine_cli, .. } => {
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::SyngNative);
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                assert_eq!(parsed.syng_params, None);
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_engine_syng_mode_and_param_assertions() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa",
+            "--gfa-engine",
+            "syng:raw,k=63,s=8,seed=7",
+        ])
+        .unwrap();
+        match args {
+            Args::Query { engine_cli, .. } => {
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::SyngNative);
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Raw));
+                assert_eq!(
+                    parsed.syng_params,
+                    Some(impg::syng::SyncmerParams { k: 8, w: 55, seed: 7 })
+                );
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_can_carry_engine_spec() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:blunt,k=63,s=8,seed=7",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                assert_eq!(
+                    parsed.syng_params,
+                    Some(impg::syng::SyncmerParams { k: 8, w: 55, seed: 7 })
+                );
+            }
+            _ => panic!("expected query command"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2945,6 +2945,26 @@ enum Args {
         common: CommonOpts,
     },
     /// Query overlaps in the alignment
+    #[command(after_help = "\
+Output formats:
+  auto       bed for -r/--target-range; bedpe for -b/--target-bed
+  bed        merged homologous intervals as BED rows
+  bedpe      paired query/result intervals; useful for batch queries and CIGAR-aware output
+  paf        PAF-like projected interval matches
+  gfa        local sequence graph built from query-selected intervals using --gfa-engine
+  maf        multiple-alignment output for query-selected intervals
+  fasta      FASTA sequences for query-selected intervals
+  fasta+paf  FASTA sequences plus PAF-like interval mappings
+  fasta-aln  FASTA alignment output from the local POA/MAF path
+  gbwt       region-specific syng GBWT/khash output; requires -O and sequence files
+
+Syng notes:
+  With -a/--alignment pointing to a syng index, supported query outputs are
+  bed, bedpe, gfa, fasta, and gbwt. Use -o gfa for a local sequence GFA from
+  query-selected intervals. Use `impg syng2gfa` to dump the whole syng
+  syncmer graph instead. `--gfa-engine` selects how -o gfa is built; it is not
+  the output-format flag.
+")]
     Query {
         // --- Input ---
         #[clap(flatten)]
@@ -3041,9 +3061,14 @@ enum Args {
         query: QueryOpts,
 
         // --- Output ---
-        /// Output format: 'auto' ('bed' for -r, 'bedpe' for -b), 'bed', 'bedpe', 'paf', 'gfa', 'maf', 'fasta', 'fasta+paf', or 'gbwt' (region-specific GBWT, requires --sequence-files)
         #[arg(help_heading = "Output options")]
-        #[clap(short = 'o', long, value_parser, default_value = "auto")]
+        #[clap(
+            short = 'o',
+            long,
+            value_parser,
+            default_value = "auto",
+            help = "Output format; see Output formats below"
+        )]
         output_format: String,
 
         /// Prefix for output file (automatically appends the extension based on format; required for 'gbwt' output)
@@ -9302,6 +9327,36 @@ mod tests {
                 assert_eq!(query.merge_distance, Some(50_000));
             }
             _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_query_help_explains_output_formats() {
+        let mut cmd = <Args as clap::CommandFactory>::command();
+        let query_cmd = cmd.find_subcommand_mut("query").unwrap();
+        let mut help = Vec::new();
+        query_cmd.write_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        for expected in [
+            "Output formats:",
+            "auto       bed for -r/--target-range; bedpe for -b/--target-bed",
+            "bed        merged homologous intervals as BED rows",
+            "bedpe      paired query/result intervals",
+            "paf        PAF-like projected interval matches",
+            "gfa        local sequence graph built from query-selected intervals",
+            "maf        multiple-alignment output for query-selected intervals",
+            "fasta      FASTA sequences for query-selected intervals",
+            "fasta+paf  FASTA sequences plus PAF-like interval mappings",
+            "fasta-aln  FASTA alignment output",
+            "gbwt       region-specific syng GBWT/khash output",
+            "Use `impg syng2gfa` to dump the whole syng",
+            "`--gfa-engine` selects how -o gfa is built",
+        ] {
+            assert!(
+                help.contains(expected),
+                "query help missing expected text: {expected}"
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,17 +149,67 @@ fn apply_gfa_output_engine_shorthand(
     output_format: String,
     engine_cli: &mut EngineCliOpts,
 ) -> io::Result<String> {
-    let Some(engine_spec) = output_format.strip_prefix("gfa:") else {
-        return Ok(output_format);
+    let (graph_format, raw_engine_spec) =
+        if let Some(raw_engine_spec) = output_format.strip_prefix("gfa:") {
+            ("gfa", raw_engine_spec)
+        } else if let Some(raw_engine_spec) = output_format.strip_prefix("vcf:") {
+            ("vcf", raw_engine_spec)
+        } else {
+            return Ok(output_format);
+        };
+    let output_example = if graph_format == "vcf" {
+        "-o vcf:syng:blunt"
+    } else {
+        "-o gfa:syng:blunt"
     };
+    let engine_spec = raw_engine_spec.trim();
     if engine_spec.trim().is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "-o gfa:<engine> requires an engine spec, e.g. -o gfa:syng:blunt",
+            format!("-o {graph_format}:<engine> requires an engine spec, e.g. {output_example}"),
         ));
     }
-    engine_cli.engine_raw = engine_spec.to_string();
-    Ok("gfa".to_string())
+
+    let (head, params) = engine_spec
+        .split_once(',')
+        .map_or((engine_spec, ""), |(head, params)| (head.trim(), params));
+    let head_parts: Vec<&str> = head.split(':').map(str::trim).collect();
+    let mut engine_start = 0usize;
+
+    if head_parts
+        .get(engine_start)
+        .is_some_and(|part| part.eq_ignore_ascii_case("sweepga"))
+    {
+        engine_start += 1;
+    }
+    if let Some(part) = head_parts.get(engine_start) {
+        let aligner = part.replace('_', "-").to_ascii_lowercase();
+        if matches!(aligner.as_str(), "wfmash" | "fastga") {
+            engine_cli.aln.sw.aligner = aligner;
+            engine_start += 1;
+        }
+    }
+
+    let normalized_head = if engine_start == 0 {
+        head.to_string()
+    } else {
+        if engine_start >= head_parts.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "-o {graph_format}:{} is missing a graph engine after the alignment prefix",
+                    engine_spec
+                ),
+            ));
+        }
+        head_parts[engine_start..].join(":")
+    };
+    engine_cli.engine_raw = if params.is_empty() {
+        normalized_head
+    } else {
+        format!("{normalized_head},{params}")
+    };
+    Ok(graph_format.to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -1400,85 +1450,6 @@ fn emit_syng_map_projection(
     Ok(())
 }
 
-fn format_syng_params(params: impg::syng::SyncmerParams) -> String {
-    format!(
-        "k={},s={},seed={}",
-        params.k + params.w,
-        params.k,
-        params.seed
-    )
-}
-
-fn validate_syng_param_assertion(
-    actual: impg::syng::SyncmerParams,
-    expected: Option<impg::syng::SyncmerParams>,
-) -> io::Result<()> {
-    if let Some(expected) = expected {
-        if actual != expected {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "syng parameter assertion does not match index: requested {}, index has {}",
-                    format_syng_params(expected),
-                    format_syng_params(actual)
-                ),
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn write_fasta_records(path: &Path, records: &[(String, Vec<u8>)]) -> io::Result<()> {
-    let mut out = BufWriter::new(File::create(path)?);
-    for (name, seq) in records {
-        writeln!(out, ">{name}")?;
-        out.write_all(seq)?;
-        writeln!(out)?;
-    }
-    out.flush()
-}
-
-fn emit_syng_region_gfa<W: Write>(
-    source_index: &impg::syng::SyngIndex,
-    fetched: &[(String, Vec<u8>)],
-    out: &mut W,
-    mode: SyngGfaMode,
-) -> io::Result<()> {
-    if fetched.is_empty() {
-        writeln!(out, "H\tVN:Z:1.0")?;
-        return Ok(());
-    }
-
-    let tempdir = tempfile::Builder::new()
-        .prefix("impg-syng-gfa-")
-        .tempdir()?;
-    let region_prefix_path = tempdir.path().join("region");
-    let region_prefix = region_prefix_path
-        .to_str()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "region prefix is not UTF-8"))?;
-    let seq_refs: Vec<(String, &[u8])> = fetched
-        .iter()
-        .map(|(name, seq)| (name.clone(), seq.as_slice()))
-        .collect();
-    source_index.build_region_gbwt(&seq_refs, region_prefix)?;
-
-    let fasta_path = tempdir.path().join("region.fa");
-    write_fasta_records(&fasta_path, fetched)?;
-    let sequence_files = vec![fasta_path.to_string_lossy().to_string()];
-    let sequence_index = UnifiedSequenceIndex::from_files(&sequence_files)?;
-    let region_index =
-        impg::syng::SyngIndex::load(region_prefix, source_index.params)?;
-
-    impg::commands::syng2gfa::write_gfa_with_mode(
-        &region_index,
-        out,
-        impg::commands::syng2gfa::GfaVersion::V1_0,
-        Some(&sequence_index),
-        mode,
-    )?;
-    Ok(())
-}
-
 const READ_SYNCMER_INDEX_VERSION: u32 = 1;
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -2598,11 +2569,11 @@ impl GfaMafFastaOpts {
 
         let needs_sequence_mandatory = matches!(
             output_format,
-            "gfa" | "maf" | "fasta" | "fasta-aln" | "fasta+paf" | "gbwt"
+            "gfa" | "vcf" | "maf" | "fasta" | "fasta-aln" | "fasta+paf" | "gbwt"
         ) || tracepoint_needs_sequences;
         let needs_sequence_optional = output_format == "paf" && original_sequence_coordinates;
         // POA scoring is needed for gfa (all engines may use it), maf, and fasta-aln
-        let needs_poa = matches!(output_format, "gfa" | "maf" | "fasta-aln");
+        let needs_poa = matches!(output_format, "gfa" | "vcf" | "maf" | "fasta-aln");
 
         let scoring_params = if needs_poa {
             Some(parse_poa_scoring_string(poa_scoring)?)
@@ -2774,7 +2745,7 @@ impl QueryOpts {
         // Default behavior per output format
         let default = match output_format {
             "fasta" | "fasta-aln" => false,
-            "maf" | "gfa" | "bed" => true,
+            "maf" | "gfa" | "vcf" | "bed" => true,
             _ => true,
         };
 
@@ -3207,7 +3178,7 @@ enum Args {
         approximate: bool,
 
         // --- Output ---
-        /// Output format: 'bed', 'gfa' (v1.0), 'maf', or 'fasta' ('gfa', 'maf', and 'fasta' require --sequence-files or --sequence-list)
+        /// Output format: 'bed', 'gfa' (v1.0), 'vcf', 'maf', or 'fasta' ('gfa', 'vcf', 'maf', and 'fasta' require --sequence-files or --sequence-list)
         #[arg(help_heading = "Output options")]
         #[clap(short = 'o', long, value_parser, default_value = "bed")]
         output_format: String,
@@ -3235,6 +3206,7 @@ Output formats:
   bedpe      paired query/result intervals; useful for batch queries and CIGAR-aware output
   paf        PAF-like projected interval matches
   gfa        local sequence graph built from query-selected intervals using --gfa-engine
+  vcf        POVU VCF calls from the local sequence graph selected by --gfa-engine
   maf        multiple-alignment output for query-selected intervals
   fasta      FASTA sequences for query-selected intervals
   fasta+paf  FASTA sequences plus PAF-like interval mappings
@@ -3243,11 +3215,19 @@ Output formats:
 
 Syng notes:
   With -a/--alignment pointing to a syng index, supported query outputs are
-  bed, bedpe, gfa, fasta, and gbwt. Use -o gfa for a local sequence GFA from
+  bed, bedpe, gfa, vcf, fasta, and gbwt. Use -o gfa for a local sequence GFA from
   query-selected intervals. `--gfa-engine syng` emits a syng syncmer GFA and
   defaults to syng:blunt; use syng:raw to preserve native overlaps. The compact
-  form `-o gfa:syng:blunt,k=63,s=8,seed=7` is accepted as shorthand. Use
+  forms `-o gfa:syng:blunt,k=63,s=8,seed=7` and `-o vcf:syng` are accepted
+  as shorthand. Use
   `impg syng2gfa` to dump the whole syng syncmer graph instead.
+
+GFA engine shorthand:
+  `-o gfa:pggb`, `-o gfa:seqwish`, `-o gfa:poa`, `-o gfa:syng`, and the
+  matching `-o vcf:<engine>` forms are equivalent to
+  `-o <format> --gfa-engine <engine>`. Alignment-backed graph builds can also
+  name the aligner prefix, e.g. `-o gfa:wfmash:seqwish`,
+  `-o gfa:fastga:pggb`, or `-o gfa:sweepga:seqwish`.
 ")]
     Query {
         // --- Input ---
@@ -4109,7 +4089,7 @@ fn run() -> io::Result<()> {
             let merge_distance = require_merge_distance("partition", merge_distance, no_merge)?;
 
             validate_selection_mode(&selection_mode)?;
-            validate_output_format(&output_format, &["bed", "gfa", "maf", "fasta"])?;
+            validate_output_format(&output_format, &["bed", "gfa", "vcf", "maf", "fasta"])?;
 
             // Validate --approximate mode compatibility
             if approximate {
@@ -4140,7 +4120,9 @@ fn run() -> io::Result<()> {
             }
 
             // For size validation, flat POA on "gfa" needs the same limit as "gfa-poa"
-            let size_check_format = if output_format == "gfa" && parsed_engine == GfaEngine::Poa {
+            let size_check_format = if matches!(output_format.as_str(), "gfa" | "vcf")
+                && parsed_engine == GfaEngine::Poa
+            {
                 "gfa-poa"
             } else {
                 &output_format
@@ -4185,7 +4167,8 @@ fn run() -> io::Result<()> {
                 let seq_index = syng_index.build_seq_index();
 
                 let reverse_complement = gfa_maf_fasta.reverse_complement;
-                let needs_sequences = matches!(output_format.as_str(), "gfa" | "maf" | "fasta");
+                let needs_sequences =
+                    matches!(output_format.as_str(), "gfa" | "vcf" | "maf" | "fasta");
                 let sequence_index = if needs_sequences {
                     let si = gfa_maf_fasta.sequence.build_sequence_index()?;
                     if si.is_none() {
@@ -4199,7 +4182,7 @@ fn run() -> io::Result<()> {
                     None
                 };
 
-                let scoring_params = if matches!(output_format.as_str(), "gfa" | "maf") {
+                let scoring_params = if matches!(output_format.as_str(), "gfa" | "vcf" | "maf") {
                     Some(parse_poa_scoring_string(&engine_cli.poa_scoring)?)
                 } else {
                     None
@@ -4348,6 +4331,7 @@ fn run() -> io::Result<()> {
                     "bedpe",
                     "paf",
                     "gfa",
+                    "vcf",
                     "maf",
                     "fasta",
                     "fasta+paf",
@@ -4373,13 +4357,13 @@ fn run() -> io::Result<()> {
                 // Validate that alignment files are NOT also provided
                 // (conflicts_with_all handles this at clap level, but be explicit)
 
-                // Only bed, bedpe, gfa, fasta, and gbwt output are supported for syng queries
+                // Only bed, bedpe, gfa, vcf, fasta, and gbwt output are supported for syng queries
                 let resolved_format = if output_format == "auto" { "bed" } else { output_format.as_str() };
-                if !matches!(resolved_format, "bed" | "bedpe" | "gfa" | "fasta" | "gbwt") {
+                if !matches!(resolved_format, "bed" | "bedpe" | "gfa" | "vcf" | "fasta" | "gbwt") {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!(
-                            "syng index queries currently support 'bed', 'bedpe', 'gfa', 'fasta', and 'gbwt' output formats, not '{}'",
+                            "syng index queries currently support 'bed', 'bedpe', 'gfa', 'vcf', 'fasta', and 'gbwt' output formats, not '{}'",
                             resolved_format
                         ),
                     ));
@@ -4442,12 +4426,12 @@ fn run() -> io::Result<()> {
                 // (local indels), paralog copies and long insertions
                 // sit at structurally different signatures (kb-scale
                 // on yeast). A typical `-d` up to a few kb cleanly
-                // Setup output resources for GFA/FASTA/GBWT (need sequence files).
+                // Setup output resources for graph/FASTA/GBWT output (need sequence files).
                 // Boundary realignment also needs them for edge-window fetches.
                 let sequence_files_supplied =
                     !gfa_maf_fasta.sequence.resolve_sequence_files()?.is_empty();
                 let needs_sequences =
-                    matches!(resolved_format, "gfa" | "fasta" | "gbwt")
+                    matches!(resolved_format, "gfa" | "vcf" | "fasta" | "gbwt")
                         || use_boundary_realign
                         || sequence_files_supplied;
                 let sequence_index = if needs_sequences {
@@ -4476,7 +4460,7 @@ fn run() -> io::Result<()> {
                     ));
                 }
 
-                let scoring_params = if resolved_format == "gfa" {
+                let scoring_params = if matches!(resolved_format, "gfa" | "vcf") {
                     Some(parse_poa_scoring_string(&engine_cli.poa_scoring)?)
                 } else {
                     None
@@ -4569,23 +4553,18 @@ fn run() -> io::Result<()> {
                                 )?;
                             }
                         }
-                        "gfa" => {
+                        "gfa" | "vcf" => {
                             let engine_opts = engine_cli.build(common.threads.get())?;
+                            let output_ext = graph_output_extension(resolved_format);
+                            let reference_names = vcf_reference_names(name, target_name);
 
                             if engine_opts.engine == GfaEngine::SyngNative {
-                                validate_syng_param_assertion(
-                                    wrapper.syng_index().params,
-                                    engine_opts.syng_params,
-                                )?;
                                 if engine_opts.partition_size.is_some() {
                                     return Err(io::Error::new(
                                         io::ErrorKind::InvalidInput,
                                         "--gfa-engine syng does not support partition windows; use syng:raw or syng:blunt",
                                     ));
                                 }
-                                let mode = engine_opts
-                                    .syng_gfa_mode
-                                    .unwrap_or(SyngGfaMode::Blunt);
                                 let seq_idx = sequence_index.as_ref().unwrap();
                                 let intervals = if use_boundary_realign {
                                     impg::syng_transitive::query_transitive_ext_with_seed_filter(
@@ -4612,27 +4591,35 @@ fn run() -> io::Result<()> {
                                         syng_extension,
                                     )?
                                 };
-                                let fetched: Vec<(String, Vec<u8>)> = intervals
+                                let query_intervals: Vec<coitrees::Interval<u32>> = intervals
                                     .iter()
-                                    .map(|iv| {
-                                        let sequence = seq_idx.fetch_sequence(
-                                            &iv.genome,
-                                            iv.start as i32,
-                                            iv.end as i32,
-                                        )?;
-                                        let seq_name = format!(
-                                            "{}:{}-{}({})",
-                                            iv.genome, iv.start, iv.end, iv.strand
-                                        );
-                                        Ok((seq_name, sequence))
-                                    })
-                                    .collect::<io::Result<Vec<_>>>()?;
-                                let mut out = find_output_stream(&output_prefix, "gfa")?;
-                                emit_syng_region_gfa(
-                                    wrapper.syng_index(),
-                                    &fetched,
+                                    .filter_map(|iv| syng_interval_to_coitree(iv, wrapper.seq_index()))
+                                    .collect();
+
+                                if query_intervals.is_empty() {
+                                    let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                    write_graph_output(
+                                        String::from("H\tVN:Z:1.0\n"),
+                                        resolved_format,
+                                        &mut out,
+                                        &reference_names,
+                                    )?;
+                                    continue;
+                                }
+
+                                let gfa_output = impg::dispatch_gfa_engine(
+                                    &wrapper,
+                                    &query_intervals,
+                                    seq_idx,
+                                    scoring_params,
+                                    &engine_opts,
+                                )?;
+                                let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                write_graph_output(
+                                    gfa_output,
+                                    resolved_format,
                                     &mut out,
-                                    mode,
+                                    &reference_names,
                                 )?;
                             } else if let Some(partition_size) = engine_opts.partition_size {
                                 // ─── Sub-windowed path: syng-at-the-outer-level ───
@@ -4673,10 +4660,7 @@ fn run() -> io::Result<()> {
                                     };
                                     let window_intervals: Vec<Interval<u32>> = intervals
                                         .iter()
-                                        .filter_map(|iv| {
-                                            let id = wrapper.seq_index().get_id(&iv.genome)?;
-                                            Some(Interval::new(iv.start as i32, iv.end as i32, id))
-                                        })
+                                        .filter_map(|iv| syng_interval_to_coitree(iv, wrapper.seq_index()))
                                         .collect();
                                     info!(
                                         "  [syng sub-window {}] {}:{}-{} → {} intervals",
@@ -4691,8 +4675,13 @@ fn run() -> io::Result<()> {
                                 }
 
                                 if partitions.is_empty() {
-                                    let mut out = find_output_stream(&output_prefix, "gfa")?;
-                                    writeln!(out, "H\tVN:Z:1.0")?;
+                                    let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                    write_graph_output(
+                                        String::from("H\tVN:Z:1.0\n"),
+                                        resolved_format,
+                                        &mut out,
+                                        &reference_names,
+                                    )?;
                                     continue;
                                 }
 
@@ -4703,8 +4692,13 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&output_prefix, "gfa")?;
-                                writeln!(out, "{gfa_output}")?;
+                                let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                write_graph_output(
+                                    gfa_output,
+                                    resolved_format,
+                                    &mut out,
+                                    &reference_names,
+                                )?;
                             } else {
                                 // ─── Flat path: one query_region, one engine run ───
                                 let intervals = if use_boundary_realign {
@@ -4728,15 +4722,17 @@ fn run() -> io::Result<()> {
                                 };
                                 let query_intervals: Vec<coitrees::Interval<u32>> = intervals
                                     .iter()
-                                    .filter_map(|iv| {
-                                        let id = wrapper.seq_index().get_id(&iv.genome)?;
-                                        Some(Interval::new(iv.start as i32, iv.end as i32, id))
-                                    })
+                                    .filter_map(|iv| syng_interval_to_coitree(iv, wrapper.seq_index()))
                                     .collect();
 
                                 if query_intervals.is_empty() {
-                                    let mut out = find_output_stream(&output_prefix, "gfa")?;
-                                    writeln!(out, "H\tVN:Z:1.0")?;
+                                    let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                    write_graph_output(
+                                        String::from("H\tVN:Z:1.0\n"),
+                                        resolved_format,
+                                        &mut out,
+                                        &reference_names,
+                                    )?;
                                     continue;
                                 }
 
@@ -4747,8 +4743,13 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&output_prefix, "gfa")?;
-                                writeln!(out, "{gfa_output}")?;
+                                let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                write_graph_output(
+                                    gfa_output,
+                                    resolved_format,
+                                    &mut out,
+                                    &reference_names,
+                                )?;
                             }
                         }
                         "fasta" => {
@@ -4875,7 +4876,9 @@ fn run() -> io::Result<()> {
             let parsed_partition_size = parsed_gfa_engine.partition_size;
 
             // For size validation, flat POA on "gfa" needs the same limit as the old "gfa-poa"
-            let size_check_format = if output_format == "gfa" && parsed_engine == GfaEngine::Poa {
+            let size_check_format = if matches!(output_format.as_str(), "gfa" | "vcf")
+                && parsed_engine == GfaEngine::Poa
+            {
                 "gfa-poa"
             } else {
                 &output_format
@@ -5083,6 +5086,37 @@ fn run() -> io::Result<()> {
                                 &name,
                                 query.effective_merge_distance(),
                                 query.merge_strands_for_output("gfa"),
+                                scoring_params,
+                                &engine_opts,
+                            )?;
+                        }
+                    }
+                    "vcf" => {
+                        let engine_opts = engine_cli.build(common.threads.get())?;
+                        let reference_names = vcf_reference_names(&name, &target_name);
+                        if let Some(ps) = engine_opts.partition_size {
+                            output_results_vcf_partitioned(
+                                &impg,
+                                &mut find_output_stream(&output_prefix, "vcf")?,
+                                sequence_index.as_ref().unwrap(),
+                                scoring_params,
+                                &engine_opts,
+                                &target_name,
+                                target_range,
+                                ps,
+                                &query,
+                                subset_filter.as_ref(),
+                                &reference_names,
+                            )?;
+                        } else {
+                            output_results_vcf(
+                                &impg,
+                                &mut results,
+                                &mut find_output_stream(&output_prefix, "vcf")?,
+                                sequence_index.as_ref().unwrap(),
+                                &reference_names,
+                                query.effective_merge_distance(),
+                                query.merge_strands_for_output("vcf"),
                                 scoring_params,
                                 &engine_opts,
                             )?;
@@ -7537,6 +7571,33 @@ fn find_output_stream(basename: &Option<String>, extension: &str) -> io::Result<
     }
 }
 
+fn graph_output_extension(output_format: &str) -> &'static str {
+    match output_format {
+        "vcf" => "vcf",
+        _ => "gfa",
+    }
+}
+
+fn vcf_reference_names(range_name: &str, target_name: &str) -> Vec<String> {
+    let mut names = vec![range_name.to_string()];
+    if target_name != range_name {
+        names.push(target_name.to_string());
+    }
+    names
+}
+
+fn write_graph_output(
+    mut gfa_output: String,
+    output_format: &str,
+    out: &mut dyn Write,
+    reference_names: &[String],
+) -> io::Result<()> {
+    if output_format == "vcf" {
+        gfa_output = impg::gfa_to_vcf_string(&gfa_output, reference_names)?;
+    }
+    out.write_all(gfa_output.as_bytes())
+}
+
 /// Load/generate index based on common and alignment options
 fn initialize_index(
     common: &CommonOpts,
@@ -8249,6 +8310,14 @@ fn syng_intervals_to_adjusted(
         .collect()
 }
 
+fn syng_interval_to_coitree(
+    iv: &impg::syng::HomologousInterval,
+    seq_index: &SequenceIndex,
+) -> Option<Interval<u32>> {
+    let id = seq_index.get_id(&iv.genome)?;
+    Some(Interval::new(iv.start as i32, iv.end as i32, id))
+}
+
 fn output_results_bed(
     impg: &impl ImpgIndex,
     results: &mut Vec<AdjustedInterval>,
@@ -8535,6 +8604,37 @@ fn output_results_gfa(
     Ok(())
 }
 
+fn output_results_vcf(
+    impg: &impl ImpgIndex,
+    results: &mut Vec<AdjustedInterval>,
+    out: &mut dyn Write,
+    sequence_index: &UnifiedSequenceIndex,
+    reference_names: &[String],
+    merge_distance: i32,
+    merge_strands: bool,
+    scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
+    engine_opts: &EngineOpts,
+) -> io::Result<()> {
+    merge_query_adjusted_intervals(results, merge_distance, merge_strands);
+
+    let query_intervals: Vec<Interval<u32>> = results
+        .drain(..)
+        .map(|(query_interval, _, _)| query_interval)
+        .collect();
+
+    let gfa_output = impg::dispatch_gfa_engine(
+        impg,
+        &query_intervals,
+        sequence_index,
+        scoring_params,
+        engine_opts,
+    )?;
+    let vcf_output = impg::gfa_to_vcf_string(&gfa_output, reference_names)?;
+    out.write_all(vcf_output.as_bytes())?;
+
+    Ok(())
+}
+
 /// Partitioned GFA output for the query command: splits the query region into
 /// sub-windows of `partition_size` bp, queries each, then runs the partitioned
 /// GFA pipeline (per-partition engine → lace → gfaffix).
@@ -8603,6 +8703,43 @@ fn output_results_gfa_partitioned(
     )?;
     out.write_all(gfa_output.as_bytes())?;
 
+    Ok(())
+}
+
+fn output_results_vcf_partitioned(
+    impg: &impl ImpgIndex,
+    out: &mut dyn Write,
+    sequence_index: &UnifiedSequenceIndex,
+    scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
+    engine_opts: &EngineOpts,
+    target_name: &str,
+    target_range: (i32, i32),
+    partition_size: usize,
+    query: &QueryOpts,
+    subset_filter: Option<&SubsetFilter>,
+    reference_names: &[String],
+) -> io::Result<()> {
+    let mut gfa = Vec::new();
+    output_results_gfa_partitioned(
+        impg,
+        &mut gfa,
+        sequence_index,
+        scoring_params,
+        engine_opts,
+        target_name,
+        target_range,
+        partition_size,
+        query,
+        subset_filter,
+    )?;
+    let gfa_output = String::from_utf8(gfa).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("partitioned GFA output is not UTF-8: {e}"),
+        )
+    })?;
+    let vcf_output = impg::gfa_to_vcf_string(&gfa_output, reference_names)?;
+    out.write_all(vcf_output.as_bytes())?;
     Ok(())
 }
 
@@ -9691,6 +9828,7 @@ mod tests {
             "bedpe      paired query/result intervals",
             "paf        PAF-like projected interval matches",
             "gfa        local sequence graph built from query-selected intervals",
+            "vcf        POVU VCF calls from the local sequence graph",
             "maf        multiple-alignment output for query-selected intervals",
             "fasta      FASTA sequences for query-selected intervals",
             "fasta+paf  FASTA sequences plus PAF-like interval mappings",
@@ -9699,6 +9837,8 @@ mod tests {
             "`--gfa-engine syng` emits a syng syncmer GFA",
             "defaults to syng:blunt; use syng:raw",
             "-o gfa:syng:blunt,k=63,s=8,seed=7",
+            "-o vcf:syng",
+            "-o gfa:wfmash:seqwish",
             "`impg syng2gfa` to dump the whole syng syncmer graph",
         ] {
             assert!(
@@ -9788,6 +9928,103 @@ mod tests {
             }
             _ => panic!("expected query command"),
         }
+    }
+
+    #[test]
+    fn test_gfa_output_format_can_carry_alignment_pipeline_spec() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:wfmash:seqwish:10k",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                assert_eq!(engine_cli.aln.sw.aligner, "wfmash");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::Seqwish);
+                assert_eq!(parsed.partition_size, Some(10_000));
+            }
+            _ => panic!("expected query command"),
+        }
+
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:sweepga:fastga:pggb,window=20k",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                assert_eq!(engine_cli.aln.sw.aligner, "fastga");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::Pggb);
+                assert_eq!(parsed.partition_size, Some(20_000));
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_vcf_output_format_can_carry_engine_spec() {
+        let args = Args::try_parse_from(["impg", "query", "-d", "0", "-o", "vcf:syng"])
+            .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "vcf");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::SyngNative);
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_povu_gfa_to_vcf_string_simple_substitution() {
+        let gfa = concat!(
+            "H\tVN:Z:1.0\n",
+            "S\t0\tA\n",
+            "S\t1\tC\n",
+            "S\t2\tG\n",
+            "S\t3\tT\n",
+            "L\t0\t+\t1\t+\t0M\n",
+            "L\t1\t+\t3\t+\t0M\n",
+            "L\t0\t+\t2\t+\t0M\n",
+            "L\t2\t+\t3\t+\t0M\n",
+            "P\tref\t0+,1+,3+\t*\n",
+            "P\talt\t0+,2+,3+\t*\n",
+        );
+        let refs = vec!["ref".to_string()];
+        let vcf = impg::gfa_to_vcf_string(gfa, &refs).unwrap();
+        assert!(vcf.contains("#CHROM\tPOS\tID\tREF\tALT"));
+        assert!(vcf.contains("ref\t2\t>0>3\tC\tG"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,11 +170,16 @@ struct SyngAgcRecord {
     length: usize,
 }
 
+fn primary_fasta_name(header: &str) -> &str {
+    header.split_whitespace().next().unwrap_or("")
+}
+
 fn syng_sequence_name(sample: &str, contig: &str) -> String {
-    if contig.contains('#') {
-        contig.to_string()
+    let primary = primary_fasta_name(contig);
+    if primary.contains('#') {
+        primary.to_string()
     } else {
-        format!("{}@{}", contig, sample)
+        format!("{}@{}", primary, sample)
     }
 }
 
@@ -6737,18 +6742,11 @@ fn run() -> io::Result<()> {
                             })
                             .collect();
 
-                        // If the contig name already follows PanSN convention
-                        // (sample#haplotype#contig), use it as-is — it already
-                        // embeds the sample, so appending @sample would create
-                        // a redundant suffix that makes query -r lookups fail.
-                        // Otherwise (raw contig name like `chr1`), prepend the
-                        // sample via `contig@sample` so names stay unique across
-                        // samples that share a contig name.
-                        let name = if contig.contains('#') {
-                            contig.clone()
-                        } else {
-                            format!("{}@{}", contig, sample)
-                        };
+                        // Use the primary FASTA/AGC contig token as the syng
+                        // path name. AGC may retain the full FASTA defline
+                        // (`name description`), but queries should address the
+                        // stable primary name only.
+                        let name = syng_sequence_name(sample, contig);
                         let seq_len = seq.len();
                         info!("  Processing {} ({} bp)", name, seq_len);
                         let stats = index.add_sequence(name.clone(), seq);
@@ -9880,6 +9878,21 @@ mod tests {
         assert_eq!(
             read_syncmer_index_path("sample.r2s", "post"),
             "sample.r2s.post"
+        );
+    }
+
+    #[test]
+    fn test_syng_sequence_name_uses_primary_defline_token() {
+        assert_eq!(
+            syng_sequence_name(
+                "GRCh38",
+                "GRCh38#0#chr6  AC:CM000668.2  LN:170805979"
+            ),
+            "GRCh38#0#chr6"
+        );
+        assert_eq!(
+            syng_sequence_name("sampleA", "chr6  AC:CM000668.2"),
+            "chr6@sampleA"
         );
     }
 

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -23,6 +23,37 @@ fn read_u64<R: std::io::Read>(r: &mut R) -> io::Result<u64> {
     Ok(u64::from_le_bytes(buf))
 }
 
+fn read_u64_from_slice(buf: &[u8], offset: &mut usize) -> io::Result<u64> {
+    let end = offset
+        .checked_add(8)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "u64 slice offset overflow"))?;
+    let bytes = buf
+        .get(*offset..end)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "truncated u64 in sidecar"))?;
+    *offset = end;
+    Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn read_u32_from_slice_at(buf: &[u8], offset: usize) -> io::Result<u32> {
+    let end = offset
+        .checked_add(4)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "u32 slice offset overflow"))?;
+    let bytes = buf
+        .get(offset..end)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "truncated u32 in sidecar"))?;
+    Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn read_u64_from_slice_at(buf: &[u8], offset: usize) -> io::Result<u64> {
+    let end = offset
+        .checked_add(8)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "u64 slice offset overflow"))?;
+    let bytes = buf
+        .get(offset..end)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "truncated u64 in sidecar"))?;
+    Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SampledPositionHit {
     pub path_idx: usize,
@@ -65,6 +96,34 @@ struct LocateCheckpointIndex {
     sample_rate: u32,
     shard_mask: usize,
     shards: Vec<FxHashMap<LocateCheckpointKey, LocateCheckpointValue>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CheckpointRecord {
+    signed_node: i32,
+    abs_rank: u32,
+    path_idx: u32,
+    bp_pos: u64,
+}
+
+impl CheckpointRecord {
+    const BYTE_LEN: usize = 16;
+}
+
+/// Persistent occurrence-major syncmer positions.
+///
+/// `.spos` is the query-time inverse of `.pstep`: for each oriented syncmer
+/// node, it stores sampled GBWT occurrence ranks and the path coordinate of
+/// that checkpoint. The payload is fixed-width so it can be memory-mapped and
+/// binary-searched without materializing a global hash table.
+#[derive(Debug)]
+pub struct SampledCheckpointIndex {
+    pub sample_rate: u32,
+    checkpoint_count: u64,
+    signed_nodes: Vec<i32>,
+    record_offsets: Vec<u64>,
+    payload_offset: usize,
+    mmap: memmap2::Mmap,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -209,6 +268,7 @@ pub struct SampledPositions {
     data: Vec<u8>,
 }
 
+#[allow(dead_code)]
 impl SampledPositions {
     const MAGIC: u64 = 0x494D50_53504F53; // "IMPSPOS"
     const VERSION: u64 = 4;
@@ -265,7 +325,10 @@ impl SampledPositions {
         starts.push(acc);
         for &len in path_lengths {
             acc = acc.checked_add(len).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "total path length overflowed u64")
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "total path length overflowed u64",
+                )
             })?;
             starts.push(acc);
         }
@@ -285,12 +348,19 @@ impl SampledPositions {
             return Ok(Vec::new());
         };
         let start = *self.byte_offsets.get(group_idx).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "sampled-position offset missing")
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sampled-position offset missing",
+            )
         })? as usize;
         let end = *self.byte_offsets.get(group_idx + 1).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "sampled-position terminal offset missing")
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sampled-position terminal offset missing",
+            )
         })? as usize;
-        if start > end || end > self.data.len() {
+        let data = self.data.as_slice();
+        if start > end || end > data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "sampled-position byte offsets are out of range",
@@ -303,7 +373,10 @@ impl SampledPositions {
         while pos < end {
             let delta = read_varint_from_slice(&self.data, &mut pos, end)?;
             packed = packed.checked_add(delta).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "sampled position overflowed u64")
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "sampled position overflowed u64",
+                )
             })?;
             let target_orient = (packed & 1) as u8;
             let global_pos = packed >> 1;
@@ -322,7 +395,9 @@ impl SampledPositions {
         if self.path_starts.len() < 2 || global_pos >= *self.path_starts.last()? {
             return None;
         }
-        let upper = self.path_starts.partition_point(|&start| start <= global_pos);
+        let upper = self
+            .path_starts
+            .partition_point(|&start| start <= global_pos);
         let path_idx = upper.checked_sub(1)?;
         Some((path_idx, global_pos - self.path_starts[path_idx]))
     }
@@ -350,7 +425,7 @@ impl SampledPositions {
         }
 
         write_u64(&mut w, self.data.len() as u64)?;
-        w.write_all(&self.data)?;
+        w.write_all(self.data.as_slice())?;
         w.flush()
     }
 
@@ -363,6 +438,7 @@ impl SampledPositions {
         })
     }
 
+    #[allow(dead_code)]
     fn load(path: &str) -> io::Result<Self> {
         let mut r = BufReader::new(std::fs::File::open(path)?);
         let magic = read_u64(&mut r)?;
@@ -452,6 +528,27 @@ impl SampledPositions {
             data,
         })
     }
+
+    fn load_sample_rate(path: &str) -> io::Result<u32> {
+        let mut r = BufReader::new(std::fs::File::open(path)?);
+        let magic = read_u64(&mut r)?;
+        if magic != Self::MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("SampledPositions: bad magic 0x{:x}", magic),
+            ));
+        }
+        let version = read_u64(&mut r)?;
+        if version != Self::VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("SampledPositions: unsupported version {}", version),
+            ));
+        }
+        let sample_rate = read_u64(&mut r)? as u32;
+        validate_position_sample_rate(sample_rate)?;
+        Ok(sample_rate)
+    }
 }
 
 /// Sampled checkpoints keyed by path coordinate.
@@ -460,11 +557,37 @@ impl SampledPositions {
 /// step plus enough GBWT state to resume walking from the sampled step. Query
 /// locate also inverts these checkpoints in memory and finds exact syncmer
 /// positions by walking arbitrary GBWT occurrences forward to the next sample.
+#[derive(Debug)]
+enum SampledPathStepData {
+    Owned(Vec<u8>),
+    Mapped {
+        mmap: memmap2::Mmap,
+        offset: usize,
+        len: usize,
+    },
+}
+
+impl SampledPathStepData {
+    fn len(&self) -> usize {
+        match self {
+            Self::Owned(data) => data.len(),
+            Self::Mapped { len, .. } => *len,
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Owned(data) => data.as_slice(),
+            Self::Mapped { mmap, offset, len } => &mmap[*offset..*offset + *len],
+        }
+    }
+}
+
 pub struct SampledPathSteps {
     pub sample_rate: u32,
     sample_count: u64,
     path_byte_offsets: Vec<u64>,
-    data: Vec<u8>,
+    data: SampledPathStepData,
 }
 
 impl SampledPathSteps {
@@ -568,7 +691,7 @@ impl SampledPathSteps {
             sample_rate,
             sample_count,
             path_byte_offsets,
-            data,
+            data: SampledPathStepData::Owned(data),
         })
     }
 
@@ -598,7 +721,8 @@ impl SampledPathSteps {
                 "path index terminal offset out of range",
             )
         })? as usize;
-        if start > end || end > self.data.len() {
+        let data = self.data.as_slice();
+        if start > end || end > data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "sampled path-step byte offsets are out of range",
@@ -610,8 +734,8 @@ impl SampledPathSteps {
         let mut bp_pos = 0u64;
         let mut step_idx = 0u32;
         while pos < end {
-            let bp_delta = read_varint_from_slice(&self.data, &mut pos, end)?;
-            let step_delta = read_varint_from_slice(&self.data, &mut pos, end)?;
+            let bp_delta = read_varint_from_slice(data, &mut pos, end)?;
+            let step_delta = read_varint_from_slice(data, &mut pos, end)?;
             bp_pos = bp_pos.checked_add(bp_delta).ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "path-step bp position overflow")
             })?;
@@ -624,10 +748,10 @@ impl SampledPathSteps {
             step_idx = step_idx.checked_add(step_delta as u32).ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "path-step index overflow")
             })?;
-            let signed_node = decode_i32(read_varint_from_slice(&self.data, &mut pos, end)?)?;
-            let prev_node = decode_i32(read_varint_from_slice(&self.data, &mut pos, end)?)?;
-            let prev_offset = read_varint_from_slice(&self.data, &mut pos, end)?;
-            let traversal_rank = read_varint_from_slice(&self.data, &mut pos, end)?;
+            let signed_node = decode_i32(read_varint_from_slice(data, &mut pos, end)?)?;
+            let prev_node = decode_i32(read_varint_from_slice(data, &mut pos, end)?)?;
+            let prev_offset = read_varint_from_slice(data, &mut pos, end)?;
+            let traversal_rank = read_varint_from_slice(data, &mut pos, end)?;
             if prev_offset > u32::MAX as u64 || traversal_rank > u32::MAX as u64 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -670,7 +794,7 @@ impl SampledPathSteps {
         }
 
         write_u64(&mut w, self.data.len() as u64)?;
-        w.write_all(&self.data)?;
+        w.write_all(self.data.as_slice())?;
         w.flush()
     }
 
@@ -684,34 +808,34 @@ impl SampledPathSteps {
     }
 
     fn load(path: &str) -> io::Result<Self> {
-        let mut r = BufReader::new(std::fs::File::open(path)?);
-        let magic = read_u64(&mut r)?;
+        let file = std::fs::File::open(path)?;
+        let mmap = unsafe { memmap2::Mmap::map(&file)? };
+        let mut offset = 0usize;
+        let magic = read_u64_from_slice(&mmap, &mut offset)?;
         if magic != Self::MAGIC {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("SampledPathSteps: bad magic 0x{:x}", magic),
             ));
         }
-        let version = read_u64(&mut r)?;
+        let version = read_u64_from_slice(&mmap, &mut offset)?;
         if version != Self::VERSION {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("SampledPathSteps: unsupported version {}", version),
             ));
         }
-        let sample_rate = read_u64(&mut r)? as u32;
+        let sample_rate = read_u64_from_slice(&mmap, &mut offset)? as u32;
         validate_position_sample_rate(sample_rate)?;
-        let sample_count = read_u64(&mut r)?;
+        let sample_count = read_u64_from_slice(&mmap, &mut offset)?;
 
-        let n_offsets = read_u64(&mut r)? as usize;
+        let n_offsets = read_u64_from_slice(&mmap, &mut offset)? as usize;
         let mut path_byte_offsets = Vec::with_capacity(n_offsets);
         for _ in 0..n_offsets {
-            path_byte_offsets.push(read_u64(&mut r)?);
+            path_byte_offsets.push(read_u64_from_slice(&mmap, &mut offset)?);
         }
 
-        let n_data = read_u64(&mut r)? as usize;
-        let mut data = vec![0u8; n_data];
-        r.read_exact(&mut data)?;
+        let n_data = read_u64_from_slice(&mmap, &mut offset)? as usize;
 
         if path_byte_offsets.is_empty() {
             return Err(io::Error::new(
@@ -719,7 +843,7 @@ impl SampledPathSteps {
                 "SampledPathSteps: path offsets cannot be empty",
             ));
         }
-        if path_byte_offsets.last().copied().unwrap_or(0) as usize != data.len() {
+        if path_byte_offsets.last().copied().unwrap_or(0) as usize != n_data {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "SampledPathSteps: final byte offset does not match data length",
@@ -731,13 +855,279 @@ impl SampledPathSteps {
                 "SampledPathSteps: byte offsets are not sorted",
             ));
         }
+        let expected_len = offset.checked_add(n_data).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "path-step file size overflow")
+        })?;
+        if mmap.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "SampledPathSteps: file has {} bytes, expected {}",
+                    mmap.len(),
+                    expected_len
+                ),
+            ));
+        }
 
         Ok(Self {
             sample_rate,
             sample_count,
             path_byte_offsets,
-            data,
+            data: SampledPathStepData::Mapped {
+                mmap,
+                offset,
+                len: n_data,
+            },
         })
+    }
+}
+
+impl SampledCheckpointIndex {
+    const MAGIC: u64 = 0x494D50_53504F31; // "IMPSPO1"
+    const VERSION: u64 = 1;
+
+    fn save_records_atomic(
+        path: &str,
+        sample_rate: u32,
+        records: &mut Vec<CheckpointRecord>,
+    ) -> io::Result<()> {
+        let tmp_path = format!("{}.tmp.{}", path, std::process::id());
+        let result = Self::save_records(&tmp_path, sample_rate, records);
+        match result {
+            Ok(()) => std::fs::rename(&tmp_path, path).map_err(|e| {
+                let _ = std::fs::remove_file(&tmp_path);
+                e
+            }),
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp_path);
+                Err(e)
+            }
+        }
+    }
+
+    fn save_records(
+        path: &str,
+        sample_rate: u32,
+        records: &mut Vec<CheckpointRecord>,
+    ) -> io::Result<()> {
+        validate_position_sample_rate(sample_rate)?;
+        records.par_sort_unstable_by(|a, b| {
+            a.signed_node
+                .cmp(&b.signed_node)
+                .then(a.abs_rank.cmp(&b.abs_rank))
+                .then(a.path_idx.cmp(&b.path_idx))
+                .then(a.bp_pos.cmp(&b.bp_pos))
+        });
+
+        let mut signed_nodes = Vec::new();
+        let mut record_offsets = Vec::new();
+        record_offsets.push(0u64);
+        let mut i = 0usize;
+        while i < records.len() {
+            let signed_node = records[i].signed_node;
+            signed_nodes.push(signed_node);
+            let mut prev_rank = None;
+            while i < records.len() && records[i].signed_node == signed_node {
+                if prev_rank == Some(records[i].abs_rank) {
+                    return Err(Self::duplicate_checkpoint_error(
+                        records[i].signed_node,
+                        records[i].abs_rank,
+                    ));
+                }
+                prev_rank = Some(records[i].abs_rank);
+                i += 1;
+            }
+            record_offsets.push(i as u64);
+        }
+
+        let mut w = BufWriter::new(std::fs::File::create(path)?);
+        write_u64(&mut w, Self::MAGIC)?;
+        write_u64(&mut w, Self::VERSION)?;
+        write_u64(&mut w, sample_rate as u64)?;
+        write_u64(&mut w, records.len() as u64)?;
+
+        write_u64(&mut w, signed_nodes.len() as u64)?;
+        for &signed_node in &signed_nodes {
+            write_u64(&mut w, encode_i32(signed_node))?;
+        }
+        for &offset in &record_offsets {
+            write_u64(&mut w, offset)?;
+        }
+
+        for record in records {
+            w.write_all(&record.abs_rank.to_le_bytes())?;
+            w.write_all(&record.path_idx.to_le_bytes())?;
+            w.write_all(&record.bp_pos.to_le_bytes())?;
+        }
+        w.flush()
+    }
+
+    fn load(path: &str) -> io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mmap = unsafe { memmap2::Mmap::map(&file)? };
+        let mut offset = 0usize;
+        let magic = read_u64_from_slice(&mmap, &mut offset)?;
+        if magic != Self::MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("SampledCheckpointIndex: bad magic 0x{:x}", magic),
+            ));
+        }
+        let version = read_u64_from_slice(&mmap, &mut offset)?;
+        if version != Self::VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("SampledCheckpointIndex: unsupported version {}", version),
+            ));
+        }
+        let sample_rate = read_u64_from_slice(&mmap, &mut offset)? as u32;
+        validate_position_sample_rate(sample_rate)?;
+        let checkpoint_count = read_u64_from_slice(&mmap, &mut offset)?;
+
+        let n_nodes = read_u64_from_slice(&mmap, &mut offset)? as usize;
+        let mut signed_nodes = Vec::with_capacity(n_nodes);
+        for _ in 0..n_nodes {
+            signed_nodes.push(decode_i32(read_u64_from_slice(&mmap, &mut offset)?)?);
+        }
+        let mut record_offsets = Vec::with_capacity(n_nodes + 1);
+        for _ in 0..=n_nodes {
+            record_offsets.push(read_u64_from_slice(&mmap, &mut offset)?);
+        }
+
+        if signed_nodes.windows(2).any(|w| w[0] >= w[1]) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SampledCheckpointIndex: signed node ids are not strictly sorted",
+            ));
+        }
+        if record_offsets.windows(2).any(|w| w[0] > w[1]) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SampledCheckpointIndex: record offsets are not sorted",
+            ));
+        }
+        if record_offsets.last().copied().unwrap_or(0) != checkpoint_count {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SampledCheckpointIndex: final record offset does not match checkpoint count",
+            ));
+        }
+
+        let payload_bytes = (checkpoint_count as usize)
+            .checked_mul(CheckpointRecord::BYTE_LEN)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "checkpoint payload size overflow",
+                )
+            })?;
+        let expected_len = offset.checked_add(payload_bytes).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "checkpoint file size overflow")
+        })?;
+        if mmap.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "SampledCheckpointIndex: file has {} bytes, expected {}",
+                    mmap.len(),
+                    expected_len
+                ),
+            ));
+        }
+
+        Ok(Self {
+            sample_rate,
+            checkpoint_count,
+            signed_nodes,
+            record_offsets,
+            payload_offset: offset,
+            mmap,
+        })
+    }
+
+    pub fn checkpoint_count(&self) -> u64 {
+        self.checkpoint_count
+    }
+
+    pub fn signed_node_count(&self) -> usize {
+        self.signed_nodes.len()
+    }
+
+    fn checkpoint(
+        &self,
+        signed_node: i32,
+        abs_rank: u32,
+    ) -> io::Result<Option<LocateCheckpointValue>> {
+        let Ok(group_idx) = self.signed_nodes.binary_search(&signed_node) else {
+            return Ok(None);
+        };
+        let start = self.record_offsets[group_idx];
+        let end = self.record_offsets[group_idx + 1];
+        let mut lo = start;
+        let mut hi = end;
+        while lo < hi {
+            let mid = lo + ((hi - lo) / 2);
+            let rank = self.record_abs_rank(mid)?;
+            if rank < abs_rank {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        if lo >= end || self.record_abs_rank(lo)? != abs_rank {
+            return Ok(None);
+        }
+        Ok(Some(LocateCheckpointValue {
+            path_idx: self.record_path_idx(lo)? as usize,
+            bp_pos: self.record_bp_pos(lo)?,
+        }))
+    }
+
+    fn record_byte_offset(&self, record_idx: u64) -> io::Result<usize> {
+        let record_idx = usize::try_from(record_idx).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "checkpoint record index exceeds usize",
+            )
+        })?;
+        let payload_delta = record_idx
+            .checked_mul(CheckpointRecord::BYTE_LEN)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "checkpoint record offset overflow",
+                )
+            })?;
+        self.payload_offset
+            .checked_add(payload_delta)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "checkpoint record offset overflow",
+                )
+            })
+    }
+
+    fn record_abs_rank(&self, record_idx: u64) -> io::Result<u32> {
+        read_u32_from_slice_at(&self.mmap, self.record_byte_offset(record_idx)?)
+    }
+
+    fn record_path_idx(&self, record_idx: u64) -> io::Result<u32> {
+        read_u32_from_slice_at(&self.mmap, self.record_byte_offset(record_idx)? + 4)
+    }
+
+    fn record_bp_pos(&self, record_idx: u64) -> io::Result<u64> {
+        read_u64_from_slice_at(&self.mmap, self.record_byte_offset(record_idx)? + 8)
+    }
+
+    fn duplicate_checkpoint_error(signed_node: i32, abs_rank: u32) -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "duplicate syng locate checkpoint for node {} rank {}",
+                signed_node, abs_rank
+            ),
+        )
     }
 }
 
@@ -755,11 +1145,8 @@ struct SampledPositionBuilder {
 }
 
 impl SampledPositionBuilder {
-    fn new(
-        sample_rate: u32,
-        next_path_start: u64,
-        paths_seen: usize,
-    ) -> io::Result<Self> {
+    #[allow(dead_code)]
+    fn new(sample_rate: u32, next_path_start: u64, paths_seen: usize) -> io::Result<Self> {
         Self::new_with_mode(sample_rate, next_path_start, paths_seen, true)
     }
 
@@ -848,7 +1235,8 @@ impl SampledPositionBuilder {
         if self.path_step_data.len() > path_step_start {
             self.sampled_step_paths += 1;
         }
-        self.path_step_offsets.push(self.path_step_data.len() as u64);
+        self.path_step_offsets
+            .push(self.path_step_data.len() as u64);
         self.next_path_start = self
             .next_path_start
             .checked_add(seq_len)
@@ -856,6 +1244,7 @@ impl SampledPositionBuilder {
         self.paths_seen += 1;
     }
 
+    #[allow(dead_code)]
     fn finish(
         self,
         path_lengths: &[u64],
@@ -873,11 +1262,8 @@ impl SampledPositionBuilder {
             walked_paths,
             ..
         } = self;
-        let sampled_positions = SampledPositions::from_samples(
-            sample_rate,
-            path_lengths,
-            position_samples,
-        )?;
+        let sampled_positions =
+            SampledPositions::from_samples(sample_rate, path_lengths, position_samples)?;
         let sampled_path_steps = SampledPathSteps::from_encoded(
             sample_rate,
             path_step_sample_count,
@@ -1047,12 +1433,15 @@ fn encode_regular_position_sample_if_selected(
             "sampled path-step bp positions are not sorted within path",
         )
     })?;
-    let step_delta = step.step_idx.checked_sub(*prev_sample_step).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            "sampled path-step indices are not sorted within path",
-        )
-    })?;
+    let step_delta = step
+        .step_idx
+        .checked_sub(*prev_sample_step)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sampled path-step indices are not sorted within path",
+            )
+        })?;
     push_varint(path_step_data, bp_delta);
     push_varint(path_step_data, step_delta as u64);
     push_varint(path_step_data, encode_i32(step.signed_node));
@@ -1717,11 +2106,7 @@ fn matched_syncmers_best_query_orientation_impl(
     );
 
     if rc_syncmers.len() > out.len() {
-        orient_reverse_query_syncmers(
-            rc_syncmers,
-            query_seq.len(),
-            (params.w + params.k) as usize,
-        );
+        orient_reverse_query_syncmers(rc_syncmers, query_seq.len(), (params.w + params.k) as usize);
         std::mem::swap(out, rc_syncmers);
     }
 }
@@ -1867,10 +2252,10 @@ pub struct SyngIndex {
     seqhash: *mut syng_ffi::Seqhash,
     pub name_map: SyngNameMap,
     pub params: SyncmerParams,
-    /// Succinct sampled path-position sidecar for projected query/map coordinates.
-    sampled_positions: Option<SampledPositions>,
     /// Sampled path checkpoints for path-position to syncmer-step lookup.
     sampled_path_steps: Option<SampledPathSteps>,
+    /// Memory-mapped occurrence-major checkpoints for fast target locate.
+    sampled_checkpoints: Option<SampledCheckpointIndex>,
     /// In-memory locate table keyed by oriented GBWT node occurrence rank.
     locate_checkpoint_index: OnceLock<Result<LocateCheckpointIndex, String>>,
     /// Online collector that records sampled positions while sequences are added.
@@ -1915,11 +2300,11 @@ impl SyngIndex {
             seqhash,
             name_map: SyngNameMap::new(),
             params,
-            sampled_positions: None,
             sampled_path_steps: None,
+            sampled_checkpoints: None,
             locate_checkpoint_index: OnceLock::new(),
             sampled_position_builder: Some(
-                SampledPositionBuilder::new(DEFAULT_POSITION_SAMPLE_RATE, 0, 0)
+                SampledPositionBuilder::new_path_steps_only(DEFAULT_POSITION_SAMPLE_RATE, 0, 0)
                     .expect("default sampled-position parameters are valid"),
             ),
         }
@@ -1987,7 +2372,7 @@ impl SyngIndex {
 
     /// True if a sampled path-position sidecar has been built or loaded.
     pub fn has_sampled_positions(&self) -> bool {
-        self.sampled_positions.is_some()
+        self.sampled_checkpoints.is_some()
     }
 
     /// True if an inverted sampled path-step sidecar has been built or loaded.
@@ -1995,14 +2380,28 @@ impl SyngIndex {
         self.sampled_path_steps.is_some()
     }
 
-    /// Sampling interval for the node-to-position sidecar, if present.
+    /// True if an occurrence-major checkpoint sidecar has been loaded.
+    pub fn has_sampled_checkpoints(&self) -> bool {
+        self.sampled_checkpoints.is_some()
+    }
+
+    /// Sampling interval for the syncmer-position sidecar, if present.
     pub fn sampled_positions_rate(&self) -> Option<u32> {
-        self.sampled_positions.as_ref().map(|positions| positions.sample_rate)
+        self.sampled_checkpoints_rate()
     }
 
     /// Sampling interval for the path-step checkpoint sidecar, if present.
     pub fn sampled_path_steps_rate(&self) -> Option<u32> {
-        self.sampled_path_steps.as_ref().map(|steps| steps.sample_rate)
+        self.sampled_path_steps
+            .as_ref()
+            .map(|steps| steps.sample_rate)
+    }
+
+    /// Sampling interval for the occurrence-major checkpoint sidecar, if present.
+    pub fn sampled_checkpoints_rate(&self) -> Option<u32> {
+        self.sampled_checkpoints
+            .as_ref()
+            .map(|checkpoints| checkpoints.sample_rate)
     }
 
     fn reset_locate_checkpoint_index(&mut self) {
@@ -2025,18 +2424,18 @@ impl SyngIndex {
                     "total path length overflowed u64",
                 )
             })?;
-        self.sampled_position_builder = Some(SampledPositionBuilder::new(
+        self.sampled_position_builder = Some(SampledPositionBuilder::new_path_steps_only(
             sample_rate,
             next_path_start,
             self.name_map.path_to_name.len(),
         )?);
-        self.sampled_positions = None;
         self.sampled_path_steps = None;
+        self.sampled_checkpoints = None;
         self.reset_locate_checkpoint_index();
         Ok(())
     }
 
-    /// Materialize the `.syng.spos` and `.syng.pstep` representations.
+    /// Materialize the `.syng.pstep` and `.syng.spos` representations.
     ///
     /// GBWT occurrence ranks are not stable until all paths have been inserted,
     /// so final `.pstep` checkpoints are rebuilt from the completed GBWT rather
@@ -2047,10 +2446,8 @@ impl SyngIndex {
         let Some(builder) = self.sampled_position_builder.take() else {
             return Ok(None);
         };
-        let stats = self.rebuild_sampled_position_indexes_from_gbwt_parallel(
-            builder.sample_rate,
-            0,
-        )?;
+        let stats =
+            self.rebuild_sampled_position_indexes_from_gbwt_parallel(builder.sample_rate, 0)?;
         Ok(Some(stats))
     }
 
@@ -2114,8 +2511,8 @@ impl SyngIndex {
         seq: Vec<u8>,
         lookup_mode: SyncmerLookupMode,
     ) -> io::Result<SyngAddSequenceStats> {
-        self.sampled_positions = None;
         self.sampled_path_steps = None;
+        self.sampled_checkpoints = None;
         self.reset_locate_checkpoint_index();
 
         let syncmer_len = (self.params.w + self.params.k) as usize;
@@ -2279,7 +2676,7 @@ impl SyngIndex {
     /// - `{prefix}.1khash` — syncmer hash (syng-compatible)
     /// - `{prefix}.1gbwt` — GBWT graph (syng-compatible)
     /// - `{prefix}.syng.names` or `{prefix}.names` — sequence name mapping
-    /// - `{prefix}.syng.spos` or `{prefix}.spos` — sampled path-position index
+    /// - `{prefix}.syng.spos` or `{prefix}.spos` — sampled syncmer occurrence positions
     /// - `{prefix}.syng.pstep` or `{prefix}.pstep` — inverted sampled path-step checkpoints
     /// - `{prefix}.syng.meta` or `{prefix}.meta` — syncmer extraction parameters
     ///
@@ -2367,20 +2764,14 @@ impl SyngIndex {
 
     /// Save only the position sidecars for an existing syng index prefix.
     pub fn save_position_sidecars(&self, prefix: &str) -> io::Result<()> {
-        let sampled_positions = self.sampled_positions.as_ref().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "cannot save syng index without sampled positions",
-            )
-        })?;
-        sampled_positions.save_atomic(&syng_spos_path(prefix))?;
         let sampled_path_steps = self.sampled_path_steps.as_ref().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 "cannot save syng index without sampled path-step checkpoints",
             )
         })?;
-        sampled_path_steps.save_atomic(&syng_pstep_path(prefix))
+        sampled_path_steps.save_atomic(&syng_pstep_path(prefix))?;
+        self.save_checkpoint_sidecar(prefix)
     }
 
     /// Save only the inverted path-step sidecar for an existing syng index prefix.
@@ -2391,7 +2782,74 @@ impl SyngIndex {
                 "cannot save syng index without sampled path-step checkpoints",
             )
         })?;
-        sampled_path_steps.save_atomic(&syng_pstep_path(prefix))
+        sampled_path_steps.save_atomic(&syng_pstep_path(prefix))?;
+        self.save_checkpoint_sidecar(prefix)
+    }
+
+    /// Save only the occurrence-major syncmer-position sidecar for an existing syng index prefix.
+    pub fn save_checkpoint_sidecar(&self, prefix: &str) -> io::Result<()> {
+        let sampled_path_steps = self.sampled_path_steps.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cannot save syng syncmer-position sidecar without sampled path-step checkpoints",
+            )
+        })?;
+        let build_start = std::time::Instant::now();
+        let mut records = self.build_checkpoint_records_from_path_steps(sampled_path_steps)?;
+        let record_count = records.len();
+        SampledCheckpointIndex::save_records_atomic(
+            &syng_spos_path(prefix),
+            sampled_path_steps.sample_rate,
+            &mut records,
+        )?;
+        if std::env::var("SYNG_EMIT_PROFILE").is_ok() {
+            eprintln!(
+                "EMITPROF save_syncmer_position_sidecar checkpoints={} build_save={:.2}s",
+                record_count,
+                build_start.elapsed().as_secs_f64(),
+            );
+        }
+        Ok(())
+    }
+
+    fn build_checkpoint_records_from_path_steps(
+        &self,
+        sampled_path_steps: &SampledPathSteps,
+    ) -> io::Result<Vec<CheckpointRecord>> {
+        let path_count = self.name_map.path_to_name.len();
+        if sampled_path_steps.path_count() != path_count {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "path-step index has {} paths, expected {}",
+                    sampled_path_steps.path_count(),
+                    path_count
+                ),
+            ));
+        }
+        (0..path_count)
+            .into_par_iter()
+            .try_fold(Vec::new, |mut records, path_idx| {
+                let path_idx_u32 = u32::try_from(path_idx).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "path index exceeds u32 in checkpoint sidecar",
+                    )
+                })?;
+                for checkpoint in sampled_path_steps.decode_path(path_idx)? {
+                    records.push(CheckpointRecord {
+                        signed_node: checkpoint.signed_node,
+                        abs_rank: self.absolute_incoming_rank(&checkpoint)?,
+                        path_idx: path_idx_u32,
+                        bp_pos: checkpoint.bp_pos,
+                    });
+                }
+                Ok(records)
+            })
+            .try_reduce(Vec::new, |mut left, right| {
+                left.extend(right);
+                Ok(left)
+            })
     }
 
     /// Load an index from disk.
@@ -2400,8 +2858,8 @@ impl SyngIndex {
     /// - `{prefix}.1khash`
     /// - `{prefix}.1gbwt`
     /// - `{prefix}.syng.names` or `{prefix}.names`
-    /// - `{prefix}.syng.spos` or `{prefix}.spos`
     /// - `{prefix}.syng.pstep` or `{prefix}.pstep`
+    /// - `{prefix}.syng.spos` or `{prefix}.spos`
     /// - `{prefix}.syng.meta` or `{prefix}.meta`
     pub fn load(prefix: &str, _params: SyncmerParams) -> io::Result<Self> {
         Self::load_with_options(prefix, true)
@@ -2479,46 +2937,6 @@ impl SyngIndex {
             syng_ffi::impg_seqhashCreateSafe(params.k as i32, params.w as i32, params.seed as i32)
         };
 
-        // Read sampled-position sidecar.
-        let sampled_positions_path = existing_syng_sidecar_path(prefix, "spos");
-        let sampled_positions = if Path::new(&sampled_positions_path).exists() {
-            match SampledPositions::load(&sampled_positions_path) {
-                Ok(sp) => Some(sp),
-                Err(e) => {
-                    if !require_sampled_positions {
-                        log::warn!(
-                            "ignoring sampled-position sidecar during repair: {} ({})",
-                            sampled_positions_path,
-                            e
-                        );
-                        None
-                    } else {
-                        unsafe {
-                            syng_ffi::syngBWTdestroy(gbwt);
-                            syng_ffi::kmerHashDestroy(kmer_hash);
-                            syng_ffi::impg_seqhashDestroy(seqhash);
-                        }
-                        return Err(e);
-                    }
-                }
-            }
-        } else if require_sampled_positions {
-            unsafe {
-                syng_ffi::syngBWTdestroy(gbwt);
-                syng_ffi::kmerHashDestroy(kmer_hash);
-                syng_ffi::impg_seqhashDestroy(seqhash);
-            }
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "sampled-position sidecar not found: {} (rebuild the syng index with this impg)",
-                    sampled_positions_path
-                ),
-            ));
-        } else {
-            None
-        };
-
         // Read sampled path-step sidecar.
         let sampled_path_steps_path = existing_syng_sidecar_path(prefix, "pstep");
         let sampled_path_steps = if Path::new(&sampled_path_steps_path).exists() {
@@ -2559,14 +2977,65 @@ impl SyngIndex {
             None
         };
 
+        // Read occurrence-major syncmer-position sidecar. Normal loads require
+        // this mmap-backed lookup; repair loads can tolerate a missing/stale
+        // `.spos` so they can rebuild it from `.pstep`.
+        let sampled_checkpoints_path = existing_syng_sidecar_path(prefix, "spos");
+        let mut sampled_checkpoints = if Path::new(&sampled_checkpoints_path).exists() {
+            match SampledCheckpointIndex::load(&sampled_checkpoints_path) {
+                Ok(spos) => Some(spos),
+                Err(e) => {
+                    log::warn!(
+                        "ignoring sampled syncmer-position sidecar: {} ({})",
+                        sampled_checkpoints_path,
+                        e
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        if let (Some(path_steps), Some(checkpoints)) =
+            (sampled_path_steps.as_ref(), sampled_checkpoints.as_ref())
+        {
+            if checkpoints.sample_rate != path_steps.sample_rate
+                || checkpoints.checkpoint_count() != path_steps.sample_count()
+            {
+                log::warn!(
+                    "ignoring stale sampled syncmer-position sidecar {}: rate/count {} / {} does not match .pstep {} / {}",
+                    sampled_checkpoints_path,
+                    checkpoints.sample_rate,
+                    checkpoints.checkpoint_count(),
+                    path_steps.sample_rate,
+                    path_steps.sample_count()
+                );
+                sampled_checkpoints = None;
+            }
+        }
+        if require_sampled_positions && sampled_checkpoints.is_none() {
+            unsafe {
+                syng_ffi::syngBWTdestroy(gbwt);
+                syng_ffi::kmerHashDestroy(kmer_hash);
+                syng_ffi::impg_seqhashDestroy(seqhash);
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "sampled syncmer-position sidecar is missing, stale, or unreadable: {} (run `impg syng-repair` for this index)",
+                    sampled_checkpoints_path
+                ),
+            ));
+        }
+
         Ok(Self {
             gbwt,
             kmer_hash,
             seqhash,
             name_map,
             params,
-            sampled_positions,
             sampled_path_steps,
+            sampled_checkpoints,
             locate_checkpoint_index: OnceLock::new(),
             sampled_position_builder: None,
         })
@@ -2704,7 +3173,7 @@ impl SyngIndex {
         self.walk_path_range_from_sampled_steps(path_idx, start, end)
     }
 
-    /// Rebuild both sampled positional sidecars by walking existing GBWT paths.
+    /// Rebuild sampled path-step checkpoints by walking existing GBWT paths.
     ///
     /// This repairs indexes that already have `.1gbwt`, `.1khash`, `.names`, and
     /// `.meta`, without re-decompressing sequences or reconstructing the graph.
@@ -2712,37 +3181,7 @@ impl SyngIndex {
         &mut self,
         sample_rate: u32,
     ) -> io::Result<SampledPositionBuildStats> {
-        unsafe { syng_ffi::impg_syng_suppress_debug() };
-        let mut builder = SampledPositionBuilder::new(sample_rate, 0, 0)?;
-        let syncmer_len = (self.params.k + self.params.w) as u64;
-        for path_idx in 0..self.name_map.path_to_name.len() {
-            let seq_len = self.name_map.path_to_length[path_idx];
-            let steps = match self
-                .name_map
-                .path_starts
-                .get(path_idx)
-                .and_then(|s| s.as_ref())
-            {
-                Some(start) => self.walk_path_steps(start)?,
-                None if seq_len < syncmer_len => Vec::new(),
-                None => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "cannot rebuild positional sidecars: missing GBWT path start for {}",
-                            self.name_map.path_to_name[path_idx]
-                        ),
-                    ));
-                }
-            };
-            builder.record_path(path_idx, seq_len, &steps);
-        }
-        let (sampled_positions, sampled_path_steps, stats) =
-            builder.finish(&self.name_map.path_to_length)?;
-        self.sampled_positions = Some(sampled_positions);
-        self.sampled_path_steps = Some(sampled_path_steps);
-        self.reset_locate_checkpoint_index();
-        Ok(stats)
+        self.rebuild_sampled_path_steps_from_gbwt(sample_rate)
     }
 
     /// Rebuild only the inverted path-step sidecar by walking existing GBWT paths.
@@ -2755,7 +3194,12 @@ impl SyngIndex {
         let syncmer_len = (self.params.k + self.params.w) as u64;
         for path_idx in 0..self.name_map.path_to_name.len() {
             let seq_len = self.name_map.path_to_length[path_idx];
-            let steps = match self.name_map.path_starts.get(path_idx).and_then(|s| s.as_ref()) {
+            let steps = match self
+                .name_map
+                .path_starts
+                .get(path_idx)
+                .and_then(|s| s.as_ref())
+            {
                 Some(start) => self.walk_path_steps(start)?,
                 None if seq_len < syncmer_len => Vec::new(),
                 None => {
@@ -2773,33 +3217,19 @@ impl SyngIndex {
         let (sampled_path_steps, stats) =
             builder.finish_path_steps(self.name_map.path_to_name.len())?;
         self.sampled_path_steps = Some(sampled_path_steps);
+        self.sampled_checkpoints = None;
         self.reset_locate_checkpoint_index();
         Ok(stats)
     }
 
-    /// Rebuild both sampled positional sidecars by walking existing GBWT paths
+    /// Rebuild sampled path-step checkpoints by walking existing GBWT paths
     /// in parallel. Sampling is a regular per-path syncmer-step grid.
     pub fn rebuild_sampled_position_indexes_from_gbwt_parallel(
         &mut self,
         sample_rate: u32,
         progress_interval: usize,
     ) -> io::Result<SampledPositionBuildStats> {
-        let (sampled_positions, sampled_path_steps, stats) =
-            self.rebuild_sampled_position_chunks_from_gbwt_parallel(
-                sample_rate,
-                true,
-                progress_interval,
-            )?;
-        let sampled_positions = sampled_positions.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "parallel positional repair did not build sampled positions",
-            )
-        })?;
-        self.sampled_positions = Some(sampled_positions);
-        self.sampled_path_steps = Some(sampled_path_steps);
-        self.reset_locate_checkpoint_index();
-        Ok(stats)
+        self.rebuild_sampled_path_steps_from_gbwt_parallel(sample_rate, progress_interval)
     }
 
     /// Rebuild only the inverted path-step sidecar by walking existing GBWT
@@ -2816,6 +3246,7 @@ impl SyngIndex {
                 progress_interval,
             )?;
         self.sampled_path_steps = Some(sampled_path_steps);
+        self.sampled_checkpoints = None;
         self.reset_locate_checkpoint_index();
         Ok(stats)
     }
@@ -2930,14 +3361,13 @@ impl SyngIndex {
                             100.0
                         };
                         log::info!(
-                            "Sampled-position repair progress: {}/{} paths complete ({:.1}%), {}/{} syncmer steps ({:.1}%), {} node-position samples, {} path-step checkpoints; completed path {}/{} {}",
+                            "Sampled-position repair progress: {}/{} paths complete ({:.1}%), {}/{} syncmer steps ({:.1}%), {} path-step checkpoints; completed path {}/{} {}",
                             done,
                             path_count,
                             path_pct,
                             progress.completed_steps,
                             total_steps,
                             step_pct,
-                            progress.completed_position_samples,
                             progress.completed_path_step_samples,
                             path_idx + 1,
                             path_count,
@@ -3278,6 +3708,14 @@ impl SyngIndex {
         })
     }
 
+    fn prepare_locate_checkpoint_lookup(&self) -> io::Result<()> {
+        if self.sampled_checkpoints.is_some() {
+            Ok(())
+        } else {
+            self.locate_checkpoint_index().map(|_| ())
+        }
+    }
+
     fn build_locate_checkpoint_index(&self) -> io::Result<LocateCheckpointIndex> {
         let build_start = std::time::Instant::now();
         let sampled_path_steps = self.sampled_path_steps.as_ref().ok_or_else(|| {
@@ -3344,8 +3782,7 @@ impl SyngIndex {
     }
 
     fn locate_checkpoint_shard(key: &LocateCheckpointKey, shard_mask: usize) -> usize {
-        let h = (key.signed_node as u32 as u64)
-            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        let h = (key.signed_node as u32 as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
             ^ key.abs_rank as u64;
         (h as usize) & shard_mask
     }
@@ -3455,13 +3892,7 @@ impl SyngIndex {
         let mut next_low = *low;
         let mut next_high = *high;
         let matched = unsafe {
-            syng_ffi::syngBWTmatchNext(
-                sbp,
-                signed_node,
-                offset,
-                &mut next_low,
-                &mut next_high,
-            )
+            syng_ffi::syngBWTmatchNext(sbp, signed_node, offset, &mut next_low, &mut next_high)
         };
         if matched {
             *low = next_low;
@@ -3564,7 +3995,8 @@ impl SyngIndex {
         }
         unsafe { syng_ffi::syngBWTpathDestroy(reverse_sbp) };
 
-        let Some((sbp, mut low, mut high)) = self.start_gbwt_match(walk[suffix_start].signed_node)?
+        let Some((sbp, mut low, mut high)) =
+            self.start_gbwt_match(walk[suffix_start].signed_node)?
         else {
             return Ok(None);
         };
@@ -3699,13 +4131,26 @@ impl SyngIndex {
         if signed_node == 0 {
             return Ok(Vec::new());
         }
-        let checkpoint_index = self.locate_checkpoint_index()?;
         if start_rank >= end_rank {
             return Ok(Vec::new());
         }
 
+        let persistent_checkpoint_index = self.sampled_checkpoints.as_ref();
+        let fallback_checkpoint_index = if persistent_checkpoint_index.is_none() {
+            Some(self.locate_checkpoint_index()?)
+        } else {
+            None
+        };
+        let max_walk_steps = persistent_checkpoint_index
+            .map(|index| index.sample_rate)
+            .or_else(|| {
+                fallback_checkpoint_index
+                    .as_ref()
+                    .map(|index| index.sample_rate)
+            })
+            .unwrap_or(DEFAULT_POSITION_SAMPLE_RATE) as usize;
+
         let target_orient = if signed_node >= 0 { 0 } else { 1 };
-        let max_walk_steps = checkpoint_index.sample_rate as usize;
         let mut hits = Vec::new();
         for start_rank in start_rank..end_rank {
             let mut current_node = signed_node;
@@ -3717,9 +4162,15 @@ impl SyngIndex {
                     signed_node: current_node,
                     abs_rank: current_rank,
                 };
-                let shard_idx =
-                    Self::locate_checkpoint_shard(&key, checkpoint_index.shard_mask);
-                if let Some(checkpoint) = checkpoint_index.shards[shard_idx].get(&key) {
+                let checkpoint = if let Some(index) = persistent_checkpoint_index {
+                    index.checkpoint(key.signed_node, key.abs_rank)?
+                } else if let Some(index) = fallback_checkpoint_index {
+                    let shard_idx = Self::locate_checkpoint_shard(&key, index.shard_mask);
+                    index.shards[shard_idx].get(&key).copied()
+                } else {
+                    None
+                };
+                if let Some(checkpoint) = checkpoint {
                     let Some(target_pos) = checkpoint.bp_pos.checked_sub(walked_bp) else {
                         break;
                     };
@@ -3772,10 +4223,9 @@ impl SyngIndex {
             self.locate_signed_node_occurrences(signed_node)?
         };
         if let Some(counts) = counts {
-            hits.extend(self.locate_signed_node_occurrences_with_count(
-                -signed_node,
-                counts.reverse,
-            )?);
+            hits.extend(
+                self.locate_signed_node_occurrences_with_count(-signed_node, counts.reverse)?,
+            );
         } else {
             hits.extend(self.locate_signed_node_occurrences(-signed_node)?);
         }
@@ -3893,15 +4343,14 @@ impl SyngIndex {
         query_extension: u64,
         seed_filter: SyngSeedFilter,
     ) -> Result<Vec<HomologousInterval>, io::Error> {
-        let with_anchors =
-            self.query_region_with_anchors_ext_seed_filtered(
-                genome,
-                start,
-                end,
-                padding,
-                query_extension,
-                seed_filter,
-            )?;
+        let with_anchors = self.query_region_with_anchors_ext_seed_filtered(
+            genome,
+            start,
+            end,
+            padding,
+            query_extension,
+            seed_filter,
+        )?;
         Ok(with_anchors
             .into_iter()
             .map(|h| HomologousInterval {
@@ -4402,10 +4851,10 @@ impl SyngIndex {
         }
 
         let locate_start = std::time::Instant::now();
-        // Build the shared locate table before entering rayon. If the first
-        // task initialized this through OnceLock, the pool could starve while
-        // other workers waited on the same initialization.
-        self.locate_checkpoint_index()?;
+        // Prepare the shared locate table before entering rayon. With `.spos`
+        // this is a no-op; unsaved in-memory indexes can still materialize the
+        // same lookup from `.pstep`-equivalent samples outside the worker pool.
+        self.prepare_locate_checkpoint_lookup()?;
         let mut seed_tasks = Vec::new();
         for run in &runs {
             Self::push_walk_seed_tasks_from_run(run, '+', walk_anchors, &mut seed_tasks);
@@ -4626,7 +5075,8 @@ impl SyngIndex {
 
         let emit_prof = std::env::var("SYNG_EMIT_PROFILE").is_ok();
         let lookup_start = std::time::Instant::now();
-        let mut unvisited: Vec<(u32, Vec<(u64, u8)>)> = Vec::with_capacity(query_node_positions.len());
+        let mut unvisited: Vec<(u32, Vec<(u64, u8)>)> =
+            Vec::with_capacity(query_node_positions.len());
         let mut skipped_visited = 0usize;
         for (node, query_positions) in query_node_positions {
             if visited_nodes
@@ -4657,10 +5107,8 @@ impl SyngIndex {
                 occurrence_counts.push((*node, occurrences));
                 occurrence_counts_by_node.insert(*node, counts);
             }
-            let top_drop_nodes = Self::top_frequency_seed_nodes(
-                &occurrence_counts,
-                seed_filter.drop_top_fraction,
-            );
+            let top_drop_nodes =
+                Self::top_frequency_seed_nodes(&occurrence_counts, seed_filter.drop_top_fraction);
             top_drop_count = top_drop_nodes.len();
             let max_occurrences = seed_filter.max_occurrences;
             let occurrence_by_node: FxHashMap<u32, u32> = occurrence_counts.into_iter().collect();
@@ -4687,6 +5135,7 @@ impl SyngIndex {
         let mut located_hits = 0u64;
         let mut emitted_anchors = 0u64;
         let locate_start = std::time::Instant::now();
+        self.prepare_locate_checkpoint_lookup()?;
         let mut per_node_sampled: FxHashMap<
             (usize, u32, char),
             (u64, u64, FxHashMap<i64, Anchor>),
@@ -5100,9 +5549,7 @@ mod tests {
         assert!(!dictionary.is_empty());
 
         let mut index = SyngIndex::new_with_packed_syncmer_dictionary(params, &dictionary).unwrap();
-        index
-            .enable_online_sampled_positions(1)
-            .unwrap();
+        index.enable_online_sampled_positions(1).unwrap();
         for (name, seq) in sequences {
             let stats = index
                 .add_sequence_with_existing_syncmers(name, seq)
@@ -5143,13 +5590,14 @@ mod tests {
             .find_map(|sm| {
                 let start = sm.query_pos as usize;
                 let end = (start + syncmer_len).min(seq.len());
-                (start..end).find(|&pos| seq[pos] == b'A').map(|pos| (*sm, pos))
+                (start..end)
+                    .find(|&pos| seq[pos] == b'A')
+                    .map(|pos| (*sm, pos))
             })
             .expect("at least one matched syncmer should contain an A base");
         assert!(
             chosen.query_pos <= invalid_pos as u64
-                && (invalid_pos as u64)
-                    < chosen.query_pos.saturating_add(syncmer_len as u64)
+                && (invalid_pos as u64) < chosen.query_pos.saturating_add(syncmer_len as u64)
         );
 
         let mut query = seq.clone();
@@ -5158,8 +5606,7 @@ mod tests {
         assert!(
             matches.iter().all(|sm| {
                 !(sm.query_pos <= invalid_pos as u64
-                    && (invalid_pos as u64)
-                        < sm.query_pos.saturating_add(syncmer_len as u64))
+                    && (invalid_pos as u64) < sm.query_pos.saturating_add(syncmer_len as u64))
             }),
             "matched syncmers must not span ambiguous query bases: {:?}",
             matches
@@ -5226,8 +5673,7 @@ mod tests {
             mems.iter().any(|mem| mem.step_start == 0
                 && mem.step_end == walk.len()
                 && mem.query_start == walk[0].bp_pos
-                && mem.query_end
-                    == walk.last().unwrap().bp_pos + index.syncmer_length_bp() as u64),
+                && mem.query_end == walk.last().unwrap().bp_pos + index.syncmer_length_bp() as u64),
             "the exact query walk should produce a full-length GBWT MEM: {:?}",
             mems
         );
@@ -6013,11 +6459,10 @@ mod tests {
         index.add_sequence("sampleA#0#chr1".to_string(), seq_a);
         index.add_sequence("sampleB#0#chr1".to_string(), seq_b);
         let stats = index.finalize_online_sampled_positions().unwrap().unwrap();
-        assert!(stats.sampled_occurrences > 0);
-        assert!(stats.sampled_nodes > 0);
+        assert_eq!(stats.sampled_occurrences, 0);
+        assert_eq!(stats.sampled_nodes, 0);
         assert!(stats.sampled_path_steps > 0);
         assert!(stats.sampled_step_paths > 0);
-        assert!(index.has_sampled_positions());
         assert!(index.has_sampled_path_steps());
 
         let query = &shared[100..800];
@@ -6049,10 +6494,10 @@ mod tests {
             std::path::Path::new(&format!("{}.syng.pstep", prefix_str)).exists(),
             ".syng.pstep file should exist after save"
         );
-
         let loaded = SyngIndex::load(prefix_str, params).unwrap();
         assert!(loaded.has_sampled_positions());
         assert!(loaded.has_sampled_path_steps());
+        assert!(loaded.has_sampled_checkpoints());
         let loaded_hits = loaded
             .map_sequence("read1", query, 2, 10_000)
             .expect("loaded sampled-position PAF mapping should succeed");
@@ -6164,7 +6609,8 @@ mod tests {
             .find(|step| {
                 !sampled_step_idxs.contains(&step.step_idx)
                     && step.bp_pos > syncmer_len
-                    && step.bp_pos.saturating_add(syncmer_len) < index.name_map.path_to_length[path_idx]
+                    && step.bp_pos.saturating_add(syncmer_len)
+                        < index.name_map.path_to_length[path_idx]
             })
             .expect("expected at least one interior unsampled syncmer");
 
@@ -6183,9 +6629,9 @@ mod tests {
             .unwrap();
 
         assert!(
-            expected
-                .iter()
-                .any(|&(node, pos)| node == boundary_step.signed_node && pos == boundary_step.bp_pos),
+            expected.iter().any(
+                |&(node, pos)| node == boundary_step.signed_node && pos == boundary_step.bp_pos
+            ),
             "test setup should include the unsampled boundary syncmer"
         );
         assert_eq!(observed, expected);
@@ -6298,10 +6744,7 @@ mod tests {
         let params = SyncmerParams::default();
         let mut index = SyngIndex::new(params);
         index.enable_online_sampled_positions(8).unwrap();
-        index.add_sequence(
-            "sampleA#0#chr1".to_string(),
-            make_test_sequence(12_000, 91),
-        );
+        index.add_sequence("sampleA#0#chr1".to_string(), make_test_sequence(12_000, 91));
         index.finalize_online_sampled_positions().unwrap().unwrap();
 
         let path_idx = *index.name_map.name_to_path.get("sampleA#0#chr1").unwrap() as usize;
@@ -6328,9 +6771,9 @@ mod tests {
             );
         }
         assert_eq!(
-            index.sampled_positions.as_ref().unwrap().sample_count(),
             index.sampled_path_steps.as_ref().unwrap().sample_count(),
-            "forward and inverted sidecars should sample the same path steps"
+            sampled_steps.len() as u64,
+            "path-step sidecar should report the decoded checkpoint count"
         );
     }
 
@@ -6340,10 +6783,7 @@ mod tests {
         let params = SyncmerParams::default();
         let mut index = SyngIndex::new(params);
         index.enable_online_sampled_positions(256).unwrap();
-        index.add_sequence(
-            "sampleA#0#chr1".to_string(),
-            make_test_sequence(2_000, 92),
-        );
+        index.add_sequence("sampleA#0#chr1".to_string(), make_test_sequence(2_000, 92));
         index.finalize_online_sampled_positions().unwrap().unwrap();
 
         let path_idx = *index.name_map.name_to_path.get("sampleA#0#chr1").unwrap() as usize;
@@ -6390,11 +6830,12 @@ mod tests {
         let mut repair = SyngIndex::load_for_repair(prefix_str, params).unwrap();
         assert!(!repair.has_sampled_positions());
         assert!(!repair.has_sampled_path_steps());
+        assert!(!repair.has_sampled_checkpoints());
         let stats = repair
             .rebuild_sampled_position_indexes_from_gbwt(1)
             .unwrap();
-        assert!(stats.sampled_occurrences > 0);
-        assert_eq!(stats.sampled_occurrences, stats.sampled_path_steps);
+        assert_eq!(stats.sampled_occurrences, 0);
+        assert!(stats.sampled_path_steps > 0);
         repair.save_position_sidecars(prefix_str).unwrap();
 
         assert!(std::path::Path::new(&format!("{}.syng.spos", prefix_str)).exists());
@@ -6403,6 +6844,7 @@ mod tests {
         let loaded = SyngIndex::load(prefix_str, params).unwrap();
         assert!(loaded.has_sampled_positions());
         assert!(loaded.has_sampled_path_steps());
+        assert!(loaded.has_sampled_checkpoints());
         let path_idx = *loaded.name_map.name_to_path.get("sampleA#0#chr1").unwrap() as usize;
         let checkpoint = loaded
             .sampled_path_step_at_or_before(path_idx, 2_000)
@@ -6410,6 +6852,40 @@ mod tests {
             .unwrap();
         let next = loaded.next_path_step_from_checkpoint(&checkpoint).unwrap();
         assert!(next.is_some());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_loaded_syng_requires_spos_but_repair_can_rebuild() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let seqs = vec![
+            ("sampleA#0#chr1".to_string(), make_test_sequence(4000, 31)),
+            ("sampleB#0#chr1".to_string(), make_test_sequence(4000, 37)),
+        ];
+        let mut index = SyngIndex::build(params, seqs.into_iter());
+
+        let dir = std::env::temp_dir().join("impg_test_syng_requires_spos");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prefix = dir.join("idx");
+        let prefix_str = prefix.to_str().unwrap();
+        index.save(prefix_str).unwrap();
+        std::fs::remove_file(format!("{}.syng.spos", prefix_str)).unwrap();
+
+        let err = match SyngIndex::load(prefix_str, params) {
+            Ok(_) => panic!("normal syng load should reject indexes without .spos"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("sampled syncmer-position sidecar"),
+            "unexpected missing-spos error: {err}"
+        );
+
+        let repair = SyngIndex::load_for_repair(prefix_str, params).unwrap();
+        assert!(repair.has_sampled_path_steps());
+        assert!(!repair.has_sampled_checkpoints());
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -6442,11 +6918,10 @@ mod tests {
             .rebuild_sampled_position_indexes_from_gbwt_parallel(8, 0)
             .unwrap();
 
-        assert_eq!(
-            serial_stats.sampled_occurrences,
-            parallel_stats.sampled_occurrences
-        );
-        assert_eq!(serial_stats.sampled_nodes, parallel_stats.sampled_nodes);
+        assert_eq!(serial_stats.sampled_occurrences, 0);
+        assert_eq!(parallel_stats.sampled_occurrences, 0);
+        assert_eq!(serial_stats.sampled_nodes, 0);
+        assert_eq!(parallel_stats.sampled_nodes, 0);
         assert_eq!(
             serial_stats.sampled_path_steps,
             parallel_stats.sampled_path_steps
@@ -6456,14 +6931,6 @@ mod tests {
             parallel_stats.sampled_step_paths
         );
         assert_eq!(serial_stats.walked_paths, parallel_stats.walked_paths);
-
-        let serial_positions = serial.sampled_positions.as_ref().unwrap();
-        let parallel_positions = parallel.sampled_positions.as_ref().unwrap();
-        assert_eq!(serial_positions.sample_count, parallel_positions.sample_count);
-        assert_eq!(serial_positions.path_starts, parallel_positions.path_starts);
-        assert_eq!(serial_positions.node_ids, parallel_positions.node_ids);
-        assert_eq!(serial_positions.byte_offsets, parallel_positions.byte_offsets);
-        assert_eq!(serial_positions.data, parallel_positions.data);
 
         let serial_steps = serial.sampled_path_steps.as_ref().unwrap();
         let parallel_steps = parallel.sampled_path_steps.as_ref().unwrap();
@@ -6588,6 +7055,7 @@ mod tests {
         let loaded = SyngIndex::load(output_prefix_str, SyncmerParams::default()).unwrap();
         assert!(loaded.has_sampled_positions());
         assert!(loaded.has_sampled_path_steps());
+        assert!(loaded.has_sampled_checkpoints());
         assert_eq!(loaded.name_map.path_to_name.len(), 3);
         assert_eq!(loaded.name_map.path_to_name[0], "HG002#1#chr1");
         assert_eq!(loaded.name_map.path_to_name[1], "HG002#2#chr1");
@@ -6641,11 +7109,14 @@ mod tests {
             !std::path::Path::new(&format!("{}.syng.locate", prefix_str)).exists(),
             ".syng.locate should not be written"
         );
-
         let loaded = SyngIndex::load(prefix_str, params).unwrap();
         assert!(
             loaded.has_sampled_positions(),
             "loaded index should have sampled positions"
+        );
+        assert!(
+            loaded.has_sampled_checkpoints(),
+            "loaded index should have sampled checkpoints"
         );
         let reloaded = loaded.query_region("ga", 0, 1000, 120).unwrap();
 
@@ -6682,7 +7153,7 @@ mod tests {
         ];
 
         let index = SyngIndex::build(params, seqs.into_iter());
-        assert!(index.has_sampled_positions());
+        assert!(index.has_sampled_path_steps());
         let intervals = index.query_region("ga", 0, 1000, 120).unwrap();
         let genomes: std::collections::BTreeSet<&str> =
             intervals.iter().map(|iv| iv.genome.as_str()).collect();
@@ -6727,10 +7198,10 @@ mod tests {
 
         let to_set =
             |v: &[HomologousInterval]| -> std::collections::BTreeSet<(String, u64, u64, char)> {
-            v.iter()
-                .map(|iv| (iv.genome.clone(), iv.start, iv.end, iv.strand))
-                .collect()
-        };
+                v.iter()
+                    .map(|iv| (iv.genome.clone(), iv.start, iv.end, iv.strand))
+                    .collect()
+            };
         assert_eq!(to_set(&path_intervals), to_set(&sequence_intervals));
         assert!(!sequence_intervals.is_empty());
     }

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -7622,6 +7622,43 @@ mod tests {
             stdout
         );
 
+        // Syng engine defaults to blunt graph output, so every emitted link
+        // should have zero overlap after pangenome/bluntg processing.
+        let output = std::process::Command::new(&bin)
+            .args([
+                "query",
+                "-d",
+                "0",
+                "-a",
+                output_prefix.to_str().unwrap(),
+                "--sequence-files",
+                fasta_path.to_str().unwrap(),
+                "-r",
+                "genome_a:0-400",
+                "-o",
+                "gfa",
+                "--gfa-engine",
+                "syng",
+            ])
+            .output()
+            .expect("Failed to run impg query -a syng prefix -o gfa --gfa-engine syng");
+        assert!(
+            output.status.success(),
+            "impg query -a syng prefix -o gfa --gfa-engine syng failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let nonzero_links: Vec<&str> = stdout
+            .lines()
+            .filter(|l| l.starts_with("L\t") && !l.ends_with("\t0M"))
+            .collect();
+        assert!(
+            nonzero_links.is_empty(),
+            "syng engine should default to blunt 0M links. Nonzero links: {:?}\n{}",
+            nonzero_links,
+            stdout
+        );
+
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -63,7 +63,8 @@ struct LocateCheckpointValue {
 #[derive(Debug)]
 struct LocateCheckpointIndex {
     sample_rate: u32,
-    checkpoints: FxHashMap<LocateCheckpointKey, LocateCheckpointValue>,
+    shard_mask: usize,
+    shards: Vec<FxHashMap<LocateCheckpointKey, LocateCheckpointValue>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1522,6 +1523,20 @@ struct QueryWalkStep {
     signed_node: i32,
     bp_pos: u64,
     query_pos: u64,
+}
+
+#[derive(Debug, Clone)]
+struct WalkSeedTask {
+    strand: char,
+    steps: Vec<QueryWalkStep>,
+}
+
+#[derive(Debug, Default)]
+struct WalkSeedTaskHits {
+    seeds_kept: u64,
+    located_hits: u64,
+    emitted_anchors: u64,
+    intervals: Vec<(usize, HomologousIntervalWithAnchors)>,
 }
 
 /// A query syncmer found in the index.
@@ -3264,6 +3279,7 @@ impl SyngIndex {
     }
 
     fn build_locate_checkpoint_index(&self) -> io::Result<LocateCheckpointIndex> {
+        let build_start = std::time::Instant::now();
         let sampled_path_steps = self.sampled_path_steps.as_ref().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -3271,35 +3287,77 @@ impl SyngIndex {
             )
         })?;
 
-        let mut checkpoints: FxHashMap<LocateCheckpointKey, LocateCheckpointValue> =
-            FxHashMap::default();
-        for path_idx in 0..self.name_map.path_to_name.len() {
-            for checkpoint in sampled_path_steps.decode_path(path_idx)? {
-                let abs_rank = self.absolute_incoming_rank(&checkpoint)?;
-                let key = LocateCheckpointKey {
-                    signed_node: checkpoint.signed_node,
-                    abs_rank,
-                };
-                let value = LocateCheckpointValue {
-                    path_idx,
-                    bp_pos: checkpoint.bp_pos,
-                };
-                if checkpoints.insert(key, value).is_some() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "duplicate syng locate checkpoint for node {} rank {}",
-                            key.signed_node, key.abs_rank
-                        ),
-                    ));
+        let shard_count = (rayon::current_num_threads().max(1) * 4).next_power_of_two();
+        let shard_mask = shard_count - 1;
+        let new_shards = || -> Vec<FxHashMap<LocateCheckpointKey, LocateCheckpointValue>> {
+            (0..shard_count).map(|_| FxHashMap::default()).collect()
+        };
+        let mut shards = (0..self.name_map.path_to_name.len())
+            .into_par_iter()
+            .try_fold(new_shards, |mut shards, path_idx| {
+                for checkpoint in sampled_path_steps.decode_path(path_idx)? {
+                    let abs_rank = self.absolute_incoming_rank(&checkpoint)?;
+                    let key = LocateCheckpointKey {
+                        signed_node: checkpoint.signed_node,
+                        abs_rank,
+                    };
+                    let value = LocateCheckpointValue {
+                        path_idx,
+                        bp_pos: checkpoint.bp_pos,
+                    };
+                    let shard_idx = Self::locate_checkpoint_shard(&key, shard_mask);
+                    if shards[shard_idx].insert(key, value).is_some() {
+                        return Err(Self::duplicate_locate_checkpoint_error(key));
+                    }
                 }
-            }
+                Ok(shards)
+            })
+            .try_reduce(new_shards, |mut left, right| {
+                for (left_shard, right_shard) in left.iter_mut().zip(right) {
+                    for (key, value) in right_shard {
+                        if left_shard.insert(key, value).is_some() {
+                            return Err(Self::duplicate_locate_checkpoint_error(key));
+                        }
+                    }
+                }
+                Ok(left)
+            })?;
+        shards.shrink_to_fit();
+        let checkpoint_count: usize = shards.iter().map(FxHashMap::len).sum();
+
+        if std::env::var("SYNG_EMIT_PROFILE").is_ok() {
+            eprintln!(
+                "EMITPROF locate_checkpoint_index paths={} samples={} checkpoints={} shards={} build={:.2}s",
+                self.name_map.path_to_name.len(),
+                sampled_path_steps.sample_count(),
+                checkpoint_count,
+                shard_count,
+                build_start.elapsed().as_secs_f64(),
+            );
         }
 
         Ok(LocateCheckpointIndex {
             sample_rate: sampled_path_steps.sample_rate,
-            checkpoints,
+            shard_mask,
+            shards,
         })
+    }
+
+    fn locate_checkpoint_shard(key: &LocateCheckpointKey, shard_mask: usize) -> usize {
+        let h = (key.signed_node as u32 as u64)
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            ^ key.abs_rank as u64;
+        (h as usize) & shard_mask
+    }
+
+    fn duplicate_locate_checkpoint_error(key: LocateCheckpointKey) -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "duplicate syng locate checkpoint for node {} rank {}",
+                key.signed_node, key.abs_rank
+            ),
+        )
     }
 
     fn absolute_incoming_rank(&self, checkpoint: &SampledPathStepHit) -> io::Result<u32> {
@@ -3659,7 +3717,9 @@ impl SyngIndex {
                     signed_node: current_node,
                     abs_rank: current_rank,
                 };
-                if let Some(checkpoint) = checkpoint_index.checkpoints.get(&key) {
+                let shard_idx =
+                    Self::locate_checkpoint_shard(&key, checkpoint_index.shard_mask);
+                if let Some(checkpoint) = checkpoint_index.shards[shard_idx].get(&key) {
                     let Some(target_pos) = checkpoint.bp_pos.checked_sub(walked_bp) else {
                         break;
                     };
@@ -4342,36 +4402,39 @@ impl SyngIndex {
         }
 
         let locate_start = std::time::Instant::now();
+        // Build the shared locate table before entering rayon. If the first
+        // task initialized this through OnceLock, the pool could starve while
+        // other workers waited on the same initialization.
+        self.locate_checkpoint_index()?;
+        let mut seed_tasks = Vec::new();
+        for run in &runs {
+            Self::push_walk_seed_tasks_from_run(run, '+', walk_anchors, &mut seed_tasks);
+            let reverse_run = self.reverse_query_run(run);
+            Self::push_walk_seed_tasks_from_run(&reverse_run, '-', walk_anchors, &mut seed_tasks);
+        }
+        let seeds_seen = seed_tasks.len() as u64;
+
+        let task_hits: Vec<io::Result<WalkSeedTaskHits>> = seed_tasks
+            .par_iter()
+            .map(|task| self.collect_walk_seed_hits_from_task(task, padding))
+            .collect();
+
         let mut per_path: FxHashMap<(usize, char), Vec<HomologousIntervalWithAnchors>> =
             FxHashMap::default();
-        let mut seeds_seen = 0u64;
         let mut seeds_kept = 0u64;
         let mut located_hits = 0u64;
         let mut emitted_anchors = 0u64;
-        for run in &runs {
-            self.collect_walk_seed_hits_from_run(
-                run,
-                '+',
-                padding,
-                walk_anchors,
-                &mut per_path,
-                &mut seeds_seen,
-                &mut seeds_kept,
-                &mut located_hits,
-                &mut emitted_anchors,
-            )?;
-            let reverse_run = self.reverse_query_run(run);
-            self.collect_walk_seed_hits_from_run(
-                &reverse_run,
-                '-',
-                padding,
-                walk_anchors,
-                &mut per_path,
-                &mut seeds_seen,
-                &mut seeds_kept,
-                &mut located_hits,
-                &mut emitted_anchors,
-            )?;
+        for hits in task_hits {
+            let hits = hits?;
+            seeds_kept += hits.seeds_kept;
+            located_hits += hits.located_hits;
+            emitted_anchors += hits.emitted_anchors;
+            for (path_idx, interval) in hits.intervals {
+                per_path
+                    .entry((path_idx, interval.strand))
+                    .or_default()
+                    .push(interval);
+            }
         }
         let locate_elapsed = locate_start.elapsed();
 
@@ -4409,6 +4472,24 @@ impl SyngIndex {
             );
         }
         Ok(merged)
+    }
+
+    fn push_walk_seed_tasks_from_run(
+        run: &[QueryWalkStep],
+        strand: char,
+        walk_anchors: usize,
+        tasks: &mut Vec<WalkSeedTask>,
+    ) {
+        if run.len() < walk_anchors {
+            return;
+        }
+        for seed_start in (0..=run.len() - walk_anchors).step_by(walk_anchors) {
+            let seed_end = seed_start + walk_anchors;
+            tasks.push(WalkSeedTask {
+                strand,
+                steps: run[seed_start..seed_end].to_vec(),
+            });
+        }
     }
 
     fn reverse_query_run(&self, run: &[QueryWalkStep]) -> Vec<QueryWalkStep> {
@@ -4451,87 +4532,78 @@ impl SyngIndex {
         Ok(Some((walk.last().unwrap().signed_node, low, high)))
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn collect_walk_seed_hits_from_run(
+    fn collect_walk_seed_hits_from_task(
         &self,
-        run: &[QueryWalkStep],
-        strand: char,
+        task: &WalkSeedTask,
         padding: u64,
-        walk_anchors: usize,
-        per_path: &mut FxHashMap<(usize, char), Vec<HomologousIntervalWithAnchors>>,
-        seeds_seen: &mut u64,
-        seeds_kept: &mut u64,
-        located_hits: &mut u64,
-        emitted_anchors: &mut u64,
-    ) -> io::Result<()> {
-        if run.len() < walk_anchors {
-            return Ok(());
-        }
+    ) -> io::Result<WalkSeedTaskHits> {
         let syncmer_len = self.syncmer_length_bp() as u64;
-        for seed_start in (0..=run.len() - walk_anchors).step_by(walk_anchors) {
-            let seed_end = seed_start + walk_anchors;
-            *seeds_seen += 1;
-            let walk: Vec<SyngWalkStep> = run[seed_start..seed_end]
-                .iter()
-                .map(|step| SyngWalkStep {
-                    signed_node: step.signed_node,
-                    bp_pos: step.bp_pos,
-                })
-                .collect();
-            let Some((match_signed_node, match_low, match_high)) = self.match_walk_seed(&walk)?
-            else {
+        let walk: Vec<SyngWalkStep> = task
+            .steps
+            .iter()
+            .map(|step| SyngWalkStep {
+                signed_node: step.signed_node,
+                bp_pos: step.bp_pos,
+            })
+            .collect();
+        let Some((match_signed_node, match_low, match_high)) = self.match_walk_seed(&walk)? else {
+            return Ok(WalkSeedTaskHits::default());
+        };
+        if match_low >= match_high {
+            return Ok(WalkSeedTaskHits::default());
+        }
+        let hits =
+            self.locate_signed_node_occurrence_range(match_signed_node, match_low, match_high)?;
+        let Some(first_step) = task.steps.first() else {
+            return Ok(WalkSeedTaskHits::default());
+        };
+        let Some(last_step) = task.steps.last() else {
+            return Ok(WalkSeedTaskHits::default());
+        };
+        let seed_span = last_step.bp_pos.saturating_sub(first_step.bp_pos);
+
+        let mut out = WalkSeedTaskHits {
+            seeds_kept: 1,
+            located_hits: hits.len() as u64,
+            emitted_anchors: 0,
+            intervals: Vec::new(),
+        };
+        for hit in hits {
+            if hit.path_idx >= self.name_map.path_to_name.len() {
+                continue;
+            }
+            let Some(target_start) = hit.target_pos.checked_sub(seed_span) else {
                 continue;
             };
-            if match_low >= match_high {
+            let genome_len = self.name_map.path_to_length[hit.path_idx];
+            let target_end = hit.target_pos.saturating_add(syncmer_len).min(genome_len);
+            let padded_start = target_start.saturating_sub(padding);
+            let padded_end = target_end.saturating_add(padding).min(genome_len);
+            if padded_start >= padded_end {
                 continue;
             }
-            *seeds_kept += 1;
-            let hits = self.locate_signed_node_occurrence_range(
-                match_signed_node,
-                match_low,
-                match_high,
-            )?;
-            let first_step = &run[seed_start];
-            let last_step = &run[seed_end - 1];
-            let seed_span = last_step.bp_pos.saturating_sub(first_step.bp_pos);
-            for hit in hits {
-                *located_hits += 1;
-                if hit.path_idx >= self.name_map.path_to_name.len() {
-                    continue;
-                }
-                let Some(target_start) = hit.target_pos.checked_sub(seed_span) else {
-                    continue;
-                };
-                let genome_len = self.name_map.path_to_length[hit.path_idx];
-                let target_end = hit.target_pos.saturating_add(syncmer_len).min(genome_len);
-                let padded_start = target_start.saturating_sub(padding);
-                let padded_end = target_end.saturating_add(padding).min(genome_len);
-                if padded_start >= padded_end {
-                    continue;
-                }
-                let mut anchors = Vec::with_capacity(walk_anchors);
-                for step in &run[seed_start..seed_end] {
-                    let rel = step.bp_pos.saturating_sub(first_step.bp_pos);
-                    anchors.push(Anchor {
-                        query_pos: step.query_pos,
-                        target_pos: target_start.saturating_add(rel),
-                        node_id: step.signed_node.unsigned_abs(),
-                    });
-                }
-                *emitted_anchors += anchors.len() as u64;
-                per_path
-                    .entry((hit.path_idx, strand))
-                    .or_default()
-                    .push(HomologousIntervalWithAnchors {
-                        genome: self.name_map.path_to_name[hit.path_idx].clone(),
-                        start: padded_start,
-                        end: padded_end,
-                        strand,
-                        anchors,
-                    });
+            let mut anchors = Vec::with_capacity(task.steps.len());
+            for step in &task.steps {
+                let rel = step.bp_pos.saturating_sub(first_step.bp_pos);
+                anchors.push(Anchor {
+                    query_pos: step.query_pos,
+                    target_pos: target_start.saturating_add(rel),
+                    node_id: step.signed_node.unsigned_abs(),
+                });
             }
+            out.emitted_anchors += anchors.len() as u64;
+            out.intervals.push((
+                hit.path_idx,
+                HomologousIntervalWithAnchors {
+                    genome: self.name_map.path_to_name[hit.path_idx].clone(),
+                    start: padded_start,
+                    end: padded_end,
+                    strand: task.strand,
+                    anchors,
+                },
+            ));
         }
-        Ok(())
+        Ok(out)
     }
 
     fn query_region_from_node_positions_seed_filtered(
@@ -4984,6 +5056,30 @@ mod tests {
         seq
     }
 
+    fn normalize_anchored_hits(
+        hits: Vec<HomologousIntervalWithAnchors>,
+    ) -> Vec<(String, u64, u64, char, Vec<(u64, u64, u32)>)> {
+        let mut out: Vec<_> = hits
+            .into_iter()
+            .map(|mut hit| {
+                hit.anchors.sort_by(|a, b| {
+                    a.query_pos
+                        .cmp(&b.query_pos)
+                        .then(a.target_pos.cmp(&b.target_pos))
+                        .then(a.node_id.cmp(&b.node_id))
+                });
+                let anchors = hit
+                    .anchors
+                    .into_iter()
+                    .map(|a| (a.query_pos, a.target_pos, a.node_id))
+                    .collect();
+                (hit.genome, hit.start, hit.end, hit.strand, anchors)
+            })
+            .collect();
+        out.sort();
+        out
+    }
+
     #[test]
     fn test_preloaded_dictionary_replay_supports_query() {
         let _guard = lock_syng();
@@ -5211,6 +5307,85 @@ mod tests {
             hits.iter().any(|hit| hit.genome == "genome_b"),
             "bounded 3-syncmer walk seeds should recover the divergent homolog; hits: {:?}",
             hits
+        );
+    }
+
+    #[test]
+    fn test_bounded_walk_parallel_query_matches_single_thread() {
+        let _guard = lock_syng();
+        let params = SyncmerParams::default();
+        let seq_a = make_test_sequence(7000, 121);
+        let mut seq_b = seq_a.clone();
+        let mut seq_c = seq_a.clone();
+        for pos in (500..6500).step_by(700) {
+            seq_b[pos] = match seq_b[pos] {
+                b'A' => b'C',
+                b'C' => b'G',
+                b'G' => b'T',
+                b'T' => b'A',
+                other => other,
+            };
+        }
+        for pos in (800..6200).step_by(900) {
+            seq_c[pos] = match seq_c[pos] {
+                b'A' => b'T',
+                b'C' => b'A',
+                b'G' => b'C',
+                b'T' => b'G',
+                other => other,
+            };
+        }
+        let index = SyngIndex::build(
+            params,
+            vec![
+                ("genome_a".to_string(), seq_a.clone()),
+                ("genome_b".to_string(), seq_b),
+                ("genome_c".to_string(), seq_c),
+            ]
+            .into_iter(),
+        );
+        let seed_filter = SyngSeedFilter {
+            max_occurrences: None,
+            drop_top_fraction: 0.0005,
+            walk_anchors: 3,
+        };
+
+        let one_thread = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| {
+                index
+                    .query_region_with_anchors_ext_seed_filtered(
+                        "genome_a",
+                        0,
+                        seq_a.len() as u64,
+                        0,
+                        0,
+                        seed_filter,
+                    )
+                    .unwrap()
+            });
+        let four_threads = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap()
+            .install(|| {
+                index
+                    .query_region_with_anchors_ext_seed_filtered(
+                        "genome_a",
+                        0,
+                        seq_a.len() as u64,
+                        0,
+                        0,
+                        seed_filter,
+                    )
+                    .unwrap()
+            });
+
+        assert_eq!(
+            normalize_anchored_hits(one_thread),
+            normalize_anchored_hits(four_threads)
         );
     }
 

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -3944,6 +3944,119 @@ fn test_partition_syng_end_to_end_bed() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+#[test]
+fn test_partition_syng_gfa_blunt_engine() {
+    let _guard = lock_syng();
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping: impg binary not built");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_partition_syng_gfa_blunt");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let fasta_path = dir.join("test.fa");
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&fasta_path).unwrap();
+        let backbone = numeric_to_ascii(&make_sequence_numeric(2500, 42));
+        let tail1 = numeric_to_ascii(&make_sequence_numeric(700, 1));
+        let tail2 = numeric_to_ascii(&make_sequence_numeric(700, 2));
+
+        writeln!(f, ">sampleA#1#chr1").unwrap();
+        f.write_all(&backbone).unwrap();
+        f.write_all(&tail1).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">sampleB#1#chr1").unwrap();
+        f.write_all(&backbone).unwrap();
+        f.write_all(&tail2).unwrap();
+        writeln!(f).unwrap();
+    }
+
+    let syng_prefix = dir.join("idx");
+    let build = Command::new(&bin)
+        .args([
+            "syng",
+            "-f",
+            fasta_path.to_str().unwrap(),
+            "-o",
+            syng_prefix.to_str().unwrap(),
+            "--position-sample-rate",
+            "1",
+        ])
+        .output()
+        .expect("Failed to run impg syng");
+    assert!(
+        build.status.success(),
+        "impg syng failed. stderr: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let out_folder = dir.join("gfas");
+    std::fs::create_dir_all(&out_folder).unwrap();
+    let part = Command::new(&bin)
+        .args([
+            "partition",
+            "-d",
+            "100000",
+            "-a",
+            syng_prefix.to_str().unwrap(),
+            "-w",
+            "1500",
+            "-o",
+            "gfa",
+            "--gfa-engine",
+            "syng",
+            "--sequence-files",
+            fasta_path.to_str().unwrap(),
+            "--separate-files",
+            "--output-folder",
+            out_folder.to_str().unwrap(),
+            "--min-missing-size",
+            "100",
+            "--min-boundary-distance",
+            "0",
+            "-t",
+            "1",
+        ])
+        .output()
+        .expect("Failed to run impg partition -a syng prefix -o gfa");
+    assert!(
+        part.status.success(),
+        "impg partition syng gfa failed. stdout: {} stderr: {}",
+        String::from_utf8_lossy(&part.stdout),
+        String::from_utf8_lossy(&part.stderr)
+    );
+
+    let gfa_files: Vec<_> = std::fs::read_dir(&out_folder)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("gfa"))
+        .collect();
+    assert!(!gfa_files.is_empty(), "No GFA files produced in {:?}", out_folder);
+
+    let mut saw_segment = false;
+    let mut nonzero_links = Vec::new();
+    for entry in &gfa_files {
+        let text = std::fs::read_to_string(entry.path()).unwrap();
+        saw_segment |= text.lines().any(|line| line.starts_with("S\t"));
+        nonzero_links.extend(
+            text.lines()
+                .filter(|line| line.starts_with("L\t") && !line.ends_with("\t0M"))
+                .map(|line| line.to_string()),
+        );
+    }
+    assert!(saw_segment, "partition syng GFA should contain segment lines");
+    assert!(
+        nonzero_links.is_empty(),
+        "syng partition GFA should be bluntified to 0M links. Nonzero links: {:?}",
+        nonzero_links
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 /// Regression test: `impg query -a <syng-prefix> -o gfa --gfa-engine seqwish:X` must
 /// treat `X` as a sub-window size and split the query range into per-window
 /// partitions, not silently collapse into a flat single-engine run.

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -300,7 +300,7 @@ fn test_syng_render_bundle_preserves_source_namespace() {
         serde_json::from_str(&std::fs::read_to_string(bundle.join("manifest.json")).unwrap())
             .unwrap();
     assert_eq!(manifest["format"], "impg-render-bundle");
-    assert_eq!(manifest["engine"], "syng-native");
+    assert_eq!(manifest["engine"], "syng:blunt");
     assert_eq!(manifest["feature_space"], "syng-syncmer-node");
     assert!(manifest["rendered_paths"].as_u64().unwrap() >= 2);
     assert!(manifest["step_samples"].as_u64().unwrap() > 0);


### PR DESCRIPTION
## Summary
- shard the syng locate checkpoint index so checkpoint-table construction can merge in parallel
- prebuild the locate checkpoint table before entering the bounded-walk rayon loop to avoid OnceLock worker starvation
- locate bounded walk seed hits in parallel and fold deterministic results back through the existing merge path
- add a one-thread vs four-thread bounded-walk determinism test

## Testing
- cargo check
- cargo test -q bounded_walk
- cargo test -q test_syng_query_reconstructs_homology_with_diffs
- cargo test -q test_syng_cli_query_bed_output
- cargo test -q test_syng_identical_sequences_build_and_query
- HPRCv2 C4 -d 50k two-query timing: outputs identical across 1/16/32-thread runs; -t32 checkpoint build 21.68s, first locate 22.38s, warmed locate 0.59s