### PR TITLE
Add graph pipeline DSL parser

### DIFF
--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -1,0 +1,138 @@
+# Graph Pipeline DSL
+
+IMPG graph output is moving toward a typed graph-construction pipeline instead
+of one-off CLI flags for every engine and transformation.
+
+The intended grammar is:
+
+```text
+gfa:<stage>[,<key=value>...][:<stage>[,<key=value>...]...]
+vcf:<stage>[,<key=value>...][:<stage>[,<key=value>...]...]
+```
+
+Stages are separated by `:`. Parameters belong to the stage immediately before
+them and are separated by commas:
+
+```text
+syng,k=63,s=8,seed=7:blunt
+seqwish,min-match-len=70
+pggb,window=20k
+syng,k=63,s=8:crush,max-span=10k,max-traversals=128
+```
+
+This is a graph-pipeline DSL, not a general shell pipeline. Each stage is a
+typed graph producer or graph transform with declared inputs, outputs, and
+parameters.
+
+## Current Runtime Support
+
+The parser accepts the staged grammar, but runtime execution is intentionally
+still conservative.
+
+Supported executable producers today:
+
+```text
+pggb
+seqwish
+poa
+syng
+```
+
+Supported syng graph modes:
+
+```text
+syng
+syng:blunt
+syng:raw
+syng,mode=blunt
+syng,mode=raw
+syng,k=63,s=8,seed=7:blunt
+syng:blunt,k=63,s=8,seed=7
+```
+
+Supported legacy alignment prefixes remain:
+
+```text
+gfa:wfmash:seqwish
+gfa:fastga:pggb
+gfa:sweepga:seqwish
+```
+
+Supported partition/window forms remain:
+
+```text
+gfa:pggb:10k
+gfa:pggb,window=10k
+gfa:seqwish:20k
+gfa:sweepga:fastga:pggb,window=20k
+```
+
+`crush` is parsed as a future graph transform but is not wired into runtime
+dispatch yet. Attempting to run `gfa:syng:crush` currently fails with an
+explicit "not wired yet" error rather than silently changing graph semantics.
+
+## Planned Stages
+
+`crush` should become a generic blunt-graph transform:
+
+```text
+input blunt graph
+  -> POVU/flubble decomposition
+  -> bottom-up non-overlapping site batches
+  -> exact path-preserving local replacement
+  -> recompute decomposition after each phase
+  -> stop when no bounded sites remain
+```
+
+For syng, `crush` should imply blunt input:
+
+```text
+syng:crush == syng:blunt -> crush
+```
+
+For seqwish and pggb, `crush` should operate on the already-blunt local graph:
+
+```text
+seqwish:crush
+pggb:crush
+```
+
+The important design point is that `crush` is not syng-specific. Syng, seqwish,
+pggb, high-k seqwish, and future GBZ/handlegraph-backed renderers should all
+feed a common path-embedded blunt graph into the same transform.
+
+## Stage Parameters
+
+Each stage owns its own parameter namespace. The top-level CLI should parse the
+pipeline into stages and then let each stage validate its own parameters.
+
+Examples:
+
+```text
+syng,k=63,s=8,seed=7
+seqwish,min-match-len=70,sparse-factor=0.001
+pggb,window=20k
+crush,max-span=10k,max-traversal-len=10k,max-traversals=128,method=poa
+```
+
+Unknown parameters should be errors, not warnings. Silent ignoring would make
+graph parameterization hard to reproduce.
+
+## POVU Requirement For Crush
+
+The current `src/resolution.rs` primitive has an exact path-preserving local
+replacement backend, but its detector is deliberately conservative. The real
+`crush` scheduler must be POVU/flubble-driven:
+
+1. Decompose the current graph into flubbles/bubbles/tangles.
+2. Build a parent/child hierarchy.
+3. Select deepest non-overlapping sites.
+4. Extract observed path traversals through each site.
+5. Replace bounded sites exactly.
+6. Recompute decomposition on the changed graph.
+
+At the current pinned `povu-rs` revision, IMPG has native GFA-to-VCF support,
+but not a public flubble hierarchy API. We need a POVU-side API that exposes
+site IDs, parent/child relationships, entry/exit handles, path-supported
+traversal boundaries, and enough node/edge identity to schedule non-overlapping
+bottom-up batches.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -155,6 +155,17 @@ The `-o gfa:<spec>` shorthand is generic. `-o gfa:pggb`, `-o gfa:seqwish`,
 backend: `-o gfa:wfmash:seqwish`, `-o gfa:fastga:pggb`, or
 `-o gfa:sweepga:seqwish`.
 
+The shorthand is parsed as a staged graph pipeline:
+
+```text
+gfa:<stage>[,<key=value>...][:<stage>[,<key=value>...]...]
+```
+
+For example, `gfa:syng,k=63,s=8,seed=7:blunt` and the legacy
+`gfa:syng:blunt,k=63,s=8,seed=7` are both accepted. Future graph transforms
+such as `:crush` use the same staged syntax; see
+`docs/graph-pipeline-dsl.md`.
+
 VCF output uses the same engine dispatch and passes the local GFA to POVU:
 `-o vcf:syng`, `-o vcf:pggb`, `-o vcf:seqwish`, and `-o vcf:poa` are
 equivalent to `-o vcf --gfa-engine <engine>`.

--- a/src/graph_pipeline.rs
+++ b/src/graph_pipeline.rs
@@ -1,0 +1,173 @@
+//! Typed parser for graph-construction pipeline specs.
+//!
+//! The CLI grammar is intentionally small:
+//!
+//! ```text
+//! stage[,key=value...][:stage[,key=value...]...
+//! ```
+//!
+//! The parser validates syntax and normalizes stage/parameter names, but does
+//! not decide whether a stage is executable. Runtime dispatch remains owned by
+//! the command layer.
+
+use std::collections::HashSet;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GraphPipelineSpec {
+    pub stages: Vec<GraphPipelineStage>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GraphPipelineStage {
+    pub name: String,
+    pub params: Vec<GraphPipelineParam>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GraphPipelineParam {
+    pub key: String,
+    pub value: String,
+}
+
+impl GraphPipelineSpec {
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err("empty graph pipeline spec".to_string());
+        }
+
+        let mut stages = Vec::new();
+        for (stage_idx, raw_stage) in raw.split(':').enumerate() {
+            let raw_stage = raw_stage.trim();
+            if raw_stage.is_empty() {
+                return Err(format!("empty stage at position {}", stage_idx + 1));
+            }
+            stages.push(GraphPipelineStage::parse(raw_stage, stage_idx)?);
+        }
+
+        Ok(Self { stages })
+    }
+
+    pub fn to_spec(&self) -> String {
+        self.stages
+            .iter()
+            .map(GraphPipelineStage::to_spec)
+            .collect::<Vec<_>>()
+            .join(":")
+    }
+
+    pub fn stages_from(&self, start: usize) -> Self {
+        Self {
+            stages: self.stages[start..].to_vec(),
+        }
+    }
+}
+
+impl GraphPipelineStage {
+    fn parse(raw: &str, stage_idx: usize) -> Result<Self, String> {
+        let mut pieces = raw.split(',').map(str::trim);
+        let name_raw = pieces.next().unwrap_or_default();
+        let name = normalize_name(name_raw);
+        if name.is_empty() {
+            return Err(format!("empty stage name at position {}", stage_idx + 1));
+        }
+
+        let mut params = Vec::new();
+        let mut seen = HashSet::new();
+        for piece in pieces {
+            if piece.is_empty() {
+                return Err(format!("stage '{}' has an empty parameter", name));
+            }
+            let (key_raw, value_raw) = piece.split_once('=').ok_or_else(|| {
+                format!(
+                    "stage '{}' parameter '{}' must be key=value",
+                    name, piece
+                )
+            })?;
+            let key = normalize_name(key_raw);
+            let value = value_raw.trim().to_string();
+            if key.is_empty() {
+                return Err(format!("stage '{}' has an empty parameter key", name));
+            }
+            if value.is_empty() {
+                return Err(format!("stage '{}' parameter '{}' has empty value", name, key));
+            }
+            if !seen.insert(key.clone()) {
+                return Err(format!("stage '{}' repeats parameter '{}'", name, key));
+            }
+            params.push(GraphPipelineParam { key, value });
+        }
+
+        Ok(Self { name, params })
+    }
+
+    pub fn param(&self, key: &str) -> Option<&str> {
+        let key = normalize_name(key);
+        self.params
+            .iter()
+            .find(|param| param.key == key)
+            .map(|param| param.value.as_str())
+    }
+
+    pub fn to_spec(&self) -> String {
+        let mut out = self.name.clone();
+        for param in &self.params {
+            out.push(',');
+            out.push_str(&param.key);
+            out.push('=');
+            out.push_str(&param.value);
+        }
+        out
+    }
+}
+
+fn normalize_name(raw: &str) -> String {
+    raw.trim().replace('_', "-").to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_stage_params() {
+        let spec = GraphPipelineSpec::parse(
+            "syng,k=63,s=8,seed=7:crush,max-span=10k,max-traversals=128",
+        )
+        .unwrap();
+        assert_eq!(spec.stages.len(), 2);
+        assert_eq!(spec.stages[0].name, "syng");
+        assert_eq!(spec.stages[0].param("k"), Some("63"));
+        assert_eq!(spec.stages[1].name, "crush");
+        assert_eq!(spec.stages[1].param("max_span"), Some("10k"));
+        assert_eq!(
+            spec.to_spec(),
+            "syng,k=63,s=8,seed=7:crush,max-span=10k,max-traversals=128"
+        );
+    }
+
+    #[test]
+    fn preserves_legacy_pipeline_shapes() {
+        let spec = GraphPipelineSpec::parse("wfmash:seqwish:10k").unwrap();
+        assert_eq!(
+            spec.stages.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+            vec!["wfmash", "seqwish", "10k"]
+        );
+
+        let spec = GraphPipelineSpec::parse("sweepga:fastga:pggb,window=20k").unwrap();
+        assert_eq!(
+            spec.stages.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+            vec!["sweepga", "fastga", "pggb"]
+        );
+        assert_eq!(spec.stages[2].param("window"), Some("20k"));
+    }
+
+    #[test]
+    fn rejects_bad_params() {
+        assert!(GraphPipelineSpec::parse("").is_err());
+        assert!(GraphPipelineSpec::parse("syng:").is_err());
+        assert!(GraphPipelineSpec::parse("syng,k").is_err());
+        assert!(GraphPipelineSpec::parse("syng,k=63,").is_err());
+        assert!(GraphPipelineSpec::parse("syng,k=63,k=31").is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod commands;
 pub mod faidx;
 pub mod forest_map;
 pub mod graph;
+pub mod graph_pipeline;
 pub mod genotyping;
 pub mod impg;
 pub mod impg_index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,45 +170,56 @@ fn apply_gfa_output_engine_shorthand(
         ));
     }
 
-    let (head, params) = engine_spec
-        .split_once(',')
-        .map_or((engine_spec, ""), |(head, params)| (head.trim(), params));
-    let head_parts: Vec<&str> = head.split(':').map(str::trim).collect();
+    let pipeline = GraphPipelineSpec::parse(engine_spec).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid -o {graph_format}:{}: {}", engine_spec, e),
+        )
+    })?;
     let mut engine_start = 0usize;
 
-    if head_parts
+    if pipeline
+        .stages
         .get(engine_start)
-        .is_some_and(|part| part.eq_ignore_ascii_case("sweepga"))
+        .is_some_and(|stage| stage.name == "sweepga")
     {
-        engine_start += 1;
-    }
-    if let Some(part) = head_parts.get(engine_start) {
-        let aligner = part.replace('_', "-").to_ascii_lowercase();
-        if matches!(aligner.as_str(), "wfmash" | "fastga") {
-            engine_cli.aln.sw.aligner = aligner;
-            engine_start += 1;
-        }
-    }
-
-    let normalized_head = if engine_start == 0 {
-        head.to_string()
-    } else {
-        if engine_start >= head_parts.len() {
+        if !pipeline.stages[engine_start].params.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
-                    "-o {graph_format}:{} is missing a graph engine after the alignment prefix",
+                    "-o {graph_format}:{} sweepga stage does not accept comma parameters yet",
                     engine_spec
                 ),
             ));
         }
-        head_parts[engine_start..].join(":")
-    };
-    engine_cli.engine_raw = if params.is_empty() {
-        normalized_head
-    } else {
-        format!("{normalized_head},{params}")
-    };
+        engine_start += 1;
+    }
+    if let Some(stage) = pipeline.stages.get(engine_start) {
+        if matches!(stage.name.as_str(), "wfmash" | "fastga") {
+            if !stage.params.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "-o {graph_format}:{} aligner stage '{}' does not accept comma parameters yet",
+                        engine_spec, stage.name
+                    ),
+                ));
+            }
+            engine_cli.aln.sw.aligner = stage.name.clone();
+            engine_start += 1;
+        }
+    }
+
+    if engine_start >= pipeline.stages.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "-o {graph_format}:{} is missing a graph engine after the alignment prefix",
+                engine_spec
+            ),
+        ));
+    }
+    engine_cli.engine_raw = pipeline.stages_from(engine_start).to_spec();
     Ok(graph_format.to_string())
 }
 
@@ -1983,6 +1994,7 @@ fn setup_temp_dir(temp_dir: &str) -> io::Result<()> {
 }
 
 use impg::commands::syng2gfa::SyngGfaMode;
+use impg::graph_pipeline::{GraphPipelineSpec, GraphPipelineStage};
 use impg::{EngineOpts, GfaEngine};
 use sweepga::knn_graph::SparsificationStrategy;
 
@@ -2137,6 +2149,153 @@ struct ParsedGfaEngine {
     syng_params: Option<impg::syng::SyncmerParams>,
 }
 
+fn set_syng_gfa_mode(
+    raw: &str,
+    current: &mut Option<SyngGfaMode>,
+    next: SyngGfaMode,
+) -> io::Result<()> {
+    if let Some(existing) = *current {
+        if existing != next {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid --gfa-engine '{}': conflicting syng modes '{}' and '{}'",
+                    raw,
+                    existing.label(),
+                    next.label()
+                ),
+            ));
+        }
+    }
+    *current = Some(next);
+    Ok(())
+}
+
+fn parse_u32_engine_param(raw: &str, key: &str, value: &str) -> io::Result<u32> {
+    value.parse::<u32>().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid --gfa-engine '{}': {}='{}' is not a u32",
+                raw, key, value
+            ),
+        )
+    })
+}
+
+fn parse_syng_assertion_params(
+    raw: &str,
+    stage: &GraphPipelineStage,
+    syncmer_length: &mut Option<u32>,
+    smer_length: &mut Option<u32>,
+    syncmer_seed: &mut Option<u32>,
+    saw_syng_param: &mut bool,
+) -> io::Result<()> {
+    for param in &stage.params {
+        match param.key.as_str() {
+            "k" | "syncmer" | "syncmer-length" => {
+                *saw_syng_param = true;
+                *syncmer_length = Some(parse_u32_engine_param(raw, &param.key, &param.value)?);
+            }
+            "s" | "smer" | "smer-length" => {
+                *saw_syng_param = true;
+                *smer_length = Some(parse_u32_engine_param(raw, &param.key, &param.value)?);
+            }
+            "seed" => {
+                *saw_syng_param = true;
+                *syncmer_seed = Some(parse_u32_engine_param(raw, &param.key, &param.value)?);
+            }
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Invalid --gfa-engine '{}': unknown syng parameter '{}' on stage '{}'",
+                        raw, other, stage.name
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_engine_stage_params<F>(
+    raw: &str,
+    stage: &GraphPipelineStage,
+    is_syng: bool,
+    parse_window: &F,
+    partition_size: &mut Option<usize>,
+    syng_gfa_mode: &mut Option<SyngGfaMode>,
+    syncmer_length: &mut Option<u32>,
+    smer_length: &mut Option<u32>,
+    syncmer_seed: &mut Option<u32>,
+    saw_syng_param: &mut bool,
+) -> io::Result<()>
+where
+    F: Fn(&str) -> io::Result<usize>,
+{
+    if is_syng {
+        let mut assertion_stage = GraphPipelineStage {
+            name: stage.name.clone(),
+            params: Vec::new(),
+        };
+        for param in &stage.params {
+            match param.key.as_str() {
+                "mode" => {
+                    set_syng_gfa_mode(raw, syng_gfa_mode, SyngGfaMode::parse(&param.value)?)?;
+                }
+                "k" | "syncmer" | "syncmer-length" | "s" | "smer" | "smer-length"
+                | "seed" => assertion_stage.params.push(param.clone()),
+                "window" | "window-size" => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid --gfa-engine '{}': syng GFA modes do not use window",
+                            raw
+                        ),
+                    ));
+                }
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid --gfa-engine '{}': unknown syng parameter '{}'",
+                            raw, other
+                        ),
+                    ));
+                }
+            }
+        }
+        parse_syng_assertion_params(
+            raw,
+            &assertion_stage,
+            syncmer_length,
+            smer_length,
+            syncmer_seed,
+            saw_syng_param,
+        )
+    } else {
+        for param in &stage.params {
+            match param.key.as_str() {
+                "window" | "window-size" => {
+                    *partition_size = Some(parse_window(&param.value)?);
+                }
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid --gfa-engine '{}': unknown parameter '{}' for engine '{}'",
+                            raw, other, stage.name
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 impl EngineCliOpts {
     /// Parse `--gfa-engine`.
     ///
@@ -2147,13 +2306,19 @@ impl EngineCliOpts {
     /// - `syng:blunt,k=63,s=8,seed=7` as an assertion about the input syng index.
     fn parse_engine(&self) -> io::Result<ParsedGfaEngine> {
         let raw = self.engine_raw.trim();
-        let mut parts = raw.split(',').map(str::trim).filter(|p| !p.is_empty());
-        let head = parts.next().unwrap_or("pggb");
-        let param_parts: Vec<&str> = parts.collect();
-        let (engine_name_raw, suffix) = head
-            .split_once(':')
-            .map_or((head, None), |(name, suffix)| (name, Some(suffix)));
-        let engine_name = engine_name_raw.trim().replace('_', "-").to_ascii_lowercase();
+        let pipeline = GraphPipelineSpec::parse(raw).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid --gfa-engine '{}': {}", raw, e),
+            )
+        })?;
+        let engine_stage = pipeline.stages.first().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid --gfa-engine '{}': missing graph engine", raw),
+            )
+        })?;
+        let engine_name = engine_stage.name.as_str();
 
         let parse_window = |value: &str| -> io::Result<usize> {
             let parsed = parse_size(value).map_err(|e| {
@@ -2180,39 +2345,21 @@ impl EngineCliOpts {
             Ok(ps)
         };
 
-        let is_syng = matches!(engine_name.as_str(), "syng" | "syng-native");
+        let is_syng = matches!(engine_name, "syng" | "syng-native");
         let mut partition_size = None;
         let mut syng_gfa_mode = None;
 
-        if let Some(suffix) = suffix {
-            let suffix = suffix.trim();
-            if suffix.is_empty() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("Invalid --gfa-engine '{}': empty value after ':'", raw),
-                ));
-            }
-            if is_syng {
-                syng_gfa_mode = Some(SyngGfaMode::parse(&format!("syng:{suffix}"))?);
-            } else {
-                partition_size = Some(parse_window(suffix)?);
-            }
-        }
-
-        let engine = match engine_name.as_str() {
+        let engine = match engine_name {
             "pggb" => GfaEngine::Pggb,
             "seqwish" => GfaEngine::Seqwish,
             "poa" => GfaEngine::Poa,
-            "syng" | "syng-native" => {
-                syng_gfa_mode.get_or_insert(SyngGfaMode::Blunt);
-                GfaEngine::SyngNative
-            }
+            "syng" | "syng-native" => GfaEngine::SyngNative,
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
                         "Unknown GFA engine '{}'. Valid engines: pggb, seqwish, poa, syng",
-                        engine_name_raw
+                        engine_stage.name
                     ),
                 ));
             }
@@ -2223,89 +2370,54 @@ impl EngineCliOpts {
         let mut syncmer_seed: Option<u32> = None;
         let mut saw_syng_param = false;
 
-        for part in param_parts {
-            let (key, value) = part.split_once('=').ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!(
-                        "Invalid --gfa-engine '{}': parameter '{}' must be key=value",
-                        raw, part
-                    ),
-                )
-            })?;
-            let key = key.trim().replace('_', "-").to_ascii_lowercase();
-            let value = value.trim();
-            match key.as_str() {
-                "window" | "window-size" => {
-                    if is_syng {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': syng GFA modes do not use window", raw),
-                        ));
-                    }
-                    partition_size = Some(parse_window(value)?);
+        parse_engine_stage_params(
+            raw,
+            engine_stage,
+            is_syng,
+            &parse_window,
+            &mut partition_size,
+            &mut syng_gfa_mode,
+            &mut syncmer_length,
+            &mut smer_length,
+            &mut syncmer_seed,
+            &mut saw_syng_param,
+        )?;
+
+        for stage in pipeline.stages.iter().skip(1) {
+            match stage.name.as_str() {
+                "raw" | "blunt" | "bluntg" if is_syng => {
+                    set_syng_gfa_mode(raw, &mut syng_gfa_mode, SyngGfaMode::parse(&stage.name)?)?;
+                    parse_syng_assertion_params(
+                        raw,
+                        stage,
+                        &mut syncmer_length,
+                        &mut smer_length,
+                        &mut syncmer_seed,
+                        &mut saw_syng_param,
+                    )?;
                 }
-                "mode" => {
-                    if !is_syng {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': mode= is only valid for syng", raw),
-                        ));
-                    }
-                    syng_gfa_mode = Some(SyngGfaMode::parse(value)?);
+                "crush" => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid --gfa-engine '{}': graph pipeline stage 'crush' is parsed but not wired yet",
+                            raw
+                        ),
+                    ));
                 }
-                "k" | "syncmer" | "syncmer-length" => {
-                    if !is_syng {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': k= is only valid for syng", raw),
-                        ));
-                    }
-                    saw_syng_param = true;
-                    syncmer_length = Some(value.parse::<u32>().map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': k='{}' is not a u32", raw, value),
-                        )
-                    })?);
-                }
-                "s" | "smer" | "smer-length" => {
-                    if !is_syng {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': s= is only valid for syng", raw),
-                        ));
-                    }
-                    saw_syng_param = true;
-                    smer_length = Some(value.parse::<u32>().map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': s='{}' is not a u32", raw, value),
-                        )
-                    })?);
-                }
-                "seed" => {
-                    if !is_syng {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': seed= is only valid for syng", raw),
-                        ));
-                    }
-                    saw_syng_param = true;
-                    syncmer_seed = Some(value.parse::<u32>().map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            format!("Invalid --gfa-engine '{}': seed='{}' is not a u32", raw, value),
-                        )
-                    })?);
+                stage_name if !is_syng && stage.params.is_empty() => {
+                    partition_size = Some(parse_window(stage_name)?);
                 }
                 other => {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
-                        format!("Invalid --gfa-engine '{}': unknown parameter '{}'", raw, other),
+                        format!("Invalid --gfa-engine '{}': unsupported pipeline stage '{}'", raw, other),
                     ));
                 }
             }
+        }
+        if is_syng && syng_gfa_mode.is_none() {
+            syng_gfa_mode = Some(SyngGfaMode::Blunt);
         }
 
         let syng_params = if saw_syng_param {
@@ -9931,6 +10043,67 @@ mod tests {
     }
 
     #[test]
+    fn test_gfa_output_format_accepts_stage_local_params() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng,k=63,s=8,seed=7:blunt",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                assert_eq!(engine_cli.engine_raw, "syng,k=63,s=8,seed=7:blunt");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                assert_eq!(
+                    parsed.syng_params,
+                    Some(impg::syng::SyncmerParams { k: 8, w: 55, seed: 7 })
+                );
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_parses_but_rejects_unwired_crush_stage() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:crush,max-span=10k",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                assert_eq!(engine_cli.engine_raw, "syng:crush,max-span=10k");
+                let err = engine_cli.parse_engine().unwrap_err();
+                assert!(err.to_string().contains("crush"));
+                assert!(err.to_string().contains("not wired yet"));
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
     fn test_gfa_output_format_can_carry_alignment_pipeline_spec() {
         let args = Args::try_parse_from([
             "impg",
@@ -9980,6 +10153,32 @@ mod tests {
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.engine, GfaEngine::Pggb);
                 assert_eq!(parsed.partition_size, Some(20_000));
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_rejects_unsupported_alignment_stage_params() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:sweepga,foo=bar:seqwish",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let err =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap_err();
+                assert!(err.to_string().contains("sweepga"));
+                assert!(err.to_string().contains("does not accept comma parameters"));
             }
             _ => panic!("expected query command"),
         }


### PR DESCRIPTION
## Summary
- add a typed graph pipeline parser for staged specs like `gfa:syng,k=63,s=8:blunt`
- route existing GFA/VCF engine shorthand through the parser while preserving current pggb/seqwish/poa/syng behavior
- document the DSL and the intended POVU/flubble-backed `crush` transform; `crush` is parsed but intentionally rejected until runtime wiring exists

## Tests
- `cargo test graph_pipeline --lib`
- `cargo test gfa_output_format --bin impg`
- `cargo test`
- `cargo test --release -- --test-threads=1`
- `git diff --check`