### PR TITLE
Wire crush graph pipeline transform

### DIFF
--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -26,8 +26,8 @@ parameters.
 
 ## Current Runtime Support
 
-The parser accepts the staged grammar, but runtime execution is intentionally
-still conservative.
+The parser accepts the staged grammar and runtime execution supports a small
+set of typed producers plus the exact path-preserving `crush` transform.
 
 Supported executable producers today:
 
@@ -67,30 +67,24 @@ gfa:seqwish:20k
 gfa:sweepga:fastga:pggb,window=20k
 ```
 
-`crush` is parsed as a future graph transform but is not wired into runtime
-dispatch yet. Attempting to run `gfa:syng:crush` currently fails with an
-explicit "not wired yet" error rather than silently changing graph semantics.
-
-## Planned Stages
-
-`crush` should become a generic blunt-graph transform:
+`crush` is a generic blunt-graph transform:
 
 ```text
 input blunt graph
-  -> POVU/flubble decomposition
-  -> bottom-up non-overlapping site batches
+  -> POVU-style collinear path-site discovery
+  -> bottom-up leaf-site ordering
   -> exact path-preserving local replacement
-  -> recompute decomposition after each phase
+  -> recompute site discovery after each replacement
   -> stop when no bounded sites remain
 ```
 
-For syng, `crush` should imply blunt input:
+For syng, `crush` implies blunt input:
 
 ```text
 syng:crush == syng:blunt -> crush
 ```
 
-For seqwish and pggb, `crush` should operate on the already-blunt local graph:
+For seqwish and pggb, `crush` operates on the already-blunt local graph:
 
 ```text
 seqwish:crush
@@ -100,6 +94,8 @@ pggb:crush
 The important design point is that `crush` is not syng-specific. Syng, seqwish,
 pggb, high-k seqwish, and future GBZ/handlegraph-backed renderers should all
 feed a common path-embedded blunt graph into the same transform.
+
+`syng:raw:crush` is rejected because the resolver requires blunt `0M` links.
 
 ## Stage Parameters
 
@@ -118,11 +114,15 @@ crush,max-span=10k,max-traversal-len=10k,max-traversals=128,method=poa
 Unknown parameters should be errors, not warnings. Silent ignoring would make
 graph parameterization hard to reproduce.
 
-## POVU Requirement For Crush
+## POVU Requirement For Fuller Crush
 
-The current `src/resolution.rs` primitive has an exact path-preserving local
-replacement backend, but its detector is deliberately conservative. The real
-`crush` scheduler must be POVU/flubble-driven:
+The current `src/resolution.rs` implementation uses the same reference-path
+collinear-match site model as POVU's native Rust VCF extractor, then processes
+leaf sites first and validates exact path-sequence preservation after every
+replacement. This is enough to make `:crush` executable and testable.
+
+The fuller scheduler should be POVU/flubble-driven when `povu-rs` exposes the
+needed hierarchy API:
 
 1. Decompose the current graph into flubbles/bubbles/tangles.
 2. Build a parent/child hierarchy.
@@ -132,7 +132,8 @@ replacement backend, but its detector is deliberately conservative. The real
 6. Recompute decomposition on the changed graph.
 
 At the current pinned `povu-rs` revision, IMPG has native GFA-to-VCF support,
-but not a public flubble hierarchy API. We need a POVU-side API that exposes
-site IDs, parent/child relationships, entry/exit handles, path-supported
-traversal boundaries, and enough node/edge identity to schedule non-overlapping
-bottom-up batches.
+but not a public flubble hierarchy API. The current `:crush` implementation
+therefore does not consume a public POVU hierarchy yet. We still need a
+POVU-side API that exposes site IDs, parent/child relationships, entry/exit
+handles, path-supported traversal boundaries, and enough node/edge identity to
+schedule non-overlapping bottom-up batches.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -162,8 +162,9 @@ gfa:<stage>[,<key=value>...][:<stage>[,<key=value>...]...]
 ```
 
 For example, `gfa:syng,k=63,s=8,seed=7:blunt` and the legacy
-`gfa:syng:blunt,k=63,s=8,seed=7` are both accepted. Future graph transforms
-such as `:crush` use the same staged syntax; see
+`gfa:syng:blunt,k=63,s=8,seed=7` are both accepted. Graph transforms use the
+same staged syntax. `gfa:syng:crush,max-span=10k,max-traversals=128` emits
+blunt syng GFA and then runs exact path-preserving bubble resolution; see
 `docs/graph-pipeline-dsl.md`.
 
 VCF output uses the same engine dispatch and passes the local GFA to POVU:

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -299,6 +299,7 @@ fn discover_partitions(
         max_node_length: 100,
         poa_padding_fraction: 0.001,
         partition_size: None,
+        crush_config: None,
     };
 
     info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub struct EngineOpts {
     /// When set, activates the partitioned GFA pipeline: build per-partition GFA,
     /// lace together, then run gfaffix once at the end.
     pub partition_size: Option<usize>,
+    /// Optional exact path-preserving blunt-graph resolution pass.
+    pub crush_config: Option<resolution::ResolutionConfig>,
 }
 
 /// Minimal ImpgIndex wrapper around a SequenceIndex for syng query path.
@@ -527,13 +529,32 @@ pub fn dispatch_gfa_engine(
             std::io::Error::other(format!("Failed to create debug dir '{}': {}", dir, e))
         })?;
     }
-    dispatch_gfa_engine_inner(
+    let gfa = dispatch_gfa_engine_inner(
         impg,
         query_intervals,
         sequence_index,
         scoring_params,
         engine_opts,
-    )
+    )?;
+    apply_graph_transforms(gfa, engine_opts)
+}
+
+fn apply_graph_transforms(
+    gfa: String,
+    engine_opts: &EngineOpts,
+) -> std::io::Result<String> {
+    let Some(config) = &engine_opts.crush_config else {
+        return Ok(gfa);
+    };
+    let resolved = resolution::resolve_gfa_bubbles(&gfa, config)?;
+    log::info!(
+        "crush: {} resolved, {} bailed, {} candidates seen across {} iterations",
+        resolved.stats.resolved,
+        resolved.stats.bailed,
+        resolved.stats.candidates_seen,
+        resolved.stats.iterations
+    );
+    Ok(resolved.gfa)
 }
 
 /// Convert an in-memory GFA string to VCF using the native Rust POVU path.
@@ -890,7 +911,8 @@ pub fn partitioned_gfa_pipeline(
 
     // 3. Single final gfaffix normalization + sort
     info!("[partitioned] Running final gfaffix normalization");
-    graph::normalize_and_sort(laced, engine_opts.pipeline.num_threads)
+    let final_gfa = graph::normalize_and_sort(laced, engine_opts.pipeline.num_threads)?;
+    apply_graph_transforms(final_gfa, engine_opts)
 }
 
 #[cfg(test)]
@@ -1059,5 +1081,38 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_crush_transform_is_applied_path_preserving() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tAAA
+S\t2\tC
+S\t3\tG
+S\t4\tTTT
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t4\t+\t0M
+L\t1\t+\t3\t+\t0M
+L\t3\t+\t4\t+\t0M
+P\tref\t1+,2+,4+\t*
+P\talt\t1+,3+,4+\t*
+";
+        let before = resolution::path_sequences(gfa).unwrap();
+        let opts = EngineOpts {
+            engine: GfaEngine::Poa,
+            syng_gfa_mode: None,
+            syng_params: None,
+            pipeline: commands::graph::GraphBuildConfig::default(),
+            target_poa_lengths: vec![700, 1100],
+            max_node_length: 100,
+            poa_padding_fraction: 0.001,
+            partition_size: None,
+            crush_config: Some(resolution::ResolutionConfig::default()),
+        };
+        let out = super::apply_graph_transforms(gfa.to_string(), &opts).unwrap();
+        let after = resolution::path_sequences(&out).unwrap();
+        assert_eq!(before, after);
+        assert_ne!(gfa, out);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2141,12 +2141,13 @@ struct EngineCliOpts {
     debug_dir: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct ParsedGfaEngine {
     engine: GfaEngine,
     partition_size: Option<usize>,
     syng_gfa_mode: Option<SyngGfaMode>,
     syng_params: Option<impg::syng::SyncmerParams>,
+    crush_config: Option<impg::resolution::ResolutionConfig>,
 }
 
 fn set_syng_gfa_mode(
@@ -2181,6 +2182,93 @@ fn parse_u32_engine_param(raw: &str, key: &str, value: &str) -> io::Result<u32> 
             ),
         )
     })
+}
+
+fn parse_usize_size_engine_param(raw: &str, key: &str, value: &str) -> io::Result<usize> {
+    let parsed = parse_size(value).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid --gfa-engine '{}': {}='{}': {}", raw, key, value, e),
+        )
+    })?;
+    usize::try_from(parsed).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid --gfa-engine '{}': {}='{}' is too large",
+                raw, key, value
+            ),
+        )
+    })
+}
+
+fn parse_crush_stage(
+    raw: &str,
+    stage: &GraphPipelineStage,
+) -> io::Result<impg::resolution::ResolutionConfig> {
+    let mut config = impg::resolution::ResolutionConfig::default();
+    for param in &stage.params {
+        match param.key.as_str() {
+            "max-iterations" | "iterations" => {
+                config.max_iterations =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "max-span" | "max-bubble-span" | "span" => {
+                config.max_bubble_span =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "max-traversal-len" | "max-traversal-length" | "max-traversal" => {
+                config.max_traversal_len =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "max-total-sequence" | "max-total-seq" | "max-sequence" => {
+                config.max_total_sequence =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "max-traversals" => {
+                config.max_traversals =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "method" => {
+                let method = param.value.replace('_', "-").to_ascii_lowercase();
+                if !matches!(method.as_str(), "poa" | "spoa") {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected poa)",
+                            raw, param.value
+                        ),
+                    ));
+                }
+            }
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Invalid --gfa-engine '{}': unknown crush parameter '{}'",
+                        raw, other
+                    ),
+                ));
+            }
+        }
+    }
+
+    if config.max_iterations == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid --gfa-engine '{}': crush iterations must be > 0", raw),
+        ));
+    }
+    if config.max_traversals == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid --gfa-engine '{}': crush max-traversals must be > 0",
+                raw
+            ),
+        ));
+    }
+    Ok(config)
 }
 
 fn parse_syng_assertion_params(
@@ -2369,6 +2457,7 @@ impl EngineCliOpts {
         let mut smer_length: Option<u32> = None;
         let mut syncmer_seed: Option<u32> = None;
         let mut saw_syng_param = false;
+        let mut crush_config = None;
 
         parse_engine_stage_params(
             raw,
@@ -2397,13 +2486,13 @@ impl EngineCliOpts {
                     )?;
                 }
                 "crush" => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "Invalid --gfa-engine '{}': graph pipeline stage 'crush' is parsed but not wired yet",
-                            raw
-                        ),
-                    ));
+                    if crush_config.is_some() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid --gfa-engine '{}': duplicate crush stage", raw),
+                        ));
+                    }
+                    crush_config = Some(parse_crush_stage(raw, stage)?);
                 }
                 stage_name if !is_syng && stage.params.is_empty() => {
                     partition_size = Some(parse_window(stage_name)?);
@@ -2418,6 +2507,18 @@ impl EngineCliOpts {
         }
         if is_syng && syng_gfa_mode.is_none() {
             syng_gfa_mode = Some(SyngGfaMode::Blunt);
+        }
+        if is_syng
+            && crush_config.is_some()
+            && matches!(syng_gfa_mode, Some(SyngGfaMode::Raw))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid --gfa-engine '{}': crush requires blunt syng GFA; use syng:crush or syng:blunt:crush",
+                    raw
+                ),
+            ));
         }
 
         let syng_params = if saw_syng_param {
@@ -2437,6 +2538,7 @@ impl EngineCliOpts {
             partition_size,
             syng_gfa_mode,
             syng_params,
+            crush_config,
         })
     }
 
@@ -2495,9 +2597,12 @@ impl EngineCliOpts {
 
     /// Resolve and build an `EngineOpts`.
     fn build(&self, num_threads: usize) -> io::Result<EngineOpts> {
-        let parsed = self.parse_engine()?;
+        let mut parsed = self.parse_engine()?;
         let engine = parsed.engine;
         self.validate_engine_params(engine)?;
+        if let Some(config) = parsed.crush_config.as_mut() {
+            config.scoring_params = self.parse_poa_scoring()?;
+        }
 
         let sparsify = self.aln.sw.sparsify.clone();
         let mash_params = sweepga::knn_graph::MashParams {
@@ -2519,6 +2624,7 @@ impl EngineCliOpts {
             parsed.partition_size,
             parsed.syng_gfa_mode,
             parsed.syng_params,
+            parsed.crush_config,
         )
     }
 }
@@ -3330,7 +3436,8 @@ Syng notes:
   bed, bedpe, gfa, vcf, fasta, and gbwt. Use -o gfa for a local sequence GFA from
   query-selected intervals. `--gfa-engine syng` emits a syng syncmer GFA and
   defaults to syng:blunt; use syng:raw to preserve native overlaps. The compact
-  forms `-o gfa:syng:blunt,k=63,s=8,seed=7` and `-o vcf:syng` are accepted
+  forms `-o gfa:syng:blunt,k=63,s=8,seed=7`, `-o gfa:syng:crush`,
+  and `-o vcf:syng` are accepted
   as shorthand. Use
   `impg syng2gfa` to dump the whole syng syncmer graph instead.
 
@@ -3339,7 +3446,8 @@ GFA engine shorthand:
   matching `-o vcf:<engine>` forms are equivalent to
   `-o <format> --gfa-engine <engine>`. Alignment-backed graph builds can also
   name the aligner prefix, e.g. `-o gfa:wfmash:seqwish`,
-  `-o gfa:fastga:pggb`, or `-o gfa:sweepga:seqwish`.
+  `-o gfa:fastga:pggb`, or `-o gfa:sweepga:seqwish`. Add `:crush` to run
+  exact path-preserving blunt-graph resolution, e.g. `-o gfa:syng:crush`.
 ")]
     Query {
         // --- Input ---
@@ -7339,6 +7447,7 @@ fn build_engine_opts(
     partition_size: Option<usize>,
     syng_gfa_mode: Option<SyngGfaMode>,
     syng_params: Option<impg::syng::SyncmerParams>,
+    crush_config: Option<impg::resolution::ResolutionConfig>,
 ) -> io::Result<EngineOpts> {
     let pipeline = graph::GraphBuildConfig {
         num_threads,
@@ -7377,6 +7486,7 @@ fn build_engine_opts(
         syng_params,
         pipeline,
         partition_size,
+        crush_config,
         target_poa_lengths: smooth.parse_target_poa_lengths()?,
         max_node_length: smooth.max_node_length,
         poa_padding_fraction: smooth.poa_padding_fraction,
@@ -9949,6 +10059,7 @@ mod tests {
             "`--gfa-engine syng` emits a syng syncmer GFA",
             "defaults to syng:blunt; use syng:raw",
             "-o gfa:syng:blunt,k=63,s=8,seed=7",
+            "-o gfa:syng:crush",
             "-o vcf:syng",
             "-o gfa:wfmash:seqwish",
             "`impg syng2gfa` to dump the whole syng syncmer graph",
@@ -10075,14 +10186,14 @@ mod tests {
     }
 
     #[test]
-    fn test_gfa_output_format_parses_but_rejects_unwired_crush_stage() {
+    fn test_gfa_output_format_accepts_crush_stage() {
         let args = Args::try_parse_from([
             "impg",
             "query",
             "-d",
             "0",
             "-o",
-            "gfa:syng:crush,max-span=10k",
+            "gfa:syng:crush,max-span=10k,max-traversals=64",
         ])
         .unwrap();
         match args {
@@ -10094,10 +10205,41 @@ mod tests {
                 let output_format =
                     apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
                 assert_eq!(output_format, "gfa");
-                assert_eq!(engine_cli.engine_raw, "syng:crush,max-span=10k");
+                assert_eq!(
+                    engine_cli.engine_raw,
+                    "syng:crush,max-span=10k,max-traversals=64"
+                );
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::SyngNative);
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                let crush = parsed.crush_config.unwrap();
+                assert_eq!(crush.max_bubble_span, 10_000);
+                assert_eq!(crush.max_traversals, 64);
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_rejects_raw_syng_crush() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:raw:crush",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
                 let err = engine_cli.parse_engine().unwrap_err();
-                assert!(err.to_string().contains("crush"));
-                assert!(err.to_string().contains("not wired yet"));
+                assert!(err.to_string().contains("crush requires blunt syng GFA"));
             }
             _ => panic!("expected query command"),
         }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -8,7 +8,7 @@
 
 use crate::graph::{build_spoa_engine, feed_sequences_to_graph, reverse_complement, unchop_gfa};
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 
 /// Configuration for exact path-preserving bubble resolution.
@@ -93,6 +93,12 @@ struct BubbleCandidate {
     ranges: Vec<PathRange>,
     signature: String,
     within_budget: bool,
+}
+
+#[derive(Clone, Debug)]
+struct SiteDraft {
+    ref_start: usize,
+    ref_end: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -316,62 +322,137 @@ fn find_next_candidate(
     let ref_path = &graph.paths[ref_path_idx];
     let ref_positions = path_positions(graph, ref_path_idx);
 
-    for begin in 0..ref_path.steps.len().saturating_sub(1) {
+    for site in leaf_site_order(&candidate_sites(graph, ref_path_idx)) {
+        let begin = site.ref_start;
+        let exit_step = site.ref_end;
         let entry = ref_path.steps[begin];
-        for exit_step in begin + 1..ref_path.steps.len() {
-            let exit = ref_path.steps[exit_step];
-            let ref_span = ref_positions[exit_step + 1] - ref_positions[begin];
-            if ref_span > config.max_bubble_span {
-                break;
+        let exit = ref_path.steps[exit_step];
+        let ref_span = ref_positions[exit_step + 1] - ref_positions[begin];
+
+        let mut ranges = Vec::new();
+        for path_idx in 0..graph.paths.len() {
+            if let Some((range_begin, range_end)) =
+                unique_anchor_range(&graph.paths[path_idx], entry, exit)
+            {
+                let mut range = PathRange {
+                    path_idx,
+                    begin_step: range_begin,
+                    end_step: range_end,
+                    sequence: Vec::new(),
+                };
+                range.sequence = range_sequence(graph, &range);
+                ranges.push(range);
             }
-
-            let mut ranges = Vec::new();
-            for path_idx in 0..graph.paths.len() {
-                if let Some((range_begin, range_end)) =
-                    unique_anchor_range(&graph.paths[path_idx], entry, exit)
-                {
-                    let mut range = PathRange {
-                        path_idx,
-                        begin_step: range_begin,
-                        end_step: range_end,
-                        sequence: Vec::new(),
-                    };
-                    range.sequence = range_sequence(graph, &range);
-                    ranges.push(range);
-                }
-            }
-
-            if ranges.len() < 2 {
-                continue;
-            }
-
-            let distinct_sequences: BTreeSet<Vec<u8>> =
-                ranges.iter().map(|r| r.sequence.clone()).collect();
-            if distinct_sequences.len() < 2 {
-                continue;
-            }
-
-            let signature = candidate_signature(graph, ref_path_idx, begin, exit_step, &ranges);
-            if seen.contains(&signature) {
-                continue;
-            }
-
-            let max_traversal_len = ranges.iter().map(|r| r.sequence.len()).max().unwrap_or(0);
-            let total_sequence = ranges.iter().map(|r| r.sequence.len()).sum::<usize>();
-            let within_budget = ref_span <= config.max_bubble_span
-                && ranges.len() <= config.max_traversals
-                && max_traversal_len <= config.max_traversal_len
-                && total_sequence <= config.max_total_sequence;
-
-            return Some(BubbleCandidate {
-                ranges,
-                signature,
-                within_budget,
-            });
         }
+
+        if ranges.len() < 2 {
+            continue;
+        }
+
+        let distinct_sequences: BTreeSet<Vec<u8>> =
+            ranges.iter().map(|r| r.sequence.clone()).collect();
+        if distinct_sequences.len() < 2 {
+            continue;
+        }
+
+        let signature = candidate_signature(graph, ref_path_idx, begin, exit_step, &ranges);
+        if seen.contains(&signature) {
+            continue;
+        }
+
+        let max_traversal_len = ranges.iter().map(|r| r.sequence.len()).max().unwrap_or(0);
+        let total_sequence = ranges.iter().map(|r| r.sequence.len()).sum::<usize>();
+        let within_budget = ref_span <= config.max_bubble_span
+            && ranges.len() <= config.max_traversals
+            && max_traversal_len <= config.max_traversal_len
+            && total_sequence <= config.max_total_sequence;
+
+        return Some(BubbleCandidate {
+            ranges,
+            signature,
+            within_budget,
+        });
     }
 
     None
+}
+
+/// Discover candidate sites using the same reference-path collinear-match
+/// model as POVU's native VCF extractor: every adjacent pair of shared,
+/// collinear steps between the reference path and another path defines a
+/// candidate if the internal traversals differ.
+fn candidate_sites(graph: &Graph, ref_path_idx: usize) -> BTreeMap<(usize, usize), SiteDraft> {
+    let reference = &graph.paths[ref_path_idx];
+    let mut candidates = BTreeMap::<(usize, usize), SiteDraft>::new();
+
+    for (path_idx, path) in graph.paths.iter().enumerate() {
+        if path_idx == ref_path_idx {
+            continue;
+        }
+        let matches = collinear_matches(&reference.steps, &path.steps);
+        for window in matches.windows(2) {
+            let (ref_start, path_start) = window[0];
+            let (ref_end, path_end) = window[1];
+            if ref_end <= ref_start || path_end <= path_start {
+                continue;
+            }
+            let ref_internal = &reference.steps[ref_start + 1..ref_end];
+            let alt_internal = &path.steps[path_start + 1..path_end];
+            if ref_internal == alt_internal {
+                continue;
+            }
+            candidates
+                .entry((ref_start, ref_end))
+                .or_insert(SiteDraft { ref_start, ref_end });
+        }
+    }
+
+    candidates
+}
+
+fn collinear_matches(reference: &[Step], path: &[Step]) -> Vec<(usize, usize)> {
+    let rows = reference.len();
+    let cols = path.len();
+    let mut dp = vec![vec![0usize; cols + 1]; rows + 1];
+    for i in (0..rows).rev() {
+        for j in (0..cols).rev() {
+            dp[i][j] = if reference[i] == path[j] {
+                1 + dp[i + 1][j + 1]
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+
+    let mut matches = Vec::new();
+    let mut i = 0usize;
+    let mut j = 0usize;
+    while i < rows && j < cols {
+        if reference[i] == path[j] {
+            matches.push((i, j));
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    matches
+}
+
+fn leaf_site_order(candidates: &BTreeMap<(usize, usize), SiteDraft>) -> Vec<SiteDraft> {
+    let mut leaves = candidates
+        .values()
+        .filter(|site| {
+            !candidates.values().any(|other| {
+                site.ref_start < other.ref_start && other.ref_end < site.ref_end
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    leaves.sort_by_key(|site| (site.ref_end - site.ref_start, site.ref_start, site.ref_end));
+    leaves
 }
 
 fn unique_anchor_range(path: &Path, entry: Step, exit: Step) -> Option<(usize, usize)> {
@@ -727,6 +808,53 @@ P\tins\t1+,2+,3+\t*
         assert_eq!(before["ref"], "ACTA");
         assert_eq!(before["ins"], "ACGGGTA");
         assert_eq!(resolved.stats.resolved, 1);
+    }
+
+    #[test]
+    fn resolves_nested_leaf_sites_bottom_up() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tA
+S\t2\tC
+S\t3\tG
+S\t4\tT
+S\t5\tAA
+S\t6\tA
+S\t7\tCCC
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+L\t3\t+\t4\t+\t0M
+L\t2\t+\t5\t+\t0M
+L\t5\t+\t4\t+\t0M
+L\t4\t+\t6\t+\t0M
+L\t1\t+\t7\t+\t0M
+L\t7\t+\t6\t+\t0M
+P\tref\t1+,2+,3+,4+,6+\t*
+P\tinner_alt\t1+,2+,5+,4+,6+\t*
+P\touter_alt\t1+,7+,6+\t*
+";
+        let before = seq_map(gfa);
+        let graph = parse_gfa(gfa).unwrap();
+        let sites = candidate_sites(&graph, 0);
+        let leaves = leaf_site_order(&sites);
+        assert_eq!(
+            leaves
+                .iter()
+                .map(|site| (site.ref_start, site.ref_end))
+                .collect::<Vec<_>>(),
+            vec![(1, 3)]
+        );
+        let resolved = resolve_gfa_bubbles(
+            gfa,
+            &ResolutionConfig {
+                max_iterations: 4,
+                ..ResolutionConfig::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(before, seq_map(&resolved.gfa));
+        assert!(resolved.stats.resolved >= 2);
+        assert_eq!(resolved.stats.bailed, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wire `:crush` as an executable graph pipeline transform for GFA/VCF graph output
- apply crush after normal local GFA rendering and after partitioned GFA lacing/final normalization
- switch the resolver candidate ordering to POVU-style reference-path collinear site discovery with bottom-up leaf-site selection and exact path-sequence validation after every replacement
- add parsing/validation for crush parameters and reject `syng:raw:crush`
- update DSL and syng GFA query docs

## Tests
- `cargo test resolution::tests --lib`
- `cargo test test_crush_transform_is_applied_path_preserving --lib`
- `cargo test --lib`
- `cargo test --bin impg`
- `cargo test`
- `cargo test --release -- --test-threads=1`
- manual CLI smoke: `impg syng` + `impg query -o gfa:syng:crush,max-span=2k,max-traversals=32`
- `git diff --check`

## Notes
The current implementation follows POVU native Rust VCF's collinear path-site model inside IMPG. It does not consume a public POVU flubble hierarchy yet because the pinned `povu-rs` API does not expose one.