### PR TITLE
Add default syng crush resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -204,7 +204,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -300,6 +300,16 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -603,7 +613,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -624,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -925,6 +935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9632601a032d2ae43f5050b454dd27c2add69b2e52bd46a4888f3aeb6e3629f5"
 dependencies = [
  "anyhow",
- "bstr",
+ "bstr 0.2.17",
  "bytemuck",
  "fnv",
  "lazy_static",
@@ -1132,7 +1148,7 @@ source = "git+https://github.com/chfi/rs-handlegraph?rev=3ac575e4216ce16a1666750
 dependencies = [
  "anyhow",
  "boomphf",
- "bstr",
+ "bstr 0.2.17",
  "crossbeam-channel",
  "fnv",
  "gfa",
@@ -1377,9 +1393,10 @@ dependencies = [
  "nalgebra",
  "natord",
  "niffler",
- "noodles",
+ "noodles 0.100.0",
  "num_cpus",
  "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=38182c7acf7cccc53509176b1d11001ae6ff2642)",
+ "poasta",
  "povu-rs",
  "ragc-core",
  "rayon",
@@ -1445,6 +1462,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1816,12 +1842,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "noodles"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110e4a86fc1551a6480a47c7ff52176dc314b3f20355550bd542f05bce65ead2"
+dependencies = [
+ "noodles-fasta",
+ "noodles-fastq",
+]
+
+[[package]]
 name = "noodles"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5d9c17e7b3fd97eee958bfba83522d3da540c395f7ae071a8fa4bb7e85969e"
 dependencies = [
- "noodles-bgzf",
+ "noodles-bgzf 0.42.0",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07e5d75eb7e00c1fe140acef39dea0aea2f48a05ab698a16c6797dd0c0db7e4"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
 ]
 
 [[package]]
@@ -1833,6 +1887,52 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "flate2",
+]
+
+[[package]]
+name = "noodles-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce89752158657dd1d7195061e9d9190e2d3bb594eb71086762163d4a430b0b4b"
+dependencies = [
+ "bstr 1.12.1",
+]
+
+[[package]]
+name = "noodles-fasta"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b181ca5d47c6df72e91fa559ae4920bf521a047a73e6fdab00df2d358e1b3ae"
+dependencies = [
+ "bstr 1.12.1",
+ "bytes",
+ "memchr",
+ "noodles-bgzf 0.41.0",
+ "noodles-core",
+]
+
+[[package]]
+name = "noodles-fastq"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509abf632d0aca5181eb137e4662bd2bdce9f82d75a46689b4d926df00074223"
+dependencies = [
+ "bstr 1.12.1",
+ "memchr",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -1860,6 +1960,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1991,6 +2102,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2149,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poasta"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac375ff690c3bc14c40f4b30ffec900847ea255c36f9efadd9b1975205091cde"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bincode 1.3.3",
+ "clap",
+ "crossbeam-channel",
+ "flate2",
+ "itertools 0.14.0",
+ "nonmax",
+ "noodles 0.99.0",
+ "num",
+ "petgraph",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,11 +2198,12 @@ dependencies = [
 [[package]]
 name = "povu-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/povu?rev=a6e4b54363dfcf033010329eb37104a168e833b7#a6e4b54363dfcf033010329eb37104a168e833b7"
+source = "git+https://github.com/pangenome/povu?rev=0c9f21a40e7755293f5b21f33a7e2c894dc6cb15#0c9f21a40e7755293f5b21f33a7e2c894dc6cb15"
 dependencies = [
  "bindgen 0.70.1",
  "cmake",
  "libc",
+ "rayon",
  "thiserror 1.0.69",
 ]
 
@@ -2549,6 +2697,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spin"
@@ -2636,7 +2787,7 @@ dependencies = [
  "libc",
  "log",
  "nom 7.1.3",
- "noodles",
+ "noodles 0.100.0",
  "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34)",
  "ordered-float",
  "ragc-core",
@@ -2838,7 +2989,7 @@ dependencies = [
  "flate2",
  "lib_wfa2",
  "log",
- "noodles",
+ "noodles 0.100.0",
  "rayon",
  "tracepoints",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ indexmap = { version = "2", features = ["rayon"] }
 nalgebra = "0.33"
 indicatif = "0.18"
 spoa_rs = { git = "https://github.com/AndreaGuarracino/spoa-rs.git" }
+poasta = "0.1.0"
 rust-htslib = { version = "1.0.0", default-features = false, features = ["libdeflate"] }
 csv = "1.3"
 serde_json = "1.0"
@@ -75,7 +76,7 @@ seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
 bluntg = { git = "https://github.com/pangenome/bluntg" }
-povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "a6e4b54363dfcf033010329eb37104a168e833b7", default-features = false }
+povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "0c9f21a40e7755293f5b21f33a7e2c894dc6cb15", default-features = false }
 
 [build-dependencies]
 cc = "1"

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -143,7 +143,7 @@ transform is exposed directly:
 impg crush -g local.blunt.gfa -o local.crushed.gfa
 ```
 
-The defaults are sized for human panels (`512` rounds and `10k` path traversals
+The defaults are sized for human panels (`64` rounds and `10k` path traversals
 per candidate). Traversal count is deliberately a high safety rail. The main
 alignment budgets are `max-median-traversal-len` (default `1k`),
 `max-traversal-len` (default `10k`), and `max-total-seq`, because a common

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -17,7 +17,7 @@ them and are separated by commas:
 syng,k=63,s=8,seed=7:blunt
 seqwish,min-match-len=70
 pggb,window=20k
-syng,k=63,s=8:crush,max-span=10k,max-traversals=10k
+syng,k=63,s=8:crush,max-traversal-len=1k,max-traversals=10k
 ```
 
 This is a graph-pipeline DSL, not a general shell pipeline. Each stage is a
@@ -109,7 +109,7 @@ Examples:
 syng,k=63,s=8,seed=7
 seqwish,min-match-len=70,sparse-factor=0.001
 pggb,window=20k
-crush,max-span=10k,max-traversal-len=10k,max-traversals=10k,method=poa
+crush,method=auto,max-median-traversal-len=1k,max-traversal-len=10k
 ```
 
 Unknown parameters should be errors, not warnings. Silent ignoring would make
@@ -120,7 +120,7 @@ graph parameterization hard to reproduce.
 `src/resolution.rs` does not implement its own flubble finder. It passes the
 current blunt GFA to `povu-rs` and calls `NativeGfa::decompose_flubbles`, then
 uses POVU's site IDs, parent/child relationships, entry/exit steps, and
-reference spans to schedule exact path-preserving replacement.
+root-path spans to schedule exact path-preserving replacement.
 
 The crush loop is iterative because each exact replacement changes the local
 graph topology and therefore can create, remove, or expose nested POVU sites.
@@ -145,6 +145,14 @@ impg crush -g local.blunt.gfa -o local.crushed.gfa
 
 The defaults are sized for human panels (`512` rounds and `10k` path traversals
 per candidate). Traversal count is deliberately a high safety rail. The main
-alignment budgets are `max-span`, `max-traversal-len`, and `max-total-seq`,
-because a common allele represented by many haplotypes should not fail only
-because many paths traverse it.
+alignment budgets are `max-median-traversal-len` (default `1k`),
+`max-traversal-len` (default `10k`), and `max-total-seq`, because a common
+allele represented by many haplotypes should not fail only because many paths
+traverse it. `max-span` is optional and disabled by default; when set, it caps
+the span on the POVU root path, currently the first GFA path, so it is a rooted
+coordinate guard rather than the main runtime budget.
+
+`method=auto` currently tries the POASTA graph builder first and falls back to
+the SPOA-backed `poa` resolver if exact path-sequence validation fails. The
+intended next tier is a SweepGA/FastGA + filtering + seqwish resolver for
+bubbles that are too large for direct POA.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -163,8 +163,9 @@ gfa:<stage>[,<key=value>...][:<stage>[,<key=value>...]...]
 
 For example, `gfa:syng,k=63,s=8,seed=7:blunt` and the legacy
 `gfa:syng:blunt,k=63,s=8,seed=7` are both accepted. Graph transforms use the
-same staged syntax. `gfa:syng:crush,max-span=10k,max-traversals=10k` emits
-blunt syng GFA and then runs exact path-preserving bubble resolution; see
+same staged syntax.
+`gfa:syng:crush,method=auto,max-median-traversal-len=1k` emits blunt syng GFA
+and then runs exact path-preserving bubble resolution; see
 `docs/graph-pipeline-dsl.md`.
 
 The transform can also be run on an existing blunt GFA:

--- a/src/main.rs
+++ b/src/main.rs
@@ -3912,7 +3912,7 @@ GFA engine shorthand:
             alias = "iterations",
             alias = "max-rounds",
             value_parser = parse_usize_size,
-            default_value = "512"
+            default_value = "64"
         )]
         max_iterations: usize,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2226,6 +2226,15 @@ fn parse_crush_stage(
                 config.max_traversal_len =
                     parse_usize_size_engine_param(raw, &param.key, &param.value)?;
             }
+            "max-median-traversal-len"
+            | "max-median-traversal-length"
+            | "median-traversal-len"
+            | "median-traversal-length"
+            | "poa-median-traversal-len"
+            | "poa-median-traversal-length" => {
+                config.max_median_traversal_len =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
             "max-total-sequence" | "max-total-seq" | "max-sequence" => {
                 config.max_total_sequence =
                     parse_usize_size_engine_param(raw, &param.key, &param.value)?;
@@ -2235,16 +2244,17 @@ fn parse_crush_stage(
                     parse_usize_size_engine_param(raw, &param.key, &param.value)?;
             }
             "method" => {
-                let method = param.value.replace('_', "-").to_ascii_lowercase();
-                if !matches!(method.as_str(), "poa" | "spoa") {
+                let Some(method) = impg::resolution::ResolutionMethod::parse_name(&param.value)
+                else {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!(
-                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected poa)",
+                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected auto, poa, or poasta)",
                             raw, param.value
                         ),
                     ));
-                }
+                };
+                config.method = method;
             }
             other => {
                 return Err(io::Error::new(
@@ -3906,13 +3916,17 @@ GFA engine shorthand:
         )]
         max_iterations: usize,
 
-        /// Maximum reference span in bp for a candidate bubble
-        #[clap(long, alias = "max-bubble-span", value_parser = parse_usize_size, default_value = "10k")]
+        /// Maximum root-path span in bp for a candidate bubble; 0 disables this guard
+        #[clap(long, alias = "max-bubble-span", value_parser = parse_usize_size, default_value = "0")]
         max_span: usize,
 
         /// Maximum sequence length of any traversal through one candidate
         #[clap(long, alias = "max-traversal-length", value_parser = parse_usize_size, default_value = "10k")]
         max_traversal_len: usize,
+
+        /// Maximum median traversal length through one candidate; 0 disables this guard
+        #[clap(long, alias = "max-median-traversal-length", value_parser = parse_usize_size, default_value = "1k")]
+        max_median_traversal_len: usize,
 
         /// Maximum total sequence across all traversals through one candidate
         #[clap(long, alias = "max-total-seq", value_parser = parse_usize_size, default_value = "1m")]
@@ -3921,6 +3935,10 @@ GFA engine shorthand:
         /// Maximum number of path-supported traversals through one candidate
         #[clap(long, value_parser = parse_usize_size, default_value = "10k")]
         max_traversals: usize,
+
+        /// Resolver method: auto, poa, or poasta
+        #[clap(long, value_parser, default_value = "auto")]
+        method: String,
 
         #[clap(flatten)]
         common: CommonOpts,
@@ -6445,8 +6463,10 @@ fn run() -> io::Result<()> {
             max_iterations,
             max_span,
             max_traversal_len,
+            max_median_traversal_len,
             max_total_sequence,
             max_traversals,
+            method,
             common,
         } => {
             initialize_threads_and_log(&common);
@@ -6462,6 +6482,12 @@ fn run() -> io::Result<()> {
                     "--max-traversals must be > 0",
                 ));
             }
+            let Some(method) = impg::resolution::ResolutionMethod::parse_name(&method) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--method must be one of: auto, poa, poasta",
+                ));
+            };
 
             let mut gfa_text = String::new();
             if gfa == "-" {
@@ -6472,8 +6498,10 @@ fn run() -> io::Result<()> {
 
             let config = impg::resolution::ResolutionConfig {
                 max_iterations,
+                method,
                 max_bubble_span: max_span,
                 max_traversal_len,
+                max_median_traversal_len,
                 max_total_sequence,
                 max_traversals,
                 ..Default::default()
@@ -10297,7 +10325,7 @@ mod tests {
             "-d",
             "0",
             "-o",
-            "gfa:syng:crush,max-span=10k,max-traversals=64,max-rounds=7",
+            "gfa:syng:crush,method=poasta,max-median-traversal-len=2k,max-traversals=64,max-rounds=7",
         ])
         .unwrap();
         match args {
@@ -10311,15 +10339,45 @@ mod tests {
                 assert_eq!(output_format, "gfa");
                 assert_eq!(
                     engine_cli.engine_raw,
-                    "syng:crush,max-span=10k,max-traversals=64,max-rounds=7"
+                    "syng:crush,method=poasta,max-median-traversal-len=2k,max-traversals=64,max-rounds=7"
                 );
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.engine, GfaEngine::SyngNative);
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
                 let crush = parsed.crush_config.unwrap();
-                assert_eq!(crush.max_bubble_span, 10_000);
+                assert_eq!(crush.method, impg::resolution::ResolutionMethod::Poasta);
+                assert_eq!(crush.max_bubble_span, 0);
+                assert_eq!(crush.max_median_traversal_len, 2_000);
                 assert_eq!(crush.max_traversals, 64);
                 assert_eq!(crush.max_iterations, 7);
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_syng_crush_uses_safe_defaults() {
+        let args = Args::try_parse_from(["impg", "query", "-d", "0", "-o", "gfa:syng:crush"])
+            .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                assert_eq!(engine_cli.engine_raw, "syng:crush");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.engine, GfaEngine::SyngNative);
+                assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                let crush = parsed.crush_config.unwrap();
+                assert_eq!(crush.method, impg::resolution::ResolutionMethod::Auto);
+                assert_eq!(crush.max_bubble_span, 0);
+                assert_eq!(crush.max_median_traversal_len, 1_000);
+                assert_eq!(crush.max_traversal_len, 10_000);
+                assert_eq!(crush.max_traversals, 10_000);
             }
             _ => panic!("expected query command"),
         }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -56,7 +56,7 @@ impl ResolutionMethod {
     }
 }
 
-pub const DEFAULT_MAX_ITERATIONS: usize = 512;
+pub const DEFAULT_MAX_ITERATIONS: usize = 64;
 /// By default, do not cap by rooted path span.
 ///
 /// `max_bubble_span` is a POVU root-path coordinate guard. The root is currently

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -12,16 +12,24 @@ use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
 use std::io;
+use std::time::Instant;
 
 /// Configuration for exact path-preserving bubble resolution.
 #[derive(Clone, Debug)]
 pub struct ResolutionConfig {
     /// Maximum number of frontier replacement rounds.
     pub max_iterations: usize,
-    /// Maximum reference path span, in bp, for a candidate bubble.
+    /// Local graph induction method used for selected bubbles.
+    pub method: ResolutionMethod,
+    /// Maximum root path span, in bp, for a candidate bubble.
+    ///
+    /// The root path is the first path in the input GFA. This is a rooted POVU
+    /// decomposition coordinate, not necessarily an external reference genome.
     pub max_bubble_span: usize,
     /// Maximum length of any observed traversal through the bubble.
     pub max_traversal_len: usize,
+    /// Maximum median traversal length. A value of 0 disables this guard.
+    pub max_median_traversal_len: usize,
     /// Maximum sum of traversal sequence lengths for one replacement.
     pub max_total_sequence: usize,
     /// Maximum number of path-supported traversals through one replacement.
@@ -30,9 +38,33 @@ pub struct ResolutionConfig {
     pub scoring_params: (u8, u8, u8, u8, u8, u8),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResolutionMethod {
+    Auto,
+    Poa,
+    Poasta,
+}
+
+impl ResolutionMethod {
+    pub fn parse_name(value: &str) -> Option<Self> {
+        match value.replace('_', "-").to_ascii_lowercase().as_str() {
+            "auto" => Some(Self::Auto),
+            "poa" | "spoa" => Some(Self::Poa),
+            "poasta" => Some(Self::Poasta),
+            _ => None,
+        }
+    }
+}
+
 pub const DEFAULT_MAX_ITERATIONS: usize = 512;
-pub const DEFAULT_MAX_BUBBLE_SPAN: usize = 10_000;
+/// By default, do not cap by rooted path span.
+///
+/// `max_bubble_span` is a POVU root-path coordinate guard. The root is currently
+/// the first GFA path, so this is intentionally not part of the default runtime
+/// budget. Use traversal length/count/total sequence for the real work cap.
+pub const DEFAULT_MAX_BUBBLE_SPAN: usize = 0;
 pub const DEFAULT_MAX_TRAVERSAL_LEN: usize = 10_000;
+pub const DEFAULT_MAX_MEDIAN_TRAVERSAL_LEN: usize = 1_000;
 pub const DEFAULT_MAX_TOTAL_SEQUENCE: usize = 1_000_000;
 pub const DEFAULT_MAX_TRAVERSALS: usize = 10_000;
 
@@ -40,8 +72,10 @@ impl Default for ResolutionConfig {
     fn default() -> Self {
         Self {
             max_iterations: DEFAULT_MAX_ITERATIONS,
+            method: ResolutionMethod::Auto,
             max_bubble_span: DEFAULT_MAX_BUBBLE_SPAN,
             max_traversal_len: DEFAULT_MAX_TRAVERSAL_LEN,
+            max_median_traversal_len: DEFAULT_MAX_MEDIAN_TRAVERSAL_LEN,
             max_total_sequence: DEFAULT_MAX_TOTAL_SEQUENCE,
             max_traversals: DEFAULT_MAX_TRAVERSALS,
             scoring_params: (1, 4, 6, 2, 26, 1),
@@ -103,15 +137,28 @@ struct BubbleCandidate {
     ranges: Vec<PathRange>,
     signature: String,
     within_budget: bool,
-    reference_start_step: usize,
-    reference_end_step: usize,
-    ref_span: usize,
+    root_start_step: usize,
+    root_end_step: usize,
+    root_span: usize,
+    traversal_stats: TraversalStats,
 }
 
 #[derive(Clone, Debug, Default)]
 struct CandidateFrontier {
     selected: Vec<BubbleCandidate>,
-    bailed_signatures: Vec<String>,
+    bailed: Vec<BubbleCandidate>,
+    sites_seen: usize,
+    candidates_seen: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct TraversalStats {
+    count: usize,
+    min_len: usize,
+    median_len: usize,
+    p90_len: usize,
+    max_len: usize,
+    total_len: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -153,14 +200,39 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
     let mut changed = false;
 
     for round in 0..config.max_iterations {
+        let round_start = Instant::now();
+        let discovery_start = Instant::now();
         let frontier = find_candidate_frontier(&graph, config, &seen)?;
-        if frontier.selected.is_empty() && frontier.bailed_signatures.is_empty() {
+        let discovery_elapsed = discovery_start.elapsed();
+        if frontier.selected.is_empty() && frontier.bailed.is_empty() {
+            log::info!(
+                "crush round {}: no eligible candidates from {} POVU site(s) in {:.2?}",
+                round + 1,
+                frontier.sites_seen,
+                discovery_elapsed
+            );
             break;
         }
         stats.iterations = round + 1;
 
-        for signature in frontier.bailed_signatures {
-            seen.insert(signature);
+        log::info!(
+            "crush round {}: {} POVU site(s), {} unseen polymorphic candidate(s), {} selected, {} over budget in {:.2?}",
+            round + 1,
+            frontier.sites_seen,
+            frontier.candidates_seen,
+            frontier.selected.len(),
+            frontier.bailed.len(),
+            discovery_elapsed
+        );
+        log::info!(
+            "crush round {} traversal stats: {}; {}",
+            round + 1,
+            format_candidate_length_summary("selected", &frontier.selected),
+            format_candidate_length_summary("over-budget", &frontier.bailed)
+        );
+
+        for candidate in frontier.bailed {
+            seen.insert(candidate.signature);
             stats.candidates_seen += 1;
             stats.bailed += 1;
         }
@@ -174,16 +246,19 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
             stats.candidates_seen += 1;
         }
 
+        let selected_count = frontier.selected.len();
+        let build_start = Instant::now();
         let build_results = frontier
             .selected
             .into_par_iter()
             .map(|candidate| {
-                build_poa_replacement(&candidate, config).map(|replacement| ReplacementPlan {
+                build_replacement(&candidate, config).map(|replacement| ReplacementPlan {
                     candidate,
                     replacement,
                 })
             })
             .collect::<Vec<_>>();
+        let build_elapsed = build_start.elapsed();
 
         let mut plans = Vec::new();
         for result in build_results {
@@ -202,13 +277,30 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
         }
 
         if plans.is_empty() {
+            log::info!(
+                "crush round {}: 0/{} replacement(s) built in {:.2?}",
+                round + 1,
+                selected_count,
+                build_elapsed
+            );
             continue;
         }
 
         let resolved_count = plans.len();
+        let rewrite_start = Instant::now();
         graph = apply_replacement_frontier(&graph, &plans)?;
+        let rewrite_elapsed = rewrite_start.elapsed();
         changed = true;
         stats.resolved += resolved_count;
+        log::info!(
+            "crush round {}: resolved {}/{} replacement(s) in {:.2?}; rewrite+validate {:.2?}; total {:.2?}",
+            round + 1,
+            resolved_count,
+            selected_count,
+            build_elapsed,
+            rewrite_elapsed,
+            round_start.elapsed()
+        );
     }
 
     Ok(ResolvedGfa {
@@ -301,7 +393,27 @@ fn parse_gfa(gfa: &str) -> io::Result<Graph> {
                     });
                 }
             }
-            "H" | "W" | "C" | "J" => {}
+            "W" => {
+                if fields.len() < 7 {
+                    return Err(invalid_gfa(line_no, "W line has fewer than 7 fields"));
+                }
+                let mut steps = Vec::new();
+                for (id, rev) in parse_w_walk(fields[6])
+                    .ok_or_else(|| invalid_gfa(line_no, "W line has a malformed walk"))?
+                {
+                    let Some(&node) = id_to_idx.get(id) else {
+                        return Err(invalid_gfa(line_no, "W line references unknown segment"));
+                    };
+                    steps.push(Step { node, rev });
+                }
+                if !steps.is_empty() {
+                    paths.push(Path {
+                        name: fields[3].to_string(),
+                        steps,
+                    });
+                }
+            }
+            "H" | "C" | "J" => {}
             _ => {}
         }
     }
@@ -322,6 +434,31 @@ fn parse_p_step(step: &str) -> Option<(&str, bool)> {
     } else {
         step.strip_suffix('-').map(|id| (id, true))
     }
+}
+
+fn parse_w_walk(walk: &str) -> Option<Vec<(&str, bool)>> {
+    let mut steps = Vec::new();
+    let mut start = None;
+    let mut rev = false;
+    for (idx, ch) in walk.char_indices() {
+        if ch != '>' && ch != '<' {
+            continue;
+        }
+        if let Some(prev_start) = start {
+            if prev_start == idx {
+                return None;
+            }
+            steps.push((&walk[prev_start..idx], rev));
+        }
+        start = Some(idx + ch.len_utf8());
+        rev = ch == '<';
+    }
+    let prev_start = start?;
+    if prev_start == walk.len() {
+        return None;
+    }
+    steps.push((&walk[prev_start..], rev));
+    Some(steps)
 }
 
 fn path_sequence(graph: &Graph, path: &Path) -> io::Result<Vec<u8>> {
@@ -352,6 +489,95 @@ fn range_sequence(graph: &Graph, range: &PathRange) -> Vec<u8> {
     seq
 }
 
+fn traversal_stats(ranges: &[PathRange]) -> TraversalStats {
+    if ranges.is_empty() {
+        return TraversalStats::default();
+    }
+
+    let mut lengths = ranges
+        .iter()
+        .map(|range| range.sequence.len())
+        .collect::<Vec<_>>();
+    lengths.sort_unstable();
+
+    TraversalStats {
+        count: lengths.len(),
+        min_len: lengths[0],
+        median_len: lengths[lengths.len() / 2],
+        p90_len: lengths[percentile_index(lengths.len(), 90, 100)],
+        max_len: *lengths.last().unwrap_or(&0),
+        total_len: lengths.iter().sum(),
+    }
+}
+
+fn percentile_index(len: usize, numerator: usize, denominator: usize) -> usize {
+    if len == 0 || denominator == 0 {
+        return 0;
+    }
+    let rank = len.saturating_mul(numerator).div_ceil(denominator);
+    rank.saturating_sub(1).min(len - 1)
+}
+
+fn format_candidate_length_summary(label: &str, candidates: &[BubbleCandidate]) -> String {
+    if candidates.is_empty() {
+        return format!("{label} none");
+    }
+
+    let mut max_lengths = candidates
+        .iter()
+        .map(|candidate| candidate.traversal_stats.max_len)
+        .collect::<Vec<_>>();
+    let mut median_lengths = candidates
+        .iter()
+        .map(|candidate| candidate.traversal_stats.median_len)
+        .collect::<Vec<_>>();
+    let mut p90_lengths = candidates
+        .iter()
+        .map(|candidate| candidate.traversal_stats.p90_len)
+        .collect::<Vec<_>>();
+    let traversal_counts = candidates
+        .iter()
+        .map(|candidate| candidate.traversal_stats.count)
+        .collect::<Vec<_>>();
+    let max_total = candidates
+        .iter()
+        .map(|candidate| candidate.traversal_stats.total_len)
+        .max()
+        .unwrap_or(0);
+    let max_root_span = candidates
+        .iter()
+        .map(|candidate| candidate.root_span)
+        .max()
+        .unwrap_or(0);
+
+    let max_len = *max_lengths.iter().max().unwrap_or(&0);
+    let max_median = *median_lengths.iter().max().unwrap_or(&0);
+    let max_p90 = *p90_lengths.iter().max().unwrap_or(&0);
+    let max_traversals = *traversal_counts.iter().max().unwrap_or(&0);
+
+    format!(
+        "{label} n={}, max-len median/max={}/{}, median-len median/max={}/{}, p90-len median/max={}/{}, traversals max={}, total max={}, root-span max={}",
+        candidates.len(),
+        median_value(&mut max_lengths),
+        max_len,
+        median_value(&mut median_lengths),
+        max_median,
+        median_value(&mut p90_lengths),
+        max_p90,
+        max_traversals,
+        max_total,
+        max_root_span
+    )
+}
+
+fn median_value(values: &mut [usize]) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
 fn path_positions(graph: &Graph, path_idx: usize) -> Vec<usize> {
     let path = &graph.paths[path_idx];
     let mut positions = Vec::with_capacity(path.steps.len() + 1);
@@ -371,97 +597,123 @@ fn find_candidate_frontier(
     if graph.paths.is_empty() || graph.paths[0].steps.len() < 2 {
         return Ok(CandidateFrontier::default());
     }
-    let ref_path_idx = 0;
-    let ref_path = &graph.paths[ref_path_idx];
-    let ref_positions = path_positions(graph, ref_path_idx);
+    let root_path_idx = 0;
+    let root_path = &graph.paths[root_path_idx];
+    let root_positions = path_positions(graph, root_path_idx);
+    let render_start = Instant::now();
     let rendered = render_graph(graph);
+    let render_elapsed = render_start.elapsed();
+    let parse_start = Instant::now();
     let native_graph = povu::NativeGfa::parse(&rendered).map_err(povu_to_io_error)?;
-    let reference_names = vec![ref_path.name.clone()];
+    let parse_elapsed = parse_start.elapsed();
+    let reference_names = vec![root_path.name.clone()];
+    let decompose_start = Instant::now();
     let decomposition = native_graph
         .decompose_flubbles(&reference_names)
         .map_err(povu_to_io_error)?;
+    let decompose_elapsed = decompose_start.elapsed();
+    let id_map_start = Instant::now();
     let id_to_idx = graph
         .segments
         .iter()
         .enumerate()
         .map(|(idx, segment)| (segment.id.as_str(), idx))
         .collect::<FxHashMap<_, _>>();
+    let id_map_elapsed = id_map_start.elapsed();
 
-    let mut candidates = Vec::new();
-    for site in &decomposition.sites {
-        let begin = site.reference_start_step;
-        let exit_step = site.reference_end_step;
-        if exit_step + 1 >= ref_positions.len() {
-            continue;
-        }
-        let Some(entry) = step_from_povu(&id_to_idx, &site.start) else {
-            continue;
-        };
-        let Some(exit) = step_from_povu(&id_to_idx, &site.end) else {
-            continue;
-        };
-        let ref_span = ref_positions[exit_step + 1] - ref_positions[begin];
-
-        let mut ranges = Vec::new();
-        for path_idx in 0..graph.paths.len() {
-            if let Some((range_begin, range_end)) =
-                unique_anchor_range(&graph.paths[path_idx], entry, exit)
-            {
-                let mut range = PathRange {
-                    path_idx,
-                    begin_step: range_begin,
-                    end_step: range_end,
-                    sequence: Vec::new(),
-                };
-                range.sequence = range_sequence(graph, &range);
-                ranges.push(range);
+    let sites_seen = decomposition.sites.len();
+    let candidate_start = Instant::now();
+    let mut candidates = decomposition
+        .sites
+        .par_iter()
+        .filter_map(|site| {
+            let begin = site.reference_start_step;
+            let exit_step = site.reference_end_step;
+            if exit_step + 1 >= root_positions.len() {
+                return None;
             }
-        }
+            let entry = step_from_povu(&id_to_idx, &site.start)?;
+            let exit = step_from_povu(&id_to_idx, &site.end)?;
+            let root_span = root_positions[exit_step + 1] - root_positions[begin];
 
-        if ranges.len() < 2 {
-            continue;
-        }
+            let mut ranges = Vec::new();
+            for path_idx in 0..graph.paths.len() {
+                if let Some((range_begin, range_end)) =
+                    unique_anchor_range(&graph.paths[path_idx], entry, exit)
+                {
+                    let mut range = PathRange {
+                        path_idx,
+                        begin_step: range_begin,
+                        end_step: range_end,
+                        sequence: Vec::new(),
+                    };
+                    range.sequence = range_sequence(graph, &range);
+                    ranges.push(range);
+                }
+            }
 
-        let distinct_sequences: BTreeSet<Vec<u8>> =
-            ranges.iter().map(|r| r.sequence.clone()).collect();
-        if distinct_sequences.len() < 2 {
-            continue;
-        }
+            if ranges.len() < 2 {
+                return None;
+            }
 
-        let signature = candidate_signature(graph, ref_path_idx, begin, exit_step, &ranges);
-        if seen.contains(&signature) {
-            continue;
-        }
+            let distinct_sequences: BTreeSet<Vec<u8>> =
+                ranges.iter().map(|r| r.sequence.clone()).collect();
+            if distinct_sequences.len() < 2 {
+                return None;
+            }
 
-        let max_traversal_len = ranges.iter().map(|r| r.sequence.len()).max().unwrap_or(0);
-        let total_sequence = ranges.iter().map(|r| r.sequence.len()).sum::<usize>();
-        let within_budget = ref_span <= config.max_bubble_span
-            && ranges.len() <= config.max_traversals
-            && max_traversal_len <= config.max_traversal_len
-            && total_sequence <= config.max_total_sequence;
+            let signature = candidate_signature(
+                graph,
+                root_path_idx,
+                &root_positions,
+                begin,
+                exit_step,
+                &ranges,
+            );
+            if seen.contains(&signature) {
+                return None;
+            }
 
-        candidates.push(BubbleCandidate {
-            ranges,
-            signature,
-            within_budget,
-            reference_start_step: begin,
-            reference_end_step: exit_step,
-            ref_span,
-        });
-    }
+            let traversal_stats = traversal_stats(&ranges);
+            let within_budget = (config.max_bubble_span == 0
+                || root_span <= config.max_bubble_span)
+                && ranges.len() <= config.max_traversals
+                && traversal_stats.max_len <= config.max_traversal_len
+                && (config.max_median_traversal_len == 0
+                    || traversal_stats.median_len <= config.max_median_traversal_len)
+                && traversal_stats.total_len <= config.max_total_sequence;
 
+            Some(BubbleCandidate {
+                ranges,
+                signature,
+                within_budget,
+                root_start_step: begin,
+                root_end_step: exit_step,
+                root_span,
+                traversal_stats,
+            })
+        })
+        .collect::<Vec<_>>();
+    let candidate_elapsed = candidate_start.elapsed();
+    let candidates_seen = candidates.len();
+
+    let select_start = Instant::now();
     candidates.sort_by(|a, b| {
-        b.reference_step_span()
-            .cmp(&a.reference_step_span())
-            .then_with(|| b.ref_span.cmp(&a.ref_span))
-            .then_with(|| a.reference_start_step.cmp(&b.reference_start_step))
-            .then_with(|| a.reference_end_step.cmp(&b.reference_end_step))
+        b.root_step_span()
+            .cmp(&a.root_step_span())
+            .then_with(|| b.root_span.cmp(&a.root_span))
+            .then_with(|| a.root_start_step.cmp(&b.root_start_step))
+            .then_with(|| a.root_end_step.cmp(&b.root_end_step))
     });
 
-    let mut frontier = CandidateFrontier::default();
+    let mut frontier = CandidateFrontier {
+        sites_seen,
+        candidates_seen,
+        ..CandidateFrontier::default()
+    };
     for candidate in candidates {
         if !candidate.within_budget {
-            frontier.bailed_signatures.push(candidate.signature);
+            frontier.bailed.push(candidate);
             continue;
         }
         if frontier
@@ -473,14 +725,24 @@ fn find_candidate_frontier(
         }
         frontier.selected.push(candidate);
     }
+    let select_elapsed = select_start.elapsed();
+
+    log::info!(
+        "crush discovery detail: render {:.2?}, povu-parse {:.2?}, povu-decompose {:.2?}, id-map {:.2?}, candidate-build {:.2?}, select {:.2?}",
+        render_elapsed,
+        parse_elapsed,
+        decompose_elapsed,
+        id_map_elapsed,
+        candidate_elapsed,
+        select_elapsed
+    );
 
     Ok(frontier)
 }
 
 impl BubbleCandidate {
-    fn reference_step_span(&self) -> usize {
-        self.reference_end_step
-            .saturating_sub(self.reference_start_step)
+    fn root_step_span(&self) -> usize {
+        self.root_end_step.saturating_sub(self.root_start_step)
     }
 }
 
@@ -543,11 +805,11 @@ fn unique_anchor_range(path: &Path, entry: Step, exit: Step) -> Option<(usize, u
 fn candidate_signature(
     graph: &Graph,
     ref_path_idx: usize,
+    ref_positions: &[usize],
     begin: usize,
     exit_step: usize,
     ranges: &[PathRange],
 ) -> String {
-    let positions = path_positions(graph, ref_path_idx);
     let mut seqs: Vec<String> = ranges
         .iter()
         .map(|r| String::from_utf8_lossy(&r.sequence).to_string())
@@ -556,8 +818,8 @@ fn candidate_signature(
     format!(
         "{}:{}-{}:{}",
         graph.paths[ref_path_idx].name,
-        positions[begin],
-        positions[exit_step + 1],
+        ref_positions[begin],
+        ref_positions[exit_step + 1],
         seqs.join("|")
     )
 }
@@ -567,9 +829,10 @@ fn apply_replacement_frontier(graph: &Graph, plans: &[ReplacementPlan]) -> io::R
 
     for (plan_idx, plan) in plans.iter().enumerate() {
         for (range_idx, range) in plan.candidate.ranges.iter().enumerate() {
-            let path = plan.replacement.paths.get(range_idx).ok_or_else(|| {
-                io::Error::other("replacement path missing for candidate range")
-            })?;
+            let path =
+                plan.replacement.paths.get(range_idx).ok_or_else(|| {
+                    io::Error::other("replacement path missing for candidate range")
+                })?;
             let steps = path
                 .steps
                 .iter()
@@ -663,6 +926,21 @@ fn apply_replacement_frontier(graph: &Graph, plans: &[ReplacementPlan]) -> io::R
     Ok(next)
 }
 
+fn build_replacement(candidate: &BubbleCandidate, config: &ResolutionConfig) -> io::Result<Graph> {
+    let method = match config.method {
+        ResolutionMethod::Auto => ResolutionMethod::Poasta,
+        method => method,
+    };
+    match method {
+        ResolutionMethod::Auto => unreachable!("auto is resolved before replacement dispatch"),
+        ResolutionMethod::Poa => build_poa_replacement(candidate, config),
+        ResolutionMethod::Poasta => build_poasta_replacement(candidate, config).or_else(|err| {
+            log::debug!("POASTA replacement failed; falling back to SPOA: {err}");
+            build_poa_replacement(candidate, config)
+        }),
+    }
+}
+
 fn build_poa_replacement(
     candidate: &BubbleCandidate,
     config: &ResolutionConfig,
@@ -710,6 +988,148 @@ fn build_poa_replacement(
     }
 
     Ok(replacement)
+}
+
+fn build_poasta_replacement(
+    candidate: &BubbleCandidate,
+    config: &ResolutionConfig,
+) -> io::Result<Graph> {
+    use poasta::aligner::config::{Affine2PieceMinGapCost, AffineMinGapCost};
+    use poasta::aligner::scoring::{AlignmentType, GapAffine, GapAffine2Piece};
+    use poasta::aligner::PoastaAligner;
+    use poasta::graphs::poa::POAGraph;
+    use poasta::io::graph::graph_to_gfa;
+
+    let headers: Vec<String> = candidate
+        .ranges
+        .iter()
+        .enumerate()
+        .map(|(i, range)| format!("__impg_bubble_path{}_{}", range.path_idx, i))
+        .collect();
+    let sequences: Vec<&[u8]> = candidate
+        .ranges
+        .iter()
+        .map(|range| range.sequence.as_slice())
+        .collect();
+    let weights = sequences
+        .iter()
+        .map(|sequence| vec![1usize; sequence.len()])
+        .collect::<Vec<_>>();
+    let (_, mismatch, gap_open, gap_extend, gap_open2, gap_extend2) = config.scoring_params;
+    let mut graph = POAGraph::<u32>::new();
+
+    if gap_extend > gap_extend2 {
+        let scoring = GapAffine2Piece::new(mismatch, gap_extend, gap_open, gap_extend2, gap_open2);
+        let mut aligner =
+            PoastaAligner::new(Affine2PieceMinGapCost(scoring), AlignmentType::Global);
+        add_poasta_sequences(
+            &mut graph,
+            &mut aligner,
+            &headers,
+            &sequences,
+            &weights,
+        )?;
+    } else {
+        let scoring = GapAffine::new(mismatch, gap_extend, gap_open);
+        let mut aligner = PoastaAligner::new(AffineMinGapCost(scoring), AlignmentType::Global);
+        add_poasta_sequences(
+            &mut graph,
+            &mut aligner,
+            &headers,
+            &sequences,
+            &weights,
+        )?;
+    }
+
+    let mut gfa = Vec::new();
+    graph_to_gfa(&mut gfa, &graph).map_err(|err| {
+        io::Error::other(format!(
+            "POASTA replacement GFA generation failed: {err}"
+        ))
+    })?;
+    let gfa = String::from_utf8(gfa).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("POASTA replacement GFA is not UTF-8: {err}"),
+        )
+    })?;
+    let mut replacement = parse_gfa(&gfa)?;
+    order_replacement_paths(&mut replacement, &headers)?;
+
+    if replacement.paths.len() != candidate.ranges.len() {
+        return Err(io::Error::other(format!(
+            "POASTA replacement emitted {} paths for {} traversals",
+            replacement.paths.len(),
+            candidate.ranges.len()
+        )));
+    }
+
+    for (idx, range) in candidate.ranges.iter().enumerate() {
+        let observed = path_sequence(&replacement, &replacement.paths[idx])?;
+        if observed != range.sequence {
+            return Err(io::Error::other(format!(
+                "POASTA replacement path {} changed sequence length {} -> {}",
+                idx,
+                range.sequence.len(),
+                observed.len()
+            )));
+        }
+    }
+
+    Ok(replacement)
+}
+
+fn add_poasta_sequences<C>(
+    graph: &mut poasta::graphs::poa::POAGraph<u32>,
+    aligner: &mut poasta::aligner::PoastaAligner<C>,
+    headers: &[String],
+    sequences: &[&[u8]],
+    weights: &[Vec<usize>],
+) -> io::Result<()>
+where
+    C: poasta::aligner::config::AlignmentConfig,
+{
+    for (idx, sequence) in sequences.iter().enumerate() {
+        if graph.is_empty() {
+            graph
+                .add_alignment_with_weights(&headers[idx], sequence, None, &weights[idx])
+                .map_err(poasta_to_io_error)?;
+        } else {
+            let result = aligner.align::<u32, _>(graph, sequence);
+            graph
+                .add_alignment_with_weights(
+                    &headers[idx],
+                    sequence,
+                    Some(&result.alignment),
+                    &weights[idx],
+                )
+                .map_err(poasta_to_io_error)?;
+        }
+    }
+    Ok(())
+}
+
+fn poasta_to_io_error(err: poasta::errors::PoastaError) -> io::Error {
+    io::Error::other(format!("POASTA replacement failed: {err}"))
+}
+
+fn order_replacement_paths(graph: &mut Graph, headers: &[String]) -> io::Result<()> {
+    let mut paths_by_name = graph
+        .paths
+        .drain(..)
+        .map(|path| (path.name.clone(), path))
+        .collect::<FxHashMap<_, _>>();
+    let mut ordered = Vec::with_capacity(headers.len());
+    for header in headers {
+        let Some(path) = paths_by_name.remove(header) else {
+            return Err(io::Error::other(format!(
+                "replacement graph is missing path '{header}'"
+            )));
+        };
+        ordered.push(path);
+    }
+    graph.paths = ordered;
+    Ok(())
 }
 
 fn path_sequences_equal(before: &Graph, after: &Graph) -> io::Result<bool> {
@@ -863,6 +1283,19 @@ mod tests {
     }
 
     #[test]
+    fn parses_w_walks_as_paths() {
+        let gfa = "\
+H\tVN:Z:1.1
+S\ts0\tAC
+S\ts1\tGT
+L\ts0\t+\ts1\t-\t0M
+W\t*\t0\twalk0\t0\t4\t>s0<s1
+";
+        let seqs = seq_map(gfa);
+        assert_eq!(seqs["walk0"], "ACAC");
+    }
+
+    #[test]
     fn resolves_simple_snp_bubble_without_changing_path_sequences() {
         let gfa = "\
 H\tVN:Z:1.0
@@ -906,6 +1339,59 @@ P\tins\t1+,2+,3+\t*
     }
 
     #[test]
+    fn resolves_insertion_bubble_with_poasta_without_changing_path_sequences() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tAC
+S\t2\tGGG
+S\t3\tTA
+L\t1\t+\t3\t+\t0M
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+P\tref\t1+,3+\t*
+P\tins\t1+,2+,3+\t*
+";
+        let before = seq_map(gfa);
+        let resolved = resolve_gfa_bubbles(
+            gfa,
+            &ResolutionConfig {
+                method: ResolutionMethod::Poasta,
+                ..ResolutionConfig::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(before, seq_map(&resolved.gfa));
+        assert_eq!(resolved.stats.resolved, 1);
+    }
+
+    #[test]
+    fn bails_out_when_candidate_exceeds_median_traversal_budget() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tAC
+S\t2\tGGG
+S\t3\tTA
+L\t1\t+\t3\t+\t0M
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+P\tref\t1+,3+\t*
+P\tins\t1+,2+,3+\t*
+";
+        let before = seq_map(gfa);
+        let resolved = resolve_gfa_bubbles(
+            gfa,
+            &ResolutionConfig {
+                max_median_traversal_len: 4,
+                ..ResolutionConfig::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(before, seq_map(&resolved.gfa));
+        assert_eq!(resolved.stats.resolved, 0);
+        assert!(resolved.stats.bailed >= 1);
+    }
+
+    #[test]
     fn resolves_maximal_eligible_nested_site_first() {
         let gfa = "\
 H\tVN:Z:1.0
@@ -943,6 +1429,7 @@ P\touter_alt\t1+,7+,6+\t*
             gfa,
             &ResolutionConfig {
                 max_iterations: 4,
+                method: ResolutionMethod::Poa,
                 ..ResolutionConfig::default()
             },
         )


### PR DESCRIPTION
## Summary
- make `gfa:syng:crush` the clean default path for syng local graph output
- default crush to `method=auto`, which currently uses POASTA and falls back to SPOA/POA when exact path-sequence validation fails
- disable the old root-path span guard by default, add a 1k median traversal cap, keep 10k per-traversal and 10k traversal count safeguards
- parse POASTA W-lines and preserve path sequences exactly through replacement
- document the graph pipeline DSL and syng GFA query command

## Validation
- `cargo test --all-targets`
- `cargo build --release`
- HPRCv2 C4 smoke test is running locally with `-o gfa:syng:crush`

## Notes
This pins POVU to a commit with the native flubble decomposition improvements needed by crush. The default user command is now `-o gfa:syng:crush`; `-o gfa:syng` remains the blunt syng graph without crush, and `-o gfa:syng:raw` remains the raw overlap form for debugging.