### PR TITLE
Tune crush defaults for human panels

### DIFF
--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -17,7 +17,7 @@ them and are separated by commas:
 syng,k=63,s=8,seed=7:blunt
 seqwish,min-match-len=70
 pggb,window=20k
-syng,k=63,s=8:crush,max-span=10k,max-traversals=128
+syng,k=63,s=8:crush,max-span=10k,max-traversals=1024
 ```
 
 This is a graph-pipeline DSL, not a general shell pipeline. Each stage is a
@@ -108,7 +108,7 @@ Examples:
 syng,k=63,s=8,seed=7
 seqwish,min-match-len=70,sparse-factor=0.001
 pggb,window=20k
-crush,max-span=10k,max-traversal-len=10k,max-traversals=128,method=poa
+crush,max-span=10k,max-traversal-len=10k,max-traversals=1024,method=poa
 ```
 
 Unknown parameters should be errors, not warnings. Silent ignoring would make
@@ -129,3 +129,14 @@ The crush loop is:
 4. Extract observed path traversals through each site.
 5. Replace bounded sites exactly.
 6. Recompute decomposition on the changed graph.
+
+For debugging or batch processing of an already rendered blunt GFA, the same
+transform is exposed directly:
+
+```bash
+impg crush -g local.blunt.gfa -o local.crushed.gfa
+```
+
+The defaults are sized for human panels (`512` iterations and `1024` path
+traversals per candidate). Smaller values are useful only for quick synthetic
+tests or deliberately capped exploratory runs.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -163,9 +163,15 @@ gfa:<stage>[,<key=value>...][:<stage>[,<key=value>...]...]
 
 For example, `gfa:syng,k=63,s=8,seed=7:blunt` and the legacy
 `gfa:syng:blunt,k=63,s=8,seed=7` are both accepted. Graph transforms use the
-same staged syntax. `gfa:syng:crush,max-span=10k,max-traversals=128` emits
+same staged syntax. `gfa:syng:crush,max-span=10k,max-traversals=1024` emits
 blunt syng GFA and then runs exact path-preserving bubble resolution; see
 `docs/graph-pipeline-dsl.md`.
+
+The transform can also be run on an existing blunt GFA:
+
+```bash
+impg crush -g local.blunt.gfa -o local.crushed.gfa
+```
 
 VCF output uses the same engine dispatch and passes the local GFA to POVU:
 `-o vcf:syng`, `-o vcf:pggb`, `-o vcf:seqwish`, and `-o vcf:poa` are

--- a/docs/syng-to-local-graph-translation.md
+++ b/docs/syng-to-local-graph-translation.md
@@ -1,0 +1,165 @@
+# Syng Evidence To Local Graph Translation
+
+IMPG has two useful feature spaces that must interoperate:
+
+```text
+syng-syncmer-node       global implicit syncmer graph used by impg map/pack
+gfa-segment            local explicit variation graph from syng/poa/seqwish/pggb/crush
+```
+
+Short-read evidence is cheap to collect in syng space. Local genotyping and
+graph smoothing often need explicit local graph nodes. The render bundle must
+therefore include a translation that projects syng-node evidence onto the local
+graph without remapping reads.
+
+## Required Invariant
+
+The root coordinate system is still source sequence coordinates. Translation
+must be path-step aware:
+
+```text
+syng node occurrence
+  -> source sequence + bp position + orientation
+  -> rendered input path + path step offset
+  -> local graph node + orientation
+```
+
+A plain `syng_node_id -> gfa_node_id` map is not sufficient. Syncmers can occur
+in repeats, local graph nodes can be shared by many paths, and graph smoothing
+can replace a path interval with new nodes. The projection key must include the
+rendered path context and source-coordinate overlap.
+
+## Bundle Schema Extension
+
+Keep the existing `RenderedPathRecord` and `StepTranslationRecord`. Add a second
+table for cross-feature projection:
+
+```rust
+pub struct SyngToGraphProjectionRecord {
+    pub rendered_path_id: u32,
+    pub rendered_step: u32,
+    pub local_feature_id: u32,
+    pub local_orientation: char,
+    pub source_start: u64,
+    pub source_end: u64,
+    pub syng_node_id: u32,
+    pub syng_orientation: char,
+    pub syng_source_start: u64,
+    pub syng_source_end: u64,
+}
+```
+
+Interpretation:
+
+- `local_feature_id` is the local GFA segment/node ID on the rendered path.
+- `source_start..source_end` is the source interval covered by that local graph
+  step on this rendered path.
+- `syng_node_id` is the global syng syncmer node ID.
+- `syng_source_start..syng_source_end` is the source interval covered by that
+  syncmer occurrence. It is normally `k=63` bp, adjusted for source strand.
+
+The same local graph node may have many projection records, one per rendered
+path context. That is intentional.
+
+Manifest additions:
+
+```json
+{
+  "feature_space": "gfa-segment",
+  "source_feature_space": "syng-syncmer-node",
+  "syng_to_graph": "syng-to-graph.bin",
+  "syng_to_graph_tsv": "syng-to-graph.tsv"
+}
+```
+
+## Build Algorithm
+
+For every rendered path in a local graph bundle:
+
+1. Get the rendered source interval from `RenderedPathRecord`.
+2. Walk the source interval in the original syng index:
+
+   ```rust
+   full_syng.walk_path_range(source_path_id, source_start, source_end)
+   ```
+
+3. Parse the local GFA path walk and its per-step source offsets. This is
+   already done by `collect_gfa_step_samples`.
+4. Sweep both sorted interval streams:
+
+   ```text
+   syng occurrence intervals on source coordinates
+   local graph step intervals on source coordinates
+   ```
+
+5. Emit a projection record for each overlap.
+
+For exact syng-native bundles this table is identity-like: a syncmer node maps
+to the matching syng GFA node on the same rendered path. For POA/seqwish/pggb
+and future `:crush`, the table maps each syncmer occurrence onto the local graph
+step or steps whose path-coordinate span overlaps that syncmer.
+
+## Projection Of Pack Evidence
+
+Given a syng pack:
+
+```text
+syng_node_id -> read_count
+```
+
+and `syng_to_graph` records for a local bundle, produce a local graph pack:
+
+```text
+local_feature_id -> projected_count
+```
+
+Initial scoring should be simple and deterministic:
+
+```text
+for each projection record:
+  contribution = syng_count[syng_node_id] * overlap_bp / syncmer_len
+  local_count[local_feature_id] += contribution
+```
+
+For genotyping, path-context records can also build haplotype feature vectors:
+
+```text
+rendered_path_id -> vector(local_feature_id weights)
+```
+
+This lets `genotype cos` compare read evidence to local graph haplotypes even
+when the reads were only mapped once to the whole syng index.
+
+## Ambiguity Rules
+
+Projection is allowed to be many-to-many, but it must be explicit:
+
+- Repeated syncmer occurrences produce multiple records with different
+  `rendered_path_id` / source coordinates.
+- A syncmer spanning a graph-node boundary contributes proportionally to both
+  local nodes.
+- Reverse-strand rendered intervals store source coordinates in forward source
+  coordinates and set orientation fields explicitly.
+- No deduplication across paths is done in the translation table. Downstream
+  pack projection may choose path-aware or node-aggregate semantics.
+
+## Implementation Plan
+
+1. Extend `RenderTranslationTables` with `syng_to_graph: Vec<SyngToGraphProjectionRecord>`.
+2. Add binary and TSV read/write support with backward-compatible versioning or
+   bump the render bundle version.
+3. In `render_local_graph`, build this table from the original full syng index,
+   not the rendered FASTA alone.
+4. Add `impg pack-project --render-bundle <bundle> --pack <syng.pack>` or wire
+   automatic projection into `genotype cos --render-bundle` when the bundle
+   feature space is `gfa-segment`.
+5. Test on synthetic bubbles:
+   - SNP bubble;
+   - insertion/deletion bubble;
+   - repeated syncmer copied twice;
+   - reverse-strand interval;
+   - a syncmer crossing a local graph node boundary.
+
+The implementation must preserve Pan-SN names through `RenderedPathRecord`.
+That is what lets the projected evidence support diploid/path-aware genotyping
+instead of only anonymous node coverage.

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use rustc_hash::FxHashMap;
 use std::collections::{hash_map::DefaultHasher, BTreeMap};
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::num::NonZeroUsize;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
@@ -51,6 +51,11 @@ fn parse_merge_distance(s: &str) -> Result<i32, String> {
             i32::MAX
         )
     })
+}
+
+fn parse_usize_size(s: &str) -> Result<usize, String> {
+    let value = parse_size(s)?;
+    usize::try_from(value).map_err(|_| format!("size {value} exceeds usize::MAX"))
 }
 
 fn resolve_syng_syncmer_params(
@@ -3881,6 +3886,40 @@ GFA engine shorthand:
         common: CommonOpts,
     },
 
+    /// Resolve bounded bubbles in an existing blunt GFA
+    Crush {
+        /// Input blunt GFA path, or '-' for stdin
+        #[clap(short = 'g', long, value_parser)]
+        gfa: String,
+
+        /// Output GFA path, or '-' for stdout
+        #[clap(short = 'o', long, value_parser, default_value = "-")]
+        output: String,
+
+        /// Maximum replacement iterations
+        #[clap(long, alias = "iterations", value_parser = parse_usize_size, default_value = "512")]
+        max_iterations: usize,
+
+        /// Maximum reference span in bp for a candidate bubble
+        #[clap(long, alias = "max-bubble-span", value_parser = parse_usize_size, default_value = "10k")]
+        max_span: usize,
+
+        /// Maximum sequence length of any traversal through one candidate
+        #[clap(long, alias = "max-traversal-length", value_parser = parse_usize_size, default_value = "10k")]
+        max_traversal_len: usize,
+
+        /// Maximum total sequence across all traversals through one candidate
+        #[clap(long, alias = "max-total-seq", value_parser = parse_usize_size, default_value = "1m")]
+        max_total_sequence: usize,
+
+        /// Maximum number of path-supported traversals through one candidate
+        #[clap(long, value_parser = parse_usize_size, default_value = "1024")]
+        max_traversals: usize,
+
+        #[clap(flatten)]
+        common: CommonOpts,
+    },
+
     /// Render a syng-backed source-coordinate region into a GBZ-style bundle
     Render {
         /// Syng index prefix or .1khash/.1gbwt/.spos/.pstep/.names/.meta path
@@ -6392,6 +6431,65 @@ fn run() -> io::Result<()> {
                         }
                     }
                 }
+            }
+        }
+        Args::Crush {
+            gfa,
+            output,
+            max_iterations,
+            max_span,
+            max_traversal_len,
+            max_total_sequence,
+            max_traversals,
+            common,
+        } => {
+            initialize_threads_and_log(&common);
+            if max_iterations == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--max-iterations must be > 0",
+                ));
+            }
+            if max_traversals == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--max-traversals must be > 0",
+                ));
+            }
+
+            let mut gfa_text = String::new();
+            if gfa == "-" {
+                io::stdin().read_to_string(&mut gfa_text)?;
+            } else {
+                File::open(&gfa)?.read_to_string(&mut gfa_text)?;
+            }
+
+            let config = impg::resolution::ResolutionConfig {
+                max_iterations,
+                max_bubble_span: max_span,
+                max_traversal_len,
+                max_total_sequence,
+                max_traversals,
+                ..Default::default()
+            };
+            let resolved = impg::resolution::resolve_gfa_bubbles(&gfa_text, &config)?;
+            info!(
+                "crush: {} resolved, {} bailed, {} candidates seen across {} iterations",
+                resolved.stats.resolved,
+                resolved.stats.bailed,
+                resolved.stats.candidates_seen,
+                resolved.stats.iterations
+            );
+
+            if output == "-" {
+                let stdout = io::stdout();
+                let mut out = BufWriter::with_capacity(1024 * 1024, stdout.lock());
+                out.write_all(resolved.gfa.as_bytes())?;
+                out.flush()?;
+            } else {
+                let mut out = BufWriter::with_capacity(1024 * 1024, File::create(&output)?);
+                out.write_all(resolved.gfa.as_bytes())?;
+                out.flush()?;
             }
         }
         Args::Render {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -29,14 +29,20 @@ pub struct ResolutionConfig {
     pub scoring_params: (u8, u8, u8, u8, u8, u8),
 }
 
+pub const DEFAULT_MAX_ITERATIONS: usize = 512;
+pub const DEFAULT_MAX_BUBBLE_SPAN: usize = 10_000;
+pub const DEFAULT_MAX_TRAVERSAL_LEN: usize = 10_000;
+pub const DEFAULT_MAX_TOTAL_SEQUENCE: usize = 1_000_000;
+pub const DEFAULT_MAX_TRAVERSALS: usize = 1_024;
+
 impl Default for ResolutionConfig {
     fn default() -> Self {
         Self {
-            max_iterations: 8,
-            max_bubble_span: 10_000,
-            max_traversal_len: 10_000,
-            max_total_sequence: 1_000_000,
-            max_traversals: 128,
+            max_iterations: DEFAULT_MAX_ITERATIONS,
+            max_bubble_span: DEFAULT_MAX_BUBBLE_SPAN,
+            max_traversal_len: DEFAULT_MAX_TRAVERSAL_LEN,
+            max_total_sequence: DEFAULT_MAX_TOTAL_SEQUENCE,
+            max_traversals: DEFAULT_MAX_TRAVERSALS,
             scoring_params: (1, 4, 6, 2, 26, 1),
         }
     }

--- a/tests/test_syng_integration.rs
+++ b/tests/test_syng_integration.rs
@@ -205,6 +205,66 @@ fn impg_binary() -> Option<PathBuf> {
 }
 
 #[test]
+fn test_crush_cli_resolves_blunt_gfa() {
+    let Some(bin) = impg_binary() else {
+        eprintln!("Skipping CLI test: impg binary not found");
+        return;
+    };
+
+    let dir = std::env::temp_dir().join("impg_test_crush_cli");
+    std::fs::remove_dir_all(&dir).ok();
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = dir.join("input.gfa");
+    let output = dir.join("out.gfa");
+    std::fs::write(
+        &input,
+        "\
+H\tVN:Z:1.0
+S\t1\tAC
+S\t2\tGGG
+S\t3\tTA
+L\t1\t+\t3\t+\t0M
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+P\tref\t1+,3+\t*
+P\tins\t1+,2+,3+\t*
+",
+    )
+    .unwrap();
+
+    let run = Command::new(&bin)
+        .args([
+            "crush",
+            "-g",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "-v",
+            "2",
+        ])
+        .env("RUST_LOG", "info")
+        .output()
+        .expect("failed to run impg crush");
+    assert!(
+        run.status.success(),
+        "impg crush failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("crush: 1 resolved"),
+        "crush should resolve one insertion bubble, stderr:\n{}",
+        stderr
+    );
+    let text = std::fs::read_to_string(&output).unwrap();
+    assert!(text.starts_with("H\tVN:Z:1.0\n"), "{}", text);
+    assert!(text.contains("\nS\t"), "{}", text);
+    assert!(text.contains("\nP\tref\t"), "{}", text);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_syng_render_bundle_preserves_source_namespace() {
     let _guard = lock_syng();
     let Some(bin) = impg_binary() else {


### PR DESCRIPTION
## Summary
- raise `crush` defaults to human-panel scale: 512 iterations and 1024 path-supported traversals
- add `impg crush` for direct blunt-GFA debugging and batch use
- document the graph pipeline crush defaults and syng-to-local-graph evidence translation design
- add an integration smoke test proving the CLI resolves a blunt insertion bubble

## Validation
- `cargo test`
- `cargo test --release -- --test-threads=1`
- HPRCv2 AMY command: `target/release/impg query -a ~/hprcv2/HPRC_r2_assemblies_0.6.1.syng -r GRCh38#0#chr13:32315086-32325086 --sequence-files ~/hprcv2/HPRC_r2_assemblies_0.6.1.agc -d 100000 -o gfa:syng:crush -O /tmp/impg_amy_crush_validation`
  - resolved 238 sites, 0 bailed, 238 candidates
  - output: 1820 S / 2017 L / 465 P
  - wall time: 5:09.42; max RSS: 38,355,848 KB
