### PR TITLE
Use POVU flubble sites for crush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "povu-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/povu?rev=168167fd2a05b8f9fa4901a2aa0feb02bfc13ea5#168167fd2a05b8f9fa4901a2aa0feb02bfc13ea5"
+source = "git+https://github.com/pangenome/povu?rev=a6e4b54363dfcf033010329eb37104a168e833b7#a6e4b54363dfcf033010329eb37104a168e833b7"
 dependencies = [
  "bindgen 0.70.1",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
 bluntg = { git = "https://github.com/pangenome/bluntg" }
-povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "168167fd2a05b8f9fa4901a2aa0feb02bfc13ea5", default-features = false }
+povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "a6e4b54363dfcf033010329eb37104a168e833b7", default-features = false }
 
 [build-dependencies]
 cc = "1"

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -71,7 +71,7 @@ gfa:sweepga:fastga:pggb,window=20k
 
 ```text
 input blunt graph
-  -> POVU-style collinear path-site discovery
+  -> POVU native flubble decomposition
   -> bottom-up leaf-site ordering
   -> exact path-preserving local replacement
   -> recompute site discovery after each replacement
@@ -114,15 +114,14 @@ crush,max-span=10k,max-traversal-len=10k,max-traversals=128,method=poa
 Unknown parameters should be errors, not warnings. Silent ignoring would make
 graph parameterization hard to reproduce.
 
-## POVU Requirement For Fuller Crush
+## POVU Decomposition Boundary
 
-The current `src/resolution.rs` implementation uses the same reference-path
-collinear-match site model as POVU's native Rust VCF extractor, then processes
-leaf sites first and validates exact path-sequence preservation after every
-replacement. This is enough to make `:crush` executable and testable.
+`src/resolution.rs` does not implement its own flubble finder. It passes the
+current blunt GFA to `povu-rs` and calls `NativeGfa::decompose_flubbles`, then
+uses POVU's site IDs, parent/child relationships, entry/exit steps, and
+bottom-up leaf ordering to schedule exact path-preserving replacement.
 
-The fuller scheduler should be POVU/flubble-driven when `povu-rs` exposes the
-needed hierarchy API:
+The crush loop is:
 
 1. Decompose the current graph into flubbles/bubbles/tangles.
 2. Build a parent/child hierarchy.
@@ -130,10 +129,3 @@ needed hierarchy API:
 4. Extract observed path traversals through each site.
 5. Replace bounded sites exactly.
 6. Recompute decomposition on the changed graph.
-
-At the current pinned `povu-rs` revision, IMPG has native GFA-to-VCF support,
-but not a public flubble hierarchy API. The current `:crush` implementation
-therefore does not consume a public POVU hierarchy yet. We still need a
-POVU-side API that exposes site IDs, parent/child relationships, entry/exit
-handles, path-supported traversal boundaries, and enough node/edge identity to
-schedule non-overlapping bottom-up batches.

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -7,8 +7,9 @@
 //! collapse and coordinate sidecars; emitted paths are the coordinate system.
 
 use crate::graph::{build_spoa_engine, feed_sequences_to_graph, reverse_complement, unchop_gfa};
+use povu::native_gfa::{Step as PovuStep, Strand as PovuStrand};
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::io;
 
 /// Configuration for exact path-preserving bubble resolution.
@@ -65,6 +66,7 @@ struct Step {
 
 #[derive(Clone, Debug)]
 struct Segment {
+    id: String,
     seq: Vec<u8>,
 }
 
@@ -95,12 +97,6 @@ struct BubbleCandidate {
     within_budget: bool,
 }
 
-#[derive(Clone, Debug)]
-struct SiteDraft {
-    ref_start: usize,
-    ref_end: usize,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 enum OutNode {
     Original(usize),
@@ -127,7 +123,7 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
     let mut changed = false;
 
     for iteration in 0..config.max_iterations {
-        let Some(candidate) = find_next_candidate(&graph, config, &seen) else {
+        let Some(candidate) = find_next_candidate(&graph, config, &seen)? else {
             break;
         };
         stats.iterations = iteration + 1;
@@ -211,6 +207,7 @@ fn parse_gfa(gfa: &str) -> io::Result<Graph> {
                 let idx = segments.len();
                 id_to_idx.insert(id.clone(), idx);
                 segments.push(Segment {
+                    id,
                     seq: fields[2].as_bytes().to_vec(),
                 });
             }
@@ -314,19 +311,38 @@ fn find_next_candidate(
     graph: &Graph,
     config: &ResolutionConfig,
     seen: &FxHashSet<String>,
-) -> Option<BubbleCandidate> {
+) -> io::Result<Option<BubbleCandidate>> {
     if graph.paths.is_empty() || graph.paths[0].steps.len() < 2 {
-        return None;
+        return Ok(None);
     }
     let ref_path_idx = 0;
     let ref_path = &graph.paths[ref_path_idx];
     let ref_positions = path_positions(graph, ref_path_idx);
+    let rendered = render_graph(graph);
+    let native_graph = povu::NativeGfa::parse(&rendered).map_err(povu_to_io_error)?;
+    let reference_names = vec![ref_path.name.clone()];
+    let decomposition = native_graph
+        .decompose_flubbles(&reference_names)
+        .map_err(povu_to_io_error)?;
+    let id_to_idx = graph
+        .segments
+        .iter()
+        .enumerate()
+        .map(|(idx, segment)| (segment.id.as_str(), idx))
+        .collect::<FxHashMap<_, _>>();
 
-    for site in leaf_site_order(&candidate_sites(graph, ref_path_idx)) {
-        let begin = site.ref_start;
-        let exit_step = site.ref_end;
-        let entry = ref_path.steps[begin];
-        let exit = ref_path.steps[exit_step];
+    for site in decomposition.leaf_sites_bottom_up() {
+        let begin = site.reference_start_step;
+        let exit_step = site.reference_end_step;
+        if exit_step + 1 >= ref_positions.len() {
+            continue;
+        }
+        let Some(entry) = step_from_povu(&id_to_idx, &site.start) else {
+            continue;
+        };
+        let Some(exit) = step_from_povu(&id_to_idx, &site.end) else {
+            continue;
+        };
         let ref_span = ref_positions[exit_step + 1] - ref_positions[begin];
 
         let mut ranges = Vec::new();
@@ -367,92 +383,29 @@ fn find_next_candidate(
             && max_traversal_len <= config.max_traversal_len
             && total_sequence <= config.max_total_sequence;
 
-        return Some(BubbleCandidate {
+        return Ok(Some(BubbleCandidate {
             ranges,
             signature,
             within_budget,
-        });
+        }));
     }
 
-    None
+    Ok(None)
 }
 
-/// Discover candidate sites using the same reference-path collinear-match
-/// model as POVU's native VCF extractor: every adjacent pair of shared,
-/// collinear steps between the reference path and another path defines a
-/// candidate if the internal traversals differ.
-fn candidate_sites(graph: &Graph, ref_path_idx: usize) -> BTreeMap<(usize, usize), SiteDraft> {
-    let reference = &graph.paths[ref_path_idx];
-    let mut candidates = BTreeMap::<(usize, usize), SiteDraft>::new();
-
-    for (path_idx, path) in graph.paths.iter().enumerate() {
-        if path_idx == ref_path_idx {
-            continue;
-        }
-        let matches = collinear_matches(&reference.steps, &path.steps);
-        for window in matches.windows(2) {
-            let (ref_start, path_start) = window[0];
-            let (ref_end, path_end) = window[1];
-            if ref_end <= ref_start || path_end <= path_start {
-                continue;
-            }
-            let ref_internal = &reference.steps[ref_start + 1..ref_end];
-            let alt_internal = &path.steps[path_start + 1..path_end];
-            if ref_internal == alt_internal {
-                continue;
-            }
-            candidates
-                .entry((ref_start, ref_end))
-                .or_insert(SiteDraft { ref_start, ref_end });
-        }
-    }
-
-    candidates
+fn step_from_povu(id_to_idx: &FxHashMap<&str, usize>, step: &PovuStep) -> Option<Step> {
+    let node = *id_to_idx.get(step.segment.as_str())?;
+    Some(Step {
+        node,
+        rev: matches!(step.strand, PovuStrand::Reverse),
+    })
 }
 
-fn collinear_matches(reference: &[Step], path: &[Step]) -> Vec<(usize, usize)> {
-    let rows = reference.len();
-    let cols = path.len();
-    let mut dp = vec![vec![0usize; cols + 1]; rows + 1];
-    for i in (0..rows).rev() {
-        for j in (0..cols).rev() {
-            dp[i][j] = if reference[i] == path[j] {
-                1 + dp[i + 1][j + 1]
-            } else {
-                dp[i + 1][j].max(dp[i][j + 1])
-            };
-        }
-    }
-
-    let mut matches = Vec::new();
-    let mut i = 0usize;
-    let mut j = 0usize;
-    while i < rows && j < cols {
-        if reference[i] == path[j] {
-            matches.push((i, j));
-            i += 1;
-            j += 1;
-        } else if dp[i + 1][j] >= dp[i][j + 1] {
-            i += 1;
-        } else {
-            j += 1;
-        }
-    }
-    matches
-}
-
-fn leaf_site_order(candidates: &BTreeMap<(usize, usize), SiteDraft>) -> Vec<SiteDraft> {
-    let mut leaves = candidates
-        .values()
-        .filter(|site| {
-            !candidates.values().any(|other| {
-                site.ref_start < other.ref_start && other.ref_end < site.ref_end
-            })
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    leaves.sort_by_key(|site| (site.ref_end - site.ref_start, site.ref_start, site.ref_end));
-    leaves
+fn povu_to_io_error(err: povu::Error) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("POVU flubble decomposition failed: {err}"),
+    )
 }
 
 fn unique_anchor_range(path: &Path, entry: Step, exit: Step) -> Option<(usize, usize)> {
@@ -654,13 +607,16 @@ fn render_rewritten_graph(
     out.push_str("H\tVN:Z:1.0\n");
 
     let mut id_by_node: FxHashMap<OutNode, String> = FxHashMap::default();
+    let mut used_ids = FxHashSet::<String>::default();
+    for node in used_original {
+        used_ids.insert(original.segments[*node].id.clone());
+    }
     let mut next_id = 1usize;
 
     let mut original_nodes: Vec<usize> = used_original.iter().copied().collect();
     original_nodes.sort_unstable();
     for node in original_nodes {
-        let id = next_id.to_string();
-        next_id += 1;
+        let id = original.segments[node].id.clone();
         id_by_node.insert(OutNode::Original(node), id.clone());
         out.push_str(&format!(
             "S\t{}\t{}\n",
@@ -672,8 +628,7 @@ fn render_rewritten_graph(
     let mut replacement_nodes: Vec<usize> = used_replacement.iter().copied().collect();
     replacement_nodes.sort_unstable();
     for node in replacement_nodes {
-        let id = next_id.to_string();
-        next_id += 1;
+        let id = next_unused_segment_id(&mut used_ids, &mut next_id);
         id_by_node.insert(OutNode::Replacement(node), id.clone());
         out.push_str(&format!(
             "S\t{}\t{}\n",
@@ -720,6 +675,16 @@ fn render_rewritten_graph(
     }
 
     out
+}
+
+fn next_unused_segment_id(used_ids: &mut FxHashSet<String>, next_id: &mut usize) -> String {
+    loop {
+        let id = next_id.to_string();
+        *next_id += 1;
+        if used_ids.insert(id.clone()) {
+            return id;
+        }
+    }
 }
 
 fn render_graph(graph: &Graph) -> String {
@@ -834,13 +799,13 @@ P\tinner_alt\t1+,2+,5+,4+,6+\t*
 P\touter_alt\t1+,7+,6+\t*
 ";
         let before = seq_map(gfa);
-        let graph = parse_gfa(gfa).unwrap();
-        let sites = candidate_sites(&graph, 0);
-        let leaves = leaf_site_order(&sites);
+        let graph = povu::NativeGfa::parse(gfa).unwrap();
+        let decomposition = graph.decompose_flubbles(&["ref".to_string()]).unwrap();
+        let leaves = decomposition.leaf_sites_bottom_up();
         assert_eq!(
             leaves
                 .iter()
-                .map(|site| (site.ref_start, site.ref_end))
+                .map(|site| (site.reference_start_step, site.reference_end_step))
                 .collect::<Vec<_>>(),
             vec![(1, 3)]
         );


### PR DESCRIPTION
Replace IMPG-local flubble discovery in the crush resolver with the real POVU native decomposition API. IMPG now calls povu-rs NativeGfa::decompose_flubbles and uses POVU leaf sites to schedule exact path-preserving replacement.\n\nAlso updates the graph pipeline docs to make the POVU boundary explicit.\n\nValidation:\n- cargo test resolution::tests --lib\n- cargo test test_crush_transform_is_applied_path_preserving --lib\n- cargo test gfa_output_format --bin impg\n- cargo test --lib\n- cargo test --bin impg\n- cargo test\n- smoke: impg query -o gfa:syng:crush on a toy syng index