### PR TITLE
Merge syng intervals before GFA output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ impg query -a aln.paf -r chr1:1000-2000 -d 100 -x -m 3
 # Many regions from a BED, mixed PAF + 1ALN
 impg query -a f1.paf f2.1aln -b regions.bed -d 100
 
+# One local graph per BED4 row, named from column 4
+impg query -a pan.syng -b regions.bed -d 100k -o gfa:syng:crush \
+           --sequence-files genomes.agc -O graphs/
+
 # Output formats: auto | bed | bedpe | paf | gfa | vcf | maf | fasta | fasta+paf | fasta-aln
 impg query -a aln.paf -r chr1:1000-2000 -d 100 -o bed
 impg query -a aln.paf -r chr1:1000-2000 -d 100 -o gfa --sequence-files genomes.fa
@@ -137,7 +141,10 @@ impg query -a pan.syng -r chr1:1000-2000 -d 100 --sequence-files genomes.fa
 
 GFA / MAF / FASTA outputs need `--sequence-files` (FASTA or AGC
 archive) or `--sequence-list`. See [GFA engines](#gfa-engines) for
-engine selection and partitioned builds.
+engine selection and partitioned builds. With `-b` and graph-like outputs
+(`gfa`, `vcf`, or `gbwt`), `-O` is treated as an output directory and
+each BED row is written separately using the BED column 4 name as the
+file stem.
 
 ### `graph` — build a pangenome graph from FASTA
 

--- a/src/commands/syng2gfa.rs
+++ b/src/commands/syng2gfa.rs
@@ -15,13 +15,24 @@
 //! syng's native overlap graph.
 
 use std::io::{self, BufWriter, Write};
+use std::time::Instant;
 
 use log::{debug, info, warn};
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::sequence_index::{SequenceIndex, UnifiedSequenceIndex};
 use crate::syng::{GbwtPathStart, SyngIndex};
 use crate::syng_ffi;
+
+/// A source path interval to render as one GFA path.
+pub struct SyngGfaPathRange {
+    pub path_idx: usize,
+    pub name: String,
+    pub start: u64,
+    pub end: u64,
+    pub strand: char,
+}
 
 /// Syng GFA graph shape.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -134,9 +145,22 @@ struct GapSegment {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 enum GapContext {
-    Prefix { right: i32 },
-    Between { left: i32, right: i32 },
-    Suffix { left: i32 },
+    Prefix {
+        right: i32,
+    },
+    Between {
+        left: i32,
+        right: i32,
+    },
+    Suffix {
+        left: i32,
+    },
+    PathOnly {
+        path_idx: usize,
+        start: u64,
+        end: u64,
+        strand: char,
+    },
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -200,6 +224,412 @@ struct WalkedPath {
     steps: Vec<PathStep>,
 }
 
+#[derive(Clone)]
+enum RawEndpoint {
+    Syncmer(i32),
+    Gap(usize),
+}
+
+#[derive(Clone)]
+enum RawPathStep {
+    Syncmer(i32),
+    Gap(usize),
+}
+
+struct RawGap {
+    context: GapContext,
+    seq: Vec<u8>,
+}
+
+struct PathWork {
+    name: String,
+    gaps: Vec<RawGap>,
+    steps: Vec<RawPathStep>,
+    edges: Vec<(RawEndpoint, RawEndpoint, u32)>,
+    gaps_filled_with_ns: usize,
+    gap_occurrences: usize,
+    gap_occurrence_bp: u64,
+    skipped: bool,
+}
+
+fn raw_syncmer_endpoint(signed: i32) -> RawEndpoint {
+    RawEndpoint::Syncmer(signed)
+}
+
+fn raw_gap_endpoint(idx: usize) -> RawEndpoint {
+    RawEndpoint::Gap(idx)
+}
+
+fn raw_endpoint_to_gfa(endpoint: &RawEndpoint, gap_ids: &[String]) -> (String, char) {
+    match endpoint {
+        RawEndpoint::Syncmer(signed) => {
+            let (id, sign) = signed_to_gfa(*signed);
+            (id.to_string(), sign)
+        }
+        RawEndpoint::Gap(idx) => (gap_ids[*idx].clone(), '+'),
+    }
+}
+
+fn collect_path_work(
+    index: &SyngIndex,
+    name: &str,
+    start_info: Option<&GbwtPathStart>,
+    path_len_bp: u64,
+    syncmer_len_u64: u64,
+    gap_fill: Option<&UnifiedSequenceIndex>,
+) -> io::Result<PathWork> {
+    let Some(start_info) = start_info else {
+        return Ok(PathWork {
+            name: name.to_string(),
+            gaps: Vec::new(),
+            steps: Vec::new(),
+            edges: Vec::new(),
+            gaps_filled_with_ns: 0,
+            gap_occurrences: 0,
+            gap_occurrence_bp: 0,
+            skipped: true,
+        });
+    };
+
+    let nodes = index.walk_forward_path(start_info);
+    let mut gaps: Vec<RawGap> = Vec::new();
+    let mut steps: Vec<RawPathStep> = Vec::with_capacity(nodes.len());
+    let mut edges: Vec<(RawEndpoint, RawEndpoint, u32)> = Vec::with_capacity(nodes.len() * 2);
+    let mut gaps_filled_with_ns = 0usize;
+    let mut gap_occurrences = 0usize;
+    let mut gap_occurrence_bp = 0u64;
+
+    let mut push_gap = |context: GapContext, seq: Vec<u8>, steps: &mut Vec<RawPathStep>| -> usize {
+        gap_occurrences += 1;
+        gap_occurrence_bp += seq.len() as u64;
+        let gap_idx = gaps.len();
+        gaps.push(RawGap { context, seq });
+        steps.push(RawPathStep::Gap(gap_idx));
+        gap_idx
+    };
+
+    // Prefix: bases [0, first_syncmer_pos) before the first syncmer.
+    if let Some(&(first, first_pos)) = nodes.first() {
+        if first_pos > 0 {
+            let gap_seq = if let Some(seq_idx) = gap_fill {
+                fetch_gap_dna(seq_idx, name, 0, first_pos)?
+            } else {
+                gaps_filled_with_ns += 1;
+                vec![b'N'; first_pos as usize]
+            };
+            let gap_idx = push_gap(GapContext::Prefix { right: first }, gap_seq, &mut steps);
+            edges.push((raw_gap_endpoint(gap_idx), raw_syncmer_endpoint(first), 0));
+        }
+        steps.push(RawPathStep::Syncmer(first));
+    }
+
+    for w in nodes.windows(2) {
+        let (a, pos_a) = w[0];
+        let (b, pos_b) = w[1];
+        let off_u64: u64 = pos_b.saturating_sub(pos_a);
+        if off_u64 <= syncmer_len_u64 {
+            // Direct adjacency: overlap = syncmer_len - offset.
+            let overlap = (syncmer_len_u64 - off_u64) as u32;
+            edges.push((raw_syncmer_endpoint(a), raw_syncmer_endpoint(b), overlap));
+            steps.push(RawPathStep::Syncmer(b));
+        } else {
+            // Inter-syncmer gap of (offset - syncmer_len) bp.
+            let gap_len = off_u64 - syncmer_len_u64;
+            let gap_seq = if let Some(seq_idx) = gap_fill {
+                let gap_start = pos_a + syncmer_len_u64;
+                let gap_end = pos_b;
+                fetch_gap_dna(seq_idx, name, gap_start, gap_end)?
+            } else {
+                gaps_filled_with_ns += 1;
+                vec![b'N'; gap_len as usize]
+            };
+            let gap_idx = push_gap(
+                GapContext::Between { left: a, right: b },
+                gap_seq,
+                &mut steps,
+            );
+            edges.push((raw_syncmer_endpoint(a), raw_gap_endpoint(gap_idx), 0));
+            edges.push((raw_gap_endpoint(gap_idx), raw_syncmer_endpoint(b), 0));
+            steps.push(RawPathStep::Syncmer(b));
+        }
+    }
+
+    // Suffix: bases [last_pos + syncmer_len, path_len) after the last syncmer.
+    if let Some(&(last, last_pos)) = nodes.last() {
+        let suffix_start = last_pos.saturating_add(syncmer_len_u64);
+        if path_len_bp > suffix_start {
+            let suffix_end = path_len_bp;
+            let gap_seq = if let Some(seq_idx) = gap_fill {
+                fetch_gap_dna(seq_idx, name, suffix_start, suffix_end)?
+            } else {
+                gaps_filled_with_ns += 1;
+                vec![b'N'; (suffix_end - suffix_start) as usize]
+            };
+            let gap_idx = push_gap(GapContext::Suffix { left: last }, gap_seq, &mut steps);
+            edges.push((raw_syncmer_endpoint(last), raw_gap_endpoint(gap_idx), 0));
+        }
+    }
+
+    Ok(PathWork {
+        name: name.to_string(),
+        gaps,
+        steps,
+        edges,
+        gaps_filled_with_ns,
+        gap_occurrences,
+        gap_occurrence_bp,
+        skipped: false,
+    })
+}
+
+fn fetch_oriented_gap_dna(
+    gap_fill: Option<&UnifiedSequenceIndex>,
+    seq_name: &str,
+    gap_start: u64,
+    gap_end: u64,
+    reverse: bool,
+) -> io::Result<Vec<u8>> {
+    let mut seq = if let Some(seq_idx) = gap_fill {
+        fetch_gap_dna(seq_idx, seq_name, gap_start, gap_end)?
+    } else {
+        vec![b'N'; gap_end.saturating_sub(gap_start) as usize]
+    };
+    if reverse {
+        seq = crate::graph::reverse_complement(&seq);
+    }
+    Ok(seq)
+}
+
+fn collect_range_work(
+    index: &SyngIndex,
+    range: &SyngGfaPathRange,
+    syncmer_len_u64: u64,
+    gap_fill: Option<&UnifiedSequenceIndex>,
+) -> io::Result<PathWork> {
+    let source_name = index
+        .name_map
+        .path_to_name
+        .get(range.path_idx)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("path index {} is outside the syng name map", range.path_idx),
+            )
+        })?;
+    let reverse = range.strand == '-';
+    let fwd_nodes = index.walk_path_range(range.path_idx, range.start, range.end)?;
+    let oriented_nodes: Vec<(i32, u64)> = if reverse {
+        fwd_nodes
+            .iter()
+            .rev()
+            .map(|(node, pos)| (-*node, *pos))
+            .collect()
+    } else {
+        fwd_nodes
+    };
+
+    let mut gaps: Vec<RawGap> = Vec::new();
+    let mut steps: Vec<RawPathStep> = Vec::with_capacity(oriented_nodes.len());
+    let mut edges: Vec<(RawEndpoint, RawEndpoint, u32)> =
+        Vec::with_capacity(oriented_nodes.len() * 2);
+    let mut gap_occurrences = 0usize;
+    let mut gap_occurrence_bp = 0u64;
+    let mut gaps_filled_with_ns = 0usize;
+
+    let mut push_gap = |context: GapContext, seq: Vec<u8>, steps: &mut Vec<RawPathStep>| -> usize {
+        gap_occurrences += 1;
+        gap_occurrence_bp += seq.len() as u64;
+        if gap_fill.is_none() {
+            gaps_filled_with_ns += 1;
+        }
+        let gap_idx = gaps.len();
+        gaps.push(RawGap { context, seq });
+        steps.push(RawPathStep::Gap(gap_idx));
+        gap_idx
+    };
+
+    if oriented_nodes.is_empty() {
+        if range.end > range.start {
+            let seq =
+                fetch_oriented_gap_dna(gap_fill, source_name, range.start, range.end, reverse)?;
+            push_gap(
+                GapContext::PathOnly {
+                    path_idx: range.path_idx,
+                    start: range.start,
+                    end: range.end,
+                    strand: range.strand,
+                },
+                seq,
+                &mut steps,
+            );
+        }
+        return Ok(PathWork {
+            name: range.name.clone(),
+            gaps,
+            steps,
+            edges,
+            gaps_filled_with_ns,
+            gap_occurrences,
+            gap_occurrence_bp,
+            skipped: false,
+        });
+    }
+
+    if !reverse {
+        if let Some(&(first, first_pos)) = oriented_nodes.first() {
+            if first_pos > range.start {
+                let gap_seq =
+                    fetch_oriented_gap_dna(gap_fill, source_name, range.start, first_pos, false)?;
+                let gap_idx = push_gap(GapContext::Prefix { right: first }, gap_seq, &mut steps);
+                edges.push((raw_gap_endpoint(gap_idx), raw_syncmer_endpoint(first), 0));
+            }
+            steps.push(RawPathStep::Syncmer(first));
+        }
+
+        for w in oriented_nodes.windows(2) {
+            let (a, pos_a) = w[0];
+            let (b, pos_b) = w[1];
+            let off_u64 = pos_b.saturating_sub(pos_a);
+            if off_u64 <= syncmer_len_u64 {
+                edges.push((
+                    raw_syncmer_endpoint(a),
+                    raw_syncmer_endpoint(b),
+                    (syncmer_len_u64 - off_u64) as u32,
+                ));
+                steps.push(RawPathStep::Syncmer(b));
+            } else {
+                let gap_seq = fetch_oriented_gap_dna(
+                    gap_fill,
+                    source_name,
+                    pos_a + syncmer_len_u64,
+                    pos_b,
+                    false,
+                )?;
+                let gap_idx = push_gap(
+                    GapContext::Between { left: a, right: b },
+                    gap_seq,
+                    &mut steps,
+                );
+                edges.push((raw_syncmer_endpoint(a), raw_gap_endpoint(gap_idx), 0));
+                edges.push((raw_gap_endpoint(gap_idx), raw_syncmer_endpoint(b), 0));
+                steps.push(RawPathStep::Syncmer(b));
+            }
+        }
+
+        if let Some(&(last, last_pos)) = oriented_nodes.last() {
+            let suffix_start = last_pos.saturating_add(syncmer_len_u64);
+            if range.end > suffix_start {
+                let gap_seq =
+                    fetch_oriented_gap_dna(gap_fill, source_name, suffix_start, range.end, false)?;
+                let gap_idx = push_gap(GapContext::Suffix { left: last }, gap_seq, &mut steps);
+                edges.push((raw_syncmer_endpoint(last), raw_gap_endpoint(gap_idx), 0));
+            }
+        }
+    } else {
+        if let Some(&(first_oriented, last_fwd_pos)) = oriented_nodes.first() {
+            let prefix_fwd_start = last_fwd_pos.saturating_add(syncmer_len_u64);
+            if range.end > prefix_fwd_start {
+                let gap_seq = fetch_oriented_gap_dna(
+                    gap_fill,
+                    source_name,
+                    prefix_fwd_start,
+                    range.end,
+                    true,
+                )?;
+                let gap_idx = push_gap(
+                    GapContext::Prefix {
+                        right: first_oriented,
+                    },
+                    gap_seq,
+                    &mut steps,
+                );
+                edges.push((
+                    raw_gap_endpoint(gap_idx),
+                    raw_syncmer_endpoint(first_oriented),
+                    0,
+                ));
+            }
+            steps.push(RawPathStep::Syncmer(first_oriented));
+        }
+
+        for w in oriented_nodes.windows(2) {
+            let (a_oriented, a_fwd_pos) = w[0];
+            let (b_oriented, b_fwd_pos) = w[1];
+            let off_u64 = a_fwd_pos.saturating_sub(b_fwd_pos);
+            if off_u64 <= syncmer_len_u64 {
+                edges.push((
+                    raw_syncmer_endpoint(a_oriented),
+                    raw_syncmer_endpoint(b_oriented),
+                    (syncmer_len_u64 - off_u64) as u32,
+                ));
+                steps.push(RawPathStep::Syncmer(b_oriented));
+            } else {
+                let gap_seq = fetch_oriented_gap_dna(
+                    gap_fill,
+                    source_name,
+                    b_fwd_pos + syncmer_len_u64,
+                    a_fwd_pos,
+                    true,
+                )?;
+                let gap_idx = push_gap(
+                    GapContext::Between {
+                        left: a_oriented,
+                        right: b_oriented,
+                    },
+                    gap_seq,
+                    &mut steps,
+                );
+                edges.push((
+                    raw_syncmer_endpoint(a_oriented),
+                    raw_gap_endpoint(gap_idx),
+                    0,
+                ));
+                edges.push((
+                    raw_gap_endpoint(gap_idx),
+                    raw_syncmer_endpoint(b_oriented),
+                    0,
+                ));
+                steps.push(RawPathStep::Syncmer(b_oriented));
+            }
+        }
+
+        if let Some(&(last_oriented, first_fwd_pos)) = oriented_nodes.last() {
+            if first_fwd_pos > range.start {
+                let gap_seq = fetch_oriented_gap_dna(
+                    gap_fill,
+                    source_name,
+                    range.start,
+                    first_fwd_pos,
+                    true,
+                )?;
+                let gap_idx = push_gap(
+                    GapContext::Suffix {
+                        left: last_oriented,
+                    },
+                    gap_seq,
+                    &mut steps,
+                );
+                edges.push((
+                    raw_syncmer_endpoint(last_oriented),
+                    raw_gap_endpoint(gap_idx),
+                    0,
+                ));
+            }
+        }
+    }
+
+    Ok(PathWork {
+        name: range.name.clone(),
+        gaps,
+        steps,
+        edges,
+        gaps_filled_with_ns,
+        gap_occurrences,
+        gap_occurrence_bp,
+        skipped: false,
+    })
+}
+
 /// Walk every forward path in `index`, gap-fill via FASTA/AGC if given,
 /// and write a GFA to `writer`.
 ///
@@ -247,106 +677,86 @@ pub fn write_gfa<W: Write>(
     let mut gap_occurrence_bp: u64 = 0;
 
     let syncmer_len_u64 = syncmer_len as u64;
+    let collect_start = Instant::now();
+    let path_work: Vec<PathWork> = (0..index.name_map.path_to_name.len())
+        .into_par_iter()
+        .map(|path_idx| {
+            let name = &index.name_map.path_to_name[path_idx];
+            let start_info = index
+                .name_map
+                .path_starts
+                .get(path_idx)
+                .and_then(|o| o.as_ref());
+            let path_len_bp = index
+                .name_map
+                .path_to_length
+                .get(path_idx)
+                .copied()
+                .unwrap_or(0);
+            collect_path_work(
+                index,
+                name,
+                start_info,
+                path_len_bp,
+                syncmer_len_u64,
+                gap_fill,
+            )
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    info!(
+        "[syng2gfa] collected {} path walks in {:.3}s using {} rayon threads",
+        path_work.len(),
+        collect_start.elapsed().as_secs_f64(),
+        rayon::current_num_threads()
+    );
 
-    for (path_idx, name) in index.name_map.path_to_name.iter().enumerate() {
-        let Some(start_info): Option<&GbwtPathStart> = index
-            .name_map
-            .path_starts
-            .get(path_idx)
-            .and_then(|o| o.as_ref())
-        else {
+    let reduce_start = Instant::now();
+    for work in path_work {
+        if work.skipped {
             warn!(
                 "[syng2gfa] path '{}' has no GBWT start info — skipping (rebuild the syng index to include path starts)",
-                name
+                work.name
             );
             n_skipped += 1;
             continue;
-        };
-        let nodes = index.walk_forward_path(start_info);
-        let path_len_bp = index
-            .name_map
-            .path_to_length
-            .get(path_idx)
-            .copied()
-            .unwrap_or(0);
-        let mut steps: Vec<PathStep> = Vec::with_capacity(nodes.len());
-
-        // Prefix: bases [0, first_syncmer_pos) before the first syncmer.
-        if let Some(&(first, first_pos)) = nodes.first() {
-            if first_pos > 0 {
-                let gap_seq = if let Some(seq_idx) = gap_fill {
-                    fetch_gap_dna(seq_idx, name, 0, first_pos)?
-                } else {
-                    gaps_filled_with_ns += 1;
-                    vec![b'N'; first_pos as usize]
-                };
-                gap_occurrences += 1;
-                gap_occurrence_bp += gap_seq.len() as u64;
-                let gap_id = gap_interner.intern(GapContext::Prefix { right: first }, gap_seq);
-                let (first_id, first_sign) = signed_to_gfa(first);
-                edges.insert((gap_id.clone(), '+', first_id.to_string(), first_sign, 0));
-                steps.push(PathStep::Gap(gap_id.clone()));
-            }
-            steps.push(PathStep::Syncmer(first));
         }
 
-        for w in nodes.windows(2) {
-            let (a, pos_a) = w[0];
-            let (b, pos_b) = w[1];
-            let off_u64: u64 = pos_b.saturating_sub(pos_a);
-            let (a_id, a_sign) = signed_to_gfa(a);
-            let (b_id, b_sign) = signed_to_gfa(b);
-            if off_u64 <= syncmer_len_u64 {
-                // Direct adjacency: overlap = syncmer_len - offset.
-                let overlap = (syncmer_len_u64 - off_u64) as u32;
-                edges.insert((a_id.to_string(), a_sign, b_id.to_string(), b_sign, overlap));
-                steps.push(PathStep::Syncmer(b));
-            } else {
-                // Inter-syncmer gap of (offset - syncmer_len) bp.
-                let gap_len = off_u64 - syncmer_len_u64;
-                let gap_seq = if let Some(seq_idx) = gap_fill {
-                    let gap_start = pos_a + syncmer_len_u64;
-                    let gap_end = pos_b;
-                    fetch_gap_dna(seq_idx, name, gap_start, gap_end)?
-                } else {
-                    gaps_filled_with_ns += 1;
-                    vec![b'N'; gap_len as usize]
-                };
-                gap_occurrences += 1;
-                gap_occurrence_bp += gap_seq.len() as u64;
-                let gap_id =
-                    gap_interner.intern(GapContext::Between { left: a, right: b }, gap_seq);
-                edges.insert((a_id.to_string(), a_sign, gap_id.clone(), '+', 0));
-                edges.insert((gap_id.clone(), '+', b_id.to_string(), b_sign, 0));
-                steps.push(PathStep::Gap(gap_id.clone()));
-                steps.push(PathStep::Syncmer(b));
-            }
+        gaps_filled_with_ns += work.gaps_filled_with_ns;
+        gap_occurrences += work.gap_occurrences;
+        gap_occurrence_bp += work.gap_occurrence_bp;
+
+        let gap_ids: Vec<String> = work
+            .gaps
+            .into_iter()
+            .map(|gap| gap_interner.intern(gap.context, gap.seq))
+            .collect();
+
+        for (from, to, overlap) in work.edges {
+            let (from_id, from_sign) = raw_endpoint_to_gfa(&from, &gap_ids);
+            let (to_id, to_sign) = raw_endpoint_to_gfa(&to, &gap_ids);
+            edges.insert((from_id, from_sign, to_id, to_sign, overlap));
         }
-        // Suffix: bases [last_pos + syncmer_len, path_len) after the last syncmer.
-        if let Some(&(last, last_pos)) = nodes.last() {
-            let suffix_start = last_pos.saturating_add(syncmer_len_u64);
-            if path_len_bp > suffix_start {
-                let suffix_end = path_len_bp;
-                let gap_seq = if let Some(seq_idx) = gap_fill {
-                    fetch_gap_dna(seq_idx, name, suffix_start, suffix_end)?
-                } else {
-                    gaps_filled_with_ns += 1;
-                    vec![b'N'; (suffix_end - suffix_start) as usize]
-                };
-                gap_occurrences += 1;
-                gap_occurrence_bp += gap_seq.len() as u64;
-                let gap_id = gap_interner.intern(GapContext::Suffix { left: last }, gap_seq);
-                let (last_id, last_sign) = signed_to_gfa(last);
-                edges.insert((last_id.to_string(), last_sign, gap_id.clone(), '+', 0));
-                steps.push(PathStep::Gap(gap_id.clone()));
-            }
-        }
+
+        let steps = work
+            .steps
+            .into_iter()
+            .map(|step| match step {
+                RawPathStep::Syncmer(signed) => PathStep::Syncmer(signed),
+                RawPathStep::Gap(idx) => PathStep::Gap(gap_ids[idx].clone()),
+            })
+            .collect();
 
         walked_paths.push(WalkedPath {
-            name: name.clone(),
+            name: work.name,
             steps,
         });
     }
+    info!(
+        "[syng2gfa] reduced path walks into {} unique gap segment(s) and {} edge(s) in {:.3}s",
+        gap_interner.len(),
+        edges.len(),
+        reduce_start.elapsed().as_secs_f64()
+    );
 
     if gaps_filled_with_ns > 0 {
         warn!(
@@ -370,6 +780,7 @@ pub fn write_gfa<W: Write>(
     // S lines: syncmer nodes 1..=N first, then gap segments in walk order.
     // Syncmer DNA from the C lib is lowercase; uppercase for consistency with
     // FASTA-fetched gap sequences (already uppercased upstream).
+    let write_start = Instant::now();
     for node_id in 1..=n_nodes as i32 {
         let mut seq = index.syncmer_seq(node_id);
         seq.make_ascii_uppercase();
@@ -410,6 +821,14 @@ pub fn write_gfa<W: Write>(
         }
     }
 
+    info!(
+        "[syng2gfa] wrote {} S, {} L, {} path line(s) in {:.3}s",
+        n_segments,
+        n_links,
+        n_paths_emitted,
+        write_start.elapsed().as_secs_f64()
+    );
+
     Ok((
         n_segments,
         n_links,
@@ -443,6 +862,211 @@ pub fn write_gfa_with_mode<W: Write>(
             Ok(stats)
         }
     }
+}
+
+pub fn write_range_gfa_with_mode<W: Write>(
+    index: &SyngIndex,
+    ranges: &[SyngGfaPathRange],
+    writer: &mut W,
+    version: GfaVersion,
+    gap_fill: Option<&UnifiedSequenceIndex>,
+    mode: SyngGfaMode,
+) -> io::Result<(usize, usize, usize, usize, usize, u64)> {
+    match mode {
+        SyngGfaMode::Raw => write_range_gfa(index, ranges, writer, version, gap_fill),
+        SyngGfaMode::Blunt => {
+            let mut raw = Vec::new();
+            let stats = write_range_gfa(index, ranges, &mut raw, version, gap_fill)?;
+            let blunt_start = Instant::now();
+            let blunted = bluntify_gfa_bytes(&raw, version)?;
+            info!(
+                "[syng2gfa] bluntg processed {} raw range-GFA bytes into {} blunt GFA bytes in {:.3}s",
+                raw.len(),
+                blunted.len(),
+                blunt_start.elapsed().as_secs_f64()
+            );
+            writer.write_all(&blunted)?;
+            Ok(stats)
+        }
+    }
+}
+
+pub fn write_range_gfa<W: Write>(
+    index: &SyngIndex,
+    ranges: &[SyngGfaPathRange],
+    writer: &mut W,
+    version: GfaVersion,
+    gap_fill: Option<&UnifiedSequenceIndex>,
+) -> io::Result<(usize, usize, usize, usize, usize, u64)> {
+    let syncmer_len = index.syncmer_length_bp();
+    info!(
+        "[syng2gfa] rendering {} selected path range(s), GFA {}, gap fill: {}",
+        ranges.len(),
+        version.header_tag(),
+        if gap_fill.is_some() {
+            "FASTA/AGC"
+        } else {
+            "Ns"
+        }
+    );
+
+    unsafe { syng_ffi::impg_syng_suppress_debug() };
+    writeln!(writer, "H\tVN:Z:{}", version.header_tag())?;
+
+    let syncmer_len_u64 = syncmer_len as u64;
+    let collect_start = Instant::now();
+    let path_work: Vec<PathWork> = ranges
+        .par_iter()
+        .map(|range| collect_range_work(index, range, syncmer_len_u64, gap_fill))
+        .collect::<io::Result<Vec<_>>>()?;
+    info!(
+        "[syng2gfa] collected {} selected path walks in {:.3}s using {} rayon threads",
+        path_work.len(),
+        collect_start.elapsed().as_secs_f64(),
+        rayon::current_num_threads()
+    );
+
+    let reduce_start = Instant::now();
+    let mut walked_paths: Vec<WalkedPath> = Vec::with_capacity(path_work.len());
+    let mut edges: FxHashSet<(String, char, String, char, u32)> = FxHashSet::default();
+    let mut gap_interner = GapInterner::new(index.num_syncmer_nodes());
+    let mut used_syncmers: FxHashSet<i32> = FxHashSet::default();
+    let mut n_skipped = 0usize;
+    let mut gaps_filled_with_ns = 0usize;
+    let mut gap_occurrences = 0usize;
+    let mut gap_occurrence_bp = 0u64;
+
+    for work in path_work {
+        if work.skipped {
+            warn!(
+                "[syng2gfa] path '{}' has no GBWT start info — skipping",
+                work.name
+            );
+            n_skipped += 1;
+            continue;
+        }
+
+        gaps_filled_with_ns += work.gaps_filled_with_ns;
+        gap_occurrences += work.gap_occurrences;
+        gap_occurrence_bp += work.gap_occurrence_bp;
+
+        let gap_ids: Vec<String> = work
+            .gaps
+            .into_iter()
+            .map(|gap| gap_interner.intern(gap.context, gap.seq))
+            .collect();
+
+        for (from, to, overlap) in work.edges {
+            if let RawEndpoint::Syncmer(node) = &from {
+                used_syncmers.insert(node.abs());
+            }
+            if let RawEndpoint::Syncmer(node) = &to {
+                used_syncmers.insert(node.abs());
+            }
+            let (from_id, from_sign) = raw_endpoint_to_gfa(&from, &gap_ids);
+            let (to_id, to_sign) = raw_endpoint_to_gfa(&to, &gap_ids);
+            edges.insert((from_id, from_sign, to_id, to_sign, overlap));
+        }
+
+        let steps = work
+            .steps
+            .into_iter()
+            .map(|step| match step {
+                RawPathStep::Syncmer(signed) => {
+                    used_syncmers.insert(signed.abs());
+                    PathStep::Syncmer(signed)
+                }
+                RawPathStep::Gap(idx) => PathStep::Gap(gap_ids[idx].clone()),
+            })
+            .collect();
+
+        walked_paths.push(WalkedPath {
+            name: work.name,
+            steps,
+        });
+    }
+    info!(
+        "[syng2gfa] reduced selected path walks into {} syncmer node(s), {} unique gap segment(s), {} edge(s) in {:.3}s",
+        used_syncmers.len(),
+        gap_interner.len(),
+        edges.len(),
+        reduce_start.elapsed().as_secs_f64()
+    );
+
+    if gaps_filled_with_ns > 0 {
+        warn!(
+            "[syng2gfa] filled {} gap occurrence(s) with 'N' ({} bp over paths; {} unique segment bp). \
+                 Concatenating these paths will NOT reconstruct the original genome. \
+                 Pass --sequence-files <FASTA> to splice in real DNA.",
+            gaps_filled_with_ns,
+            gap_occurrence_bp,
+            gap_interner.total_segment_bp()
+        );
+    } else if !gap_interner.is_empty() {
+        info!(
+            "[syng2gfa] spliced {} unique real-DNA gap segment(s) from {} gap occurrence(s), {} unique bp ({} bp over paths)",
+            gap_interner.len(),
+            gap_occurrences,
+            gap_interner.total_segment_bp(),
+            gap_occurrence_bp
+        );
+    }
+
+    let write_start = Instant::now();
+    let mut used_nodes: Vec<i32> = used_syncmers.into_iter().collect();
+    used_nodes.sort_unstable();
+    let n_syncmer_segments = used_nodes.len();
+    for node_id in used_nodes {
+        let mut seq = index.syncmer_seq(node_id);
+        seq.make_ascii_uppercase();
+        write_segment(writer, &node_id.to_string(), &seq)?;
+    }
+    for gap in &gap_interner.segments {
+        write_segment(writer, &gap.id, &gap.seq)?;
+    }
+    let n_segments = n_syncmer_segments + gap_interner.len();
+    let n_gap_segments = gap_interner.len();
+
+    let mut edge_vec: Vec<(String, char, String, char, u32)> = edges.into_iter().collect();
+    edge_vec.sort_unstable();
+    for (a_id, a_sign, b_id, b_sign, overlap) in &edge_vec {
+        writeln!(writer, "L\t{a_id}\t{a_sign}\t{b_id}\t{b_sign}\t{overlap}M")?;
+    }
+    let n_links = edge_vec.len();
+
+    let n_paths_emitted = walked_paths.len();
+    for walked in &walked_paths {
+        match version {
+            GfaVersion::V1_0 => write_p_line(writer, &walked.name, &walked.steps)?,
+            GfaVersion::V1_1 => {
+                if let Some(parts) = parse_pansn(&walked.name) {
+                    write_w_line(writer, &parts, &walked.steps)?;
+                } else {
+                    warn!(
+                        "[syng2gfa] path '{}' is not PanSN-style; falling back to P line under GFA 1.1",
+                        walked.name
+                    );
+                    write_p_line(writer, &walked.name, &walked.steps)?;
+                }
+            }
+        }
+    }
+    info!(
+        "[syng2gfa] wrote selected range GFA: {} S, {} L, {} path line(s) in {:.3}s",
+        n_segments,
+        n_links,
+        n_paths_emitted,
+        write_start.elapsed().as_secs_f64()
+    );
+
+    Ok((
+        n_segments,
+        n_links,
+        n_paths_emitted,
+        n_skipped,
+        n_gap_segments,
+        gap_interner.total_segment_bp(),
+    ))
 }
 
 fn bluntify_gfa_bytes(raw: &[u8], version: GfaVersion) -> io::Result<Vec<u8>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,15 @@ pub fn write_syng_region_gfa_from_sequences<W: std::io::Write>(
         return Ok(());
     }
 
+    let total_start = std::time::Instant::now();
+    let total_bp: usize = sequences.iter().map(|(_, seq)| seq.len()).sum();
+    log::info!(
+        "[syng region gfa] rendering {} sequence(s), {} bp, mode={}",
+        sequences.len(),
+        total_bp,
+        mode.label()
+    );
+
     let tempdir = tempfile::Builder::new()
         .prefix("impg-syng-gfa-")
         .tempdir()?;
@@ -477,14 +486,35 @@ pub fn write_syng_region_gfa_from_sequences<W: std::io::Write>(
         .iter()
         .map(|(name, seq)| (name.clone(), seq.as_slice()))
         .collect();
+    let build_start = std::time::Instant::now();
     source_index.build_region_gbwt(&seq_refs, region_prefix)?;
+    log::info!(
+        "[syng region gfa] built regional syng GBWT in {:.3}s",
+        build_start.elapsed().as_secs_f64()
+    );
 
     let fasta_path = tempdir.path().join("region.fa");
+    let fasta_start = std::time::Instant::now();
     write_fasta_records(&fasta_path, sequences)?;
+    log::info!(
+        "[syng region gfa] wrote temporary FASTA in {:.3}s",
+        fasta_start.elapsed().as_secs_f64()
+    );
     let sequence_files = vec![fasta_path.to_string_lossy().to_string()];
+    let seqidx_start = std::time::Instant::now();
     let sequence_index = sequence_index::UnifiedSequenceIndex::from_files(&sequence_files)?;
+    log::info!(
+        "[syng region gfa] built temporary sequence index in {:.3}s",
+        seqidx_start.elapsed().as_secs_f64()
+    );
+    let load_start = std::time::Instant::now();
     let region_index = syng::SyngIndex::load(region_prefix, source_index.params)?;
+    log::info!(
+        "[syng region gfa] loaded regional syng index in {:.3}s",
+        load_start.elapsed().as_secs_f64()
+    );
 
+    let write_start = std::time::Instant::now();
     commands::syng2gfa::write_gfa_with_mode(
         &region_index,
         out,
@@ -492,6 +522,11 @@ pub fn write_syng_region_gfa_from_sequences<W: std::io::Write>(
         Some(&sequence_index),
         mode,
     )?;
+    log::info!(
+        "[syng region gfa] wrote regional GFA in {:.3}s; total {:.3}s",
+        write_start.elapsed().as_secs_f64(),
+        total_start.elapsed().as_secs_f64()
+    );
     Ok(())
 }
 
@@ -502,13 +537,63 @@ fn build_syng_region_gfa_from_intervals(
     sequence_index: &sequence_index::UnifiedSequenceIndex,
     mode: commands::syng2gfa::SyngGfaMode,
 ) -> std::io::Result<String> {
-    let sequences = graph::prepare_sequences(impg, query_intervals, sequence_index)?;
-    let fetched: Vec<(String, Vec<u8>)> = sequences
-        .into_iter()
-        .map(|(seq, meta)| (meta.path_name(), seq.into_bytes()))
-        .collect();
+    let range_start = std::time::Instant::now();
+    let ranges: Vec<commands::syng2gfa::SyngGfaPathRange> = query_intervals
+        .iter()
+        .map(|interval| {
+            let seq_name = impg
+                .seq_index()
+                .get_name(interval.metadata)
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("Sequence name not found for ID {}", interval.metadata),
+                    )
+                })?;
+            let path_idx = syng_idx
+                .name_map
+                .name_to_path
+                .get(seq_name)
+                .copied()
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("Sequence '{seq_name}' not found in syng name map"),
+                    )
+                })? as usize;
+            let (start, end, strand) = if interval.first <= interval.last {
+                (interval.first as u64, interval.last as u64, '+')
+            } else {
+                (interval.last as u64, interval.first as u64, '-')
+            };
+            Ok(commands::syng2gfa::SyngGfaPathRange {
+                path_idx,
+                name: format!("{seq_name}:{start}-{end}"),
+                start,
+                end,
+                strand,
+            })
+        })
+        .collect::<std::io::Result<Vec<_>>>()?;
+    log::info!(
+        "[syng region gfa] prepared {} direct syng path range(s) in {:.3}s",
+        ranges.len(),
+        range_start.elapsed().as_secs_f64()
+    );
     let mut out = Vec::new();
-    write_syng_region_gfa_from_sequences(syng_idx, &fetched, &mut out, mode)?;
+    let write_start = std::time::Instant::now();
+    commands::syng2gfa::write_range_gfa_with_mode(
+        syng_idx,
+        &ranges,
+        &mut out,
+        commands::syng2gfa::GfaVersion::V1_0,
+        Some(sequence_index),
+        mode,
+    )?;
+    log::info!(
+        "[syng region gfa] wrote direct syng range GFA in {:.3}s",
+        write_start.elapsed().as_secs_f64()
+    );
     String::from_utf8(out).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,11 +278,16 @@ impl SyngImpgWrapper {
             syncmer_len,
         );
         let query_range_len = (range_end - range_start).max(0) as u64;
+        let effective_min = syng_transitive::effective_min_chain_anchors(
+            query_range_len,
+            syncmer_len,
+            min_anchors,
+        );
         let min_extent_bp = (query_range_len as f64 * min_fraction.max(0.0)) as u64;
         chained
             .into_iter()
             .filter(|c| {
-                if c.anchors.len() < min_anchors {
+                if c.anchors.len() < effective_min {
                     return false;
                 }
                 if min_extent_bp == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4874,10 +4874,15 @@ fn run() -> io::Result<()> {
                                         syng_extension,
                                     )?
                                 };
-                                let query_intervals: Vec<coitrees::Interval<u32>> = intervals
-                                    .iter()
-                                    .filter_map(|iv| syng_interval_to_coitree(iv, wrapper.seq_index()))
-                                    .collect();
+                                let query_intervals = syng_intervals_to_merged_query_intervals(
+                                    &intervals,
+                                    target_name,
+                                    *range_start,
+                                    *range_end,
+                                    wrapper.seq_index(),
+                                    query.effective_merge_distance(),
+                                    query.merge_strands_for_output(resolved_format),
+                                );
 
                                 if query_intervals.is_empty() {
                                     let mut out = find_output_stream(&output_prefix, output_ext)?;
@@ -4941,10 +4946,15 @@ fn run() -> io::Result<()> {
                                     } else {
                                         query_raw_syng(target_name, window_start, window_end, syng_padding, syng_extension)?
                                     };
-                                    let window_intervals: Vec<Interval<u32>> = intervals
-                                        .iter()
-                                        .filter_map(|iv| syng_interval_to_coitree(iv, wrapper.seq_index()))
-                                        .collect();
+                                    let window_intervals = syng_intervals_to_merged_query_intervals(
+                                        &intervals,
+                                        target_name,
+                                        window_start,
+                                        window_end,
+                                        wrapper.seq_index(),
+                                        query.effective_merge_distance(),
+                                        query.merge_strands_for_output(resolved_format),
+                                    );
                                     info!(
                                         "  [syng sub-window {}] {}:{}-{} → {} intervals",
                                         window_idx, target_name, window_start, window_end,
@@ -5003,10 +5013,15 @@ fn run() -> io::Result<()> {
                                 } else {
                                     query_raw_syng(target_name, *range_start, *range_end, syng_padding, syng_extension)?
                                 };
-                                let query_intervals: Vec<coitrees::Interval<u32>> = intervals
-                                    .iter()
-                                    .filter_map(|iv| syng_interval_to_coitree(iv, wrapper.seq_index()))
-                                    .collect();
+                                let query_intervals = syng_intervals_to_merged_query_intervals(
+                                    &intervals,
+                                    target_name,
+                                    *range_start,
+                                    *range_end,
+                                    wrapper.seq_index(),
+                                    query.effective_merge_distance(),
+                                    query.merge_strands_for_output(resolved_format),
+                                );
 
                                 if query_intervals.is_empty() {
                                     let mut out = find_output_stream(&output_prefix, output_ext)?;
@@ -8664,12 +8679,22 @@ fn syng_intervals_to_adjusted(
         .collect()
 }
 
-fn syng_interval_to_coitree(
-    iv: &impg::syng::HomologousInterval,
+fn syng_intervals_to_merged_query_intervals(
+    intervals: &[impg::syng::HomologousInterval],
+    query_name: &str,
+    range_start: i32,
+    range_end: i32,
     seq_index: &SequenceIndex,
-) -> Option<Interval<u32>> {
-    let id = seq_index.get_id(&iv.genome)?;
-    Some(Interval::new(iv.start as i32, iv.end as i32, id))
+    merge_distance: i32,
+    merge_strands: bool,
+) -> Vec<Interval<u32>> {
+    let mut adjusted =
+        syng_intervals_to_adjusted(intervals, query_name, range_start, range_end, seq_index);
+    merge_query_adjusted_intervals(&mut adjusted, merge_distance, merge_strands);
+    adjusted
+        .into_iter()
+        .map(|(query_interval, _, _)| query_interval)
+        .collect()
 }
 
 fn output_results_bed(
@@ -10139,6 +10164,53 @@ mod tests {
         let opts = minimal_query_opts(None, true);
         opts.validate_merge_distance("query").unwrap();
         assert_eq!(opts.effective_merge_distance(), -1);
+    }
+
+    #[test]
+    fn test_syng_gfa_intervals_are_merged_before_graph_build() {
+        let mut seq_index = SequenceIndex::new();
+        seq_index.get_or_insert_id("GRCh38#0#chr1", Some(1_000));
+        seq_index.get_or_insert_id("sample#1#ctg", Some(1_000));
+        let intervals = vec![
+            impg::syng::HomologousInterval {
+                genome: "sample#1#ctg".to_string(),
+                start: 10,
+                end: 100,
+                strand: '+',
+                cigar: None,
+            },
+            impg::syng::HomologousInterval {
+                genome: "sample#1#ctg".to_string(),
+                start: 150,
+                end: 220,
+                strand: '+',
+                cigar: None,
+            },
+        ];
+
+        let merged = syng_intervals_to_merged_query_intervals(
+            &intervals,
+            "GRCh38#0#chr1",
+            0,
+            300,
+            &seq_index,
+            100,
+            true,
+        );
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].first, 10);
+        assert_eq!(merged[0].last, 220);
+
+        let unmerged = syng_intervals_to_merged_query_intervals(
+            &intervals,
+            "GRCh38#0#chr1",
+            0,
+            300,
+            &seq_index,
+            10,
+            true,
+        );
+        assert_eq!(unmerged.len(), 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3915,7 +3915,7 @@ GFA engine shorthand:
             alias = "iterations",
             alias = "max-rounds",
             value_parser = parse_usize_size,
-            default_value = "64"
+            default_value = "1"
         )]
         max_iterations: usize,
 
@@ -10620,6 +10620,7 @@ mod tests {
                 assert_eq!(crush.max_median_traversal_len, 1_000);
                 assert_eq!(crush.max_traversal_len, 10_000);
                 assert_eq!(crush.max_traversals, 10_000);
+                assert_eq!(crush.max_iterations, 1);
             }
             _ => panic!("expected query command"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3502,12 +3502,11 @@ GFA engine shorthand:
 
         /// Minimum anchor count for a syng chain to be emitted. Chains
         /// with fewer anchors than this are dropped at emission. Default
-        /// 2 filters singletons (one-anchor chains with no colinear
-        /// mutual-best partner — weakest possible evidence, mostly
-        /// noise in repeat-dense regions). Set to 1 to keep singletons
-        /// (useful when you want every syncmer match reported).
+        /// 20 requires support from multiple bounded GBWT-walk seed islands;
+        /// lower this for exploratory local-chain discovery or very sparse
+        /// indexes.
         #[arg(help_heading = "Syng input")]
-        #[clap(long, value_parser, default_value_t = 2)]
+        #[clap(long, value_parser, default_value_t = impg::syng_transitive::DEFAULT_MIN_CHAIN_ANCHORS)]
         syng_min_chain_anchors: usize,
 
         /// Minimum chain query-extent as a fraction of the queried

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use rustc_hash::FxHashMap;
 use std::collections::{hash_map::DefaultHasher, BTreeMap};
-use std::fs::File;
+use std::fs::{self, File};
 use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::num::NonZeroUsize;
@@ -3446,6 +3446,9 @@ Output formats:
   fasta-aln  FASTA alignment output from the local POA/MAF path
   gbwt       region-specific syng GBWT/khash output; requires -O and sequence files
 
+For BED graph output (`-b regions.bed -o gfa|vcf|gbwt`), `-O` is an output
+directory and each BED row is written to its own file named from BED column 4.
+
 Syng notes:
   With -a/--alignment pointing to a syng index, supported query outputs are
   bed, bedpe, gfa, vcf, fasta, and gbwt. Use -o gfa for a local sequence GFA from
@@ -4742,6 +4745,15 @@ fn run() -> io::Result<()> {
                         "Output prefix (-O) is required for 'gbwt' output format",
                     ));
                 }
+                let bed_graph_dir =
+                    bed_graph_output_dir(&output_prefix, resolved_format, &query.target_bed)?;
+                if let Some(dir) = &bed_graph_dir {
+                    info!(
+                        "BED graph output: writing one {} per BED row under {} using BED column 4 names",
+                        resolved_format,
+                        dir.display()
+                    );
+                }
 
                 let scoring_params = if matches!(resolved_format, "gfa" | "vcf") {
                     Some(parse_poa_scoring_string(&engine_cli.poa_scoring)?)
@@ -4774,6 +4786,9 @@ fn run() -> io::Result<()> {
                 // an outer par_iter over tiles oversubscribes and
                 // actually slowed things down in measurement.
                 for (target_name, (range_start, range_end), name) in &target_ranges {
+                    let target_query_start = Instant::now();
+                    let target_output_prefix =
+                        output_prefix_for_target(&output_prefix, bed_graph_dir.as_deref(), name);
                     info!("Syng query: {} ({}:{}-{})", name, target_name, range_start, range_end);
 
                     match resolved_format {
@@ -4814,7 +4829,7 @@ fn run() -> io::Result<()> {
                                 wrapper.seq_index(),
                             );
                             let ext = if resolved_format == "bedpe" { "bedpe" } else { "bed" };
-                            let mut out = find_output_stream(&output_prefix, ext)?;
+                            let mut out = find_output_stream(&target_output_prefix, ext)?;
                             if resolved_format == "bedpe" {
                                 output_results_bedpe(
                                     &wrapper,
@@ -4885,13 +4900,21 @@ fn run() -> io::Result<()> {
                                 );
 
                                 if query_intervals.is_empty() {
-                                    let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                    let mut out = find_output_stream(&target_output_prefix, output_ext)?;
                                     write_graph_output(
                                         String::from("H\tVN:Z:1.0\n"),
                                         resolved_format,
                                         &mut out,
                                         &reference_names,
                                     )?;
+                                    info!(
+                                        "Syng query complete: {} ({}:{}-{}) in {}",
+                                        name,
+                                        target_name,
+                                        range_start,
+                                        range_end,
+                                        format_duration(target_query_start.elapsed())
+                                    );
                                     continue;
                                 }
 
@@ -4902,7 +4925,7 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                let mut out = find_output_stream(&target_output_prefix, output_ext)?;
                                 write_graph_output(
                                     gfa_output,
                                     resolved_format,
@@ -4968,13 +4991,21 @@ fn run() -> io::Result<()> {
                                 }
 
                                 if partitions.is_empty() {
-                                    let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                    let mut out = find_output_stream(&target_output_prefix, output_ext)?;
                                     write_graph_output(
                                         String::from("H\tVN:Z:1.0\n"),
                                         resolved_format,
                                         &mut out,
                                         &reference_names,
                                     )?;
+                                    info!(
+                                        "Syng query complete: {} ({}:{}-{}) in {}",
+                                        name,
+                                        target_name,
+                                        range_start,
+                                        range_end,
+                                        format_duration(target_query_start.elapsed())
+                                    );
                                     continue;
                                 }
 
@@ -4985,7 +5016,7 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                let mut out = find_output_stream(&target_output_prefix, output_ext)?;
                                 write_graph_output(
                                     gfa_output,
                                     resolved_format,
@@ -5024,13 +5055,21 @@ fn run() -> io::Result<()> {
                                 );
 
                                 if query_intervals.is_empty() {
-                                    let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                    let mut out = find_output_stream(&target_output_prefix, output_ext)?;
                                     write_graph_output(
                                         String::from("H\tVN:Z:1.0\n"),
                                         resolved_format,
                                         &mut out,
                                         &reference_names,
                                     )?;
+                                    info!(
+                                        "Syng query complete: {} ({}:{}-{}) in {}",
+                                        name,
+                                        target_name,
+                                        range_start,
+                                        range_end,
+                                        format_duration(target_query_start.elapsed())
+                                    );
                                     continue;
                                 }
 
@@ -5041,7 +5080,7 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&output_prefix, output_ext)?;
+                                let mut out = find_output_stream(&target_output_prefix, output_ext)?;
                                 write_graph_output(
                                     gfa_output,
                                     resolved_format,
@@ -5071,7 +5110,7 @@ fn run() -> io::Result<()> {
                             } else {
                                 query_raw_syng(target_name, *range_start, *range_end, syng_padding, syng_extension)?
                             };
-                            let mut out = find_output_stream(&output_prefix, "fa")?;
+                            let mut out = find_output_stream(&target_output_prefix, "fa")?;
                             for iv in &intervals {
                                 let sequence = seq_idx.fetch_sequence(&iv.genome, iv.start as i32, iv.end as i32)?;
                                 writeln!(out, ">{}:{}-{}({})", iv.genome, iv.start, iv.end, iv.strand)?;
@@ -5100,7 +5139,7 @@ fn run() -> io::Result<()> {
                             } else {
                                 query_raw_syng(target_name, *range_start, *range_end, syng_padding, syng_extension)?
                             };
-                            let gbwt_prefix = output_prefix.as_ref().unwrap();
+                            let gbwt_prefix = target_output_prefix.as_ref().unwrap();
 
                             // Fetch sequences for all intervals
                             let fetched: Vec<(String, Vec<u8>)> = intervals
@@ -5122,6 +5161,14 @@ fn run() -> io::Result<()> {
                         }
                         _ => unreachable!(),
                     }
+                    info!(
+                        "Syng query complete: {} ({}:{}-{}) in {}",
+                        name,
+                        target_name,
+                        range_start,
+                        range_end,
+                        format_duration(target_query_start.elapsed())
+                    );
                 }
                 // Skip the rest of the normal query path
             } else {
@@ -5289,6 +5336,15 @@ fn run() -> io::Result<()> {
                     "Output prefix (-O) is required for 'gbwt' output format",
                 ));
             }
+            let bed_graph_dir =
+                bed_graph_output_dir(&output_prefix, resolved_output_format, &query.target_bed)?;
+            if let Some(dir) = &bed_graph_dir {
+                info!(
+                    "BED graph output: writing one {} per BED row under {} using BED column 4 names",
+                    resolved_output_format,
+                    dir.display()
+                );
+            }
 
             // Extract reverse_complement before moving gfa_maf_fasta
             let reverse_complement = gfa_maf_fasta.reverse_complement;
@@ -5305,6 +5361,13 @@ fn run() -> io::Result<()> {
             // Process all target ranges in a unified loop
             info!("Querying target ranges");
             for (target_name, target_range, name) in target_ranges {
+                let target_query_start = Instant::now();
+                let target_output_prefix =
+                    output_prefix_for_target(&output_prefix, bed_graph_dir.as_deref(), &name);
+                info!(
+                    "Query: {} ({}:{}-{})",
+                    name, target_name, target_range.0, target_range.1
+                );
                 let mut results = perform_query(
                     &impg,
                     &target_name,
@@ -5327,7 +5390,7 @@ fn run() -> io::Result<()> {
                         output_results_bed(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "bed")?,
+                            &mut find_output_stream(&target_output_prefix, "bed")?,
                             &name,
                             query.effective_merge_distance(),
                             query.merge_strands_for_output("bed"),
@@ -5340,7 +5403,7 @@ fn run() -> io::Result<()> {
                         output_results_bedpe(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "bed")?,
+                            &mut find_output_stream(&target_output_prefix, "bed")?,
                             &name,
                             query.effective_merge_distance(),
                             query.original_sequence_coordinates,
@@ -5352,7 +5415,7 @@ fn run() -> io::Result<()> {
                         output_results_paf(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "paf")?,
+                            &mut find_output_stream(&target_output_prefix, "paf")?,
                             &name,
                             query.effective_merge_distance(),
                             query.original_sequence_coordinates,
@@ -5365,7 +5428,7 @@ fn run() -> io::Result<()> {
                             // Partitioned mode: split query region into sub-windows
                             output_results_gfa_partitioned(
                                 &impg,
-                                &mut find_output_stream(&output_prefix, "gfa")?,
+                                &mut find_output_stream(&target_output_prefix, "gfa")?,
                                 sequence_index.as_ref().unwrap(),
                                 scoring_params,
                                 &engine_opts,
@@ -5379,7 +5442,7 @@ fn run() -> io::Result<()> {
                             output_results_gfa(
                                 &impg,
                                 &mut results,
-                                &mut find_output_stream(&output_prefix, "gfa")?,
+                                &mut find_output_stream(&target_output_prefix, "gfa")?,
                                 sequence_index.as_ref().unwrap(),
                                 &name,
                                 query.effective_merge_distance(),
@@ -5395,7 +5458,7 @@ fn run() -> io::Result<()> {
                         if let Some(ps) = engine_opts.partition_size {
                             output_results_vcf_partitioned(
                                 &impg,
-                                &mut find_output_stream(&output_prefix, "vcf")?,
+                                &mut find_output_stream(&target_output_prefix, "vcf")?,
                                 sequence_index.as_ref().unwrap(),
                                 scoring_params,
                                 &engine_opts,
@@ -5410,7 +5473,7 @@ fn run() -> io::Result<()> {
                             output_results_vcf(
                                 &impg,
                                 &mut results,
-                                &mut find_output_stream(&output_prefix, "vcf")?,
+                                &mut find_output_stream(&target_output_prefix, "vcf")?,
                                 sequence_index.as_ref().unwrap(),
                                 &reference_names,
                                 query.effective_merge_distance(),
@@ -5424,7 +5487,7 @@ fn run() -> io::Result<()> {
                         output_results_maf(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "maf")?,
+                            &mut find_output_stream(&target_output_prefix, "maf")?,
                             sequence_index.as_ref().unwrap(),
                             &name,
                             query.effective_merge_distance(),
@@ -5436,7 +5499,7 @@ fn run() -> io::Result<()> {
                         output_results_fasta(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "fa")?,
+                            &mut find_output_stream(&target_output_prefix, "fa")?,
                             sequence_index.as_ref().unwrap(),
                             &name,
                             query.effective_merge_distance(),
@@ -5448,7 +5511,7 @@ fn run() -> io::Result<()> {
                         output_results_fasta(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "fa")?,
+                            &mut find_output_stream(&target_output_prefix, "fa")?,
                             sequence_index.as_ref().unwrap(),
                             &name,
                             query.effective_merge_distance(),
@@ -5460,7 +5523,7 @@ fn run() -> io::Result<()> {
                         output_results_paf(
                             &impg,
                             &mut results,
-                            &mut find_output_stream(&output_prefix, "paf")?,
+                            &mut find_output_stream(&target_output_prefix, "paf")?,
                             &name,
                             query.effective_merge_distance(),
                             query.original_sequence_coordinates,
@@ -5480,7 +5543,7 @@ fn run() -> io::Result<()> {
                     }
                     "gbwt" => {
                         let seq_idx = sequence_index.as_ref().unwrap();
-                        let gbwt_prefix = output_prefix.as_ref().ok_or_else(|| {
+                        let gbwt_prefix = target_output_prefix.as_ref().ok_or_else(|| {
                             io::Error::new(
                                 io::ErrorKind::InvalidInput,
                                 "Output prefix (-O) is required for 'gbwt' output format",
@@ -5527,6 +5590,14 @@ fn run() -> io::Result<()> {
                         ));
                     }
                 }
+                info!(
+                    "Query complete: {} ({}:{}-{}) in {}",
+                    name,
+                    target_name,
+                    target_range.0,
+                    target_range.1,
+                    format_duration(target_query_start.elapsed())
+                );
             }
             } // end of else (normal query path)
         }
@@ -7940,6 +8011,71 @@ fn find_output_stream(basename: &Option<String>, extension: &str) -> io::Result<
     }
 }
 
+fn sanitize_output_stem(name: &str) -> String {
+    let mut stem = String::with_capacity(name.len());
+    for c in name.trim().chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+            stem.push(c);
+        } else {
+            stem.push('_');
+        }
+    }
+    let stem = stem.trim_matches('_');
+    if stem.is_empty() || stem == "." || stem == ".." {
+        "region".to_string()
+    } else {
+        stem.to_string()
+    }
+}
+
+fn bed_graph_output_dir(
+    output_prefix: &Option<String>,
+    output_format: &str,
+    target_bed: &Option<String>,
+) -> io::Result<Option<PathBuf>> {
+    if target_bed.is_none() || !matches!(output_format, "gfa" | "vcf" | "gbwt") {
+        return Ok(None);
+    }
+    let dir = output_prefix.as_ref().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "-O/--output-prefix is required for `query -b ... -o {output_format}`; \
+                 with BED graph output it is treated as an output directory and files \
+                 are named from BED column 4"
+            ),
+        )
+    })?;
+    let dir = PathBuf::from(dir);
+    if dir.exists() && !dir.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "BED graph output path '{}' exists and is not a directory",
+                dir.display()
+            ),
+        ));
+    }
+    fs::create_dir_all(&dir)?;
+    Ok(Some(dir))
+}
+
+fn output_prefix_for_target(
+    output_prefix: &Option<String>,
+    bed_graph_dir: Option<&Path>,
+    range_name: &str,
+) -> Option<String> {
+    if let Some(dir) = bed_graph_dir {
+        Some(
+            dir.join(sanitize_output_stem(range_name))
+                .to_string_lossy()
+                .into_owned(),
+        )
+    } else {
+        output_prefix.clone()
+    }
+}
+
 fn graph_output_extension(output_format: &str) -> &'static str {
     match output_format {
         "vcf" => "vcf",
@@ -10167,6 +10303,38 @@ mod tests {
     }
 
     #[test]
+    fn test_bed_graph_output_uses_bed_name_as_file_stem() {
+        assert_eq!(sanitize_output_stem("AMY1A"), "AMY1A");
+        assert_eq!(sanitize_output_stem("C4A/C4B locus"), "C4A_C4B_locus");
+        assert_eq!(sanitize_output_stem(".."), "region");
+
+        let dir = tempfile::tempdir().unwrap();
+        let output_root = dir.path().join("graphs");
+        let output_prefix = Some(output_root.to_string_lossy().to_string());
+        let target_bed = Some("regions.bed".to_string());
+        let graph_dir = bed_graph_output_dir(&output_prefix, "gfa", &target_bed)
+            .unwrap()
+            .unwrap();
+        assert_eq!(graph_dir, output_root);
+        assert!(graph_dir.is_dir());
+
+        let target_prefix =
+            output_prefix_for_target(&output_prefix, Some(&graph_dir), "C4A/C4B locus").unwrap();
+        assert!(target_prefix.ends_with("graphs/C4A_C4B_locus"));
+    }
+
+    #[test]
+    fn test_bed_graph_output_requires_directory_prefix_for_graph_formats() {
+        let target_bed = Some("regions.bed".to_string());
+        let err = bed_graph_output_dir(&None, "gfa", &target_bed).unwrap_err();
+        assert!(err.to_string().contains("-O/--output-prefix is required"));
+
+        assert!(bed_graph_output_dir(&None, "bed", &target_bed)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
     fn test_syng_gfa_intervals_are_merged_before_graph_build() {
         let mut seq_index = SequenceIndex::new();
         seq_index.get_or_insert_id("GRCh38#0#chr1", Some(1_000));
@@ -10260,6 +10428,8 @@ mod tests {
             "fasta+paf  FASTA sequences plus PAF-like interval mappings",
             "fasta-aln  FASTA alignment output",
             "gbwt       region-specific syng GBWT/khash output",
+            "For BED graph output (`-b regions.bed -o gfa|vcf|gbwt`)",
+            "named from BED column 4",
             "`--gfa-engine syng` emits a syng syncmer GFA",
             "defaults to syng:blunt; use syng:raw",
             "-o gfa:syng:blunt,k=63,s=8,seed=7",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3500,11 +3500,12 @@ GFA engine shorthand:
         #[clap(long, value_parser, default_value_t = 1_000)]
         syng_extend_budget: u64,
 
-        /// Minimum anchor count for a syng chain to be emitted. Chains
-        /// with fewer anchors than this are dropped at emission. Default
-        /// 20 requires support from multiple bounded GBWT-walk seed islands;
-        /// lower this for exploratory local-chain discovery or very sparse
-        /// indexes.
+        /// Maximum adaptive minimum anchor count for a syng chain to be
+        /// emitted. The effective threshold scales with query span (roughly
+        /// one anchor per 5 kb, capped by this value). The default cap 20
+        /// requires support from multiple bounded GBWT-walk seed islands for
+        /// locus-scale queries without making short queries satisfy 20 anchors.
+        /// Set 0 to disable anchor-count filtering.
         #[arg(help_heading = "Syng input")]
         #[clap(long, value_parser, default_value_t = impg::syng_transitive::DEFAULT_MIN_CHAIN_ANCHORS)]
         syng_min_chain_anchors: usize,

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -500,15 +500,10 @@ fn range_sequence(graph: &Graph, range: &PathRange) -> Vec<u8> {
     seq
 }
 
-fn traversal_stats(ranges: &[PathRange]) -> TraversalStats {
-    if ranges.is_empty() {
+fn traversal_stats_from_lengths(mut lengths: Vec<usize>) -> TraversalStats {
+    if lengths.is_empty() {
         return TraversalStats::default();
     }
-
-    let mut lengths = ranges
-        .iter()
-        .map(|range| range.sequence.len())
-        .collect::<Vec<_>>();
     lengths.sort_unstable();
 
     TraversalStats {
@@ -610,7 +605,13 @@ fn find_candidate_frontier(
     }
     let root_path_idx = 0;
     let root_path = &graph.paths[root_path_idx];
-    let root_positions = path_positions(graph, root_path_idx);
+    let path_positions_by_path: Vec<Vec<usize>> = graph
+        .paths
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| path_positions(graph, idx))
+        .collect();
+    let root_positions = &path_positions_by_path[root_path_idx];
     let render_start = Instant::now();
     log::info!(
         "crush discovery: rendering working graph with {} segment(s), {} path(s)",
@@ -644,6 +645,10 @@ fn find_candidate_frontier(
         .map(|(idx, segment)| (segment.id.as_str(), idx))
         .collect::<FxHashMap<_, _>>();
     let id_map_elapsed = id_map_start.elapsed();
+    let path_index_start = Instant::now();
+    let path_step_indexes: Vec<FxHashMap<Step, Vec<usize>>> =
+        graph.paths.par_iter().map(path_step_index).collect();
+    let path_index_elapsed = path_index_start.elapsed();
 
     let sites_seen = decomposition.sites.len();
     let candidate_start = Instant::now();
@@ -661,18 +666,15 @@ fn find_candidate_frontier(
             let root_span = root_positions[exit_step + 1] - root_positions[begin];
 
             let mut ranges = Vec::new();
-            for path_idx in 0..graph.paths.len() {
-                if let Some((range_begin, range_end)) =
-                    unique_anchor_range(&graph.paths[path_idx], entry, exit)
+            for (path_idx, path_index) in path_step_indexes.iter().enumerate() {
+                if let Some((range_begin, range_end)) = unique_anchor_range(path_index, entry, exit)
                 {
-                    let mut range = PathRange {
+                    ranges.push(PathRange {
                         path_idx,
                         begin_step: range_begin,
                         end_step: range_end,
                         sequence: Vec::new(),
-                    };
-                    range.sequence = range_sequence(graph, &range);
-                    ranges.push(range);
+                    });
                 }
             }
 
@@ -680,25 +682,14 @@ fn find_candidate_frontier(
                 return None;
             }
 
-            let distinct_sequences: BTreeSet<Vec<u8>> =
-                ranges.iter().map(|r| r.sequence.clone()).collect();
-            if distinct_sequences.len() < 2 {
-                return None;
-            }
-
-            let signature = candidate_signature(
-                graph,
-                root_path_idx,
-                &root_positions,
-                begin,
-                exit_step,
-                &ranges,
-            );
-            if seen.contains(&signature) {
-                return None;
-            }
-
-            let traversal_stats = traversal_stats(&ranges);
+            let lengths = ranges
+                .iter()
+                .map(|range| {
+                    let positions = &path_positions_by_path[range.path_idx];
+                    positions[range.end_step] - positions[range.begin_step]
+                })
+                .collect::<Vec<_>>();
+            let traversal_stats = traversal_stats_from_lengths(lengths);
             let within_budget = (config.max_bubble_span == 0
                 || root_span <= config.max_bubble_span)
                 && ranges.len() <= config.max_traversals
@@ -706,6 +697,17 @@ fn find_candidate_frontier(
                 && (config.max_median_traversal_len == 0
                     || traversal_stats.median_len <= config.max_median_traversal_len)
                 && traversal_stats.total_len <= config.max_total_sequence;
+            let signature = candidate_signature(
+                graph,
+                root_path_idx,
+                root_positions,
+                begin,
+                exit_step,
+                &ranges,
+            );
+            if seen.contains(&signature) {
+                return None;
+            }
 
             Some(BubbleCandidate {
                 ranges,
@@ -735,30 +737,42 @@ fn find_candidate_frontier(
         candidates_seen,
         ..CandidateFrontier::default()
     };
+    let mut occupied_by_path: Vec<Vec<(usize, usize)>> = vec![Vec::new(); graph.paths.len()];
     for candidate in candidates {
         if !candidate.within_budget {
             frontier.bailed.push(candidate);
             continue;
         }
-        if frontier
-            .selected
-            .iter()
-            .any(|selected| candidates_conflict(selected, &candidate))
-        {
+        if candidate_conflicts_with_occupied(&occupied_by_path, &candidate) {
             continue;
         }
+        mark_candidate_occupied(&mut occupied_by_path, &candidate);
         frontier.selected.push(candidate);
     }
+    let selected_before_materialize = frontier.selected.len();
+    let materialize_start = Instant::now();
+    frontier.selected = frontier
+        .selected
+        .into_par_iter()
+        .filter_map(|mut candidate| {
+            materialize_candidate_sequences(graph, &mut candidate).then_some(candidate)
+        })
+        .collect();
+    let materialize_elapsed = materialize_start.elapsed();
     let select_elapsed = select_start.elapsed();
 
     log::info!(
-        "crush discovery detail: render {:.2?}, povu-parse {:.2?}, povu-decompose {:.2?}, id-map {:.2?}, candidate-build {:.2?}, select {:.2?}",
+        "crush discovery detail: render {:.2?}, povu-parse {:.2?}, povu-decompose {:.2?}, id-map {:.2?}, path-index {:.2?}, candidate-build {:.2?}, select+materialize {:.2?} ({} -> {} selected, materialize {:.2?})",
         render_elapsed,
         parse_elapsed,
         decompose_elapsed,
         id_map_elapsed,
+        path_index_elapsed,
         candidate_elapsed,
-        select_elapsed
+        select_elapsed,
+        selected_before_materialize,
+        frontier.selected.len(),
+        materialize_elapsed
     );
 
     Ok(frontier)
@@ -770,26 +784,51 @@ impl BubbleCandidate {
     }
 }
 
-fn candidates_conflict(a: &BubbleCandidate, b: &BubbleCandidate) -> bool {
-    for a_range in &a.ranges {
-        for b_range in &b.ranges {
-            if a_range.path_idx == b_range.path_idx
-                && ranges_overlap(
-                    a_range.begin_step,
-                    a_range.end_step,
-                    b_range.begin_step,
-                    b_range.end_step,
-                )
-            {
-                return true;
-            }
+fn candidate_conflicts_with_occupied(
+    occupied_by_path: &[Vec<(usize, usize)>],
+    candidate: &BubbleCandidate,
+) -> bool {
+    candidate.ranges.iter().any(|range| {
+        range_conflicts_with_occupied(
+            &occupied_by_path[range.path_idx],
+            range.begin_step,
+            range.end_step,
+        )
+    })
+}
+
+fn mark_candidate_occupied(
+    occupied_by_path: &mut [Vec<(usize, usize)>],
+    candidate: &BubbleCandidate,
+) {
+    for range in &candidate.ranges {
+        insert_occupied_range(
+            &mut occupied_by_path[range.path_idx],
+            range.begin_step,
+            range.end_step,
+        );
+    }
+}
+
+fn range_conflicts_with_occupied(occupied: &[(usize, usize)], begin: usize, end: usize) -> bool {
+    let insert_pos = occupied.partition_point(|&(occupied_begin, _)| occupied_begin < begin);
+    if insert_pos > 0 {
+        let (_, previous_end) = occupied[insert_pos - 1];
+        if previous_end > begin {
+            return true;
+        }
+    }
+    if let Some(&(next_begin, _)) = occupied.get(insert_pos) {
+        if next_begin < end {
+            return true;
         }
     }
     false
 }
 
-fn ranges_overlap(a_begin: usize, a_end: usize, b_begin: usize, b_end: usize) -> bool {
-    a_begin < b_end && b_begin < a_end
+fn insert_occupied_range(occupied: &mut Vec<(usize, usize)>, begin: usize, end: usize) {
+    let insert_pos = occupied.partition_point(|&(occupied_begin, _)| occupied_begin < begin);
+    occupied.insert(insert_pos, (begin, end));
 }
 
 fn step_from_povu(id_to_idx: &FxHashMap<&str, usize>, step: &PovuStep) -> Option<Step> {
@@ -807,23 +846,47 @@ fn povu_to_io_error(err: povu::Error) -> io::Error {
     )
 }
 
-fn unique_anchor_range(path: &Path, entry: Step, exit: Step) -> Option<(usize, usize)> {
+fn path_step_index(path: &Path) -> FxHashMap<Step, Vec<usize>> {
+    let mut index: FxHashMap<Step, Vec<usize>> = FxHashMap::default();
+    for (idx, &step) in path.steps.iter().enumerate() {
+        index.entry(step).or_default().push(idx);
+    }
+    index
+}
+
+fn unique_anchor_range(
+    path_index: &FxHashMap<Step, Vec<usize>>,
+    entry: Step,
+    exit: Step,
+) -> Option<(usize, usize)> {
+    let starts = path_index.get(&entry)?;
+    let exits = path_index.get(&exit)?;
     let mut found = None;
-    for (i, &step) in path.steps.iter().enumerate() {
-        if step != entry {
+    for &i in starts {
+        let exit_pos = exits.partition_point(|&j| j <= i);
+        if exit_pos >= exits.len() {
             continue;
         }
-        for j in i + 1..path.steps.len() {
-            if path.steps[j] == exit {
-                if found.is_some() {
-                    return None;
-                }
-                found = Some((i, j + 1));
-                break;
-            }
+        let j = exits[exit_pos];
+        if found.is_some() {
+            return None;
         }
+        found = Some((i, j + 1));
     }
     found
+}
+
+fn materialize_candidate_sequences(graph: &Graph, candidate: &mut BubbleCandidate) -> bool {
+    for range in &mut candidate.ranges {
+        range.sequence = range_sequence(graph, range);
+    }
+    let Some(first) = candidate.ranges.first() else {
+        return false;
+    };
+    candidate
+        .ranges
+        .iter()
+        .any(|range| range.sequence != first.sequence)
 }
 
 fn candidate_signature(
@@ -834,17 +897,17 @@ fn candidate_signature(
     exit_step: usize,
     ranges: &[PathRange],
 ) -> String {
-    let mut seqs: Vec<String> = ranges
+    let mut coords: Vec<String> = ranges
         .iter()
-        .map(|r| String::from_utf8_lossy(&r.sequence).to_string())
+        .map(|r| format!("{}:{}-{}", r.path_idx, r.begin_step, r.end_step))
         .collect();
-    seqs.sort();
+    coords.sort();
     format!(
         "{}:{}-{}:{}",
         graph.paths[ref_path_idx].name,
         ref_positions[begin],
         ref_positions[exit_step + 1],
-        seqs.join("|")
+        coords.join("|")
     )
 }
 
@@ -1375,6 +1438,28 @@ P\tins\t1+,2+,3+\t*
     }
 
     #[test]
+    fn skips_sequence_identical_bubbles_after_deferred_materialization() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tA
+S\t2\tC
+S\t3\tC
+S\t4\tT
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t4\t+\t0M
+L\t1\t+\t3\t+\t0M
+L\t3\t+\t4\t+\t0M
+P\tref\t1+,2+,4+\t*
+P\talt\t1+,3+,4+\t*
+";
+        let before = seq_map(gfa);
+        let resolved = resolve_gfa_bubbles(gfa, &ResolutionConfig::default()).unwrap();
+        assert_eq!(before, seq_map(&resolved.gfa));
+        assert_eq!(resolved.stats.resolved, 0);
+        assert_eq!(resolved.stats.bailed, 0);
+    }
+
+    #[test]
     fn bails_out_when_candidate_exceeds_median_traversal_budget() {
         let gfa = "\
 H\tVN:Z:1.0
@@ -1535,6 +1620,141 @@ P\talt\t1+,3+,4+\t*
         assert_eq!(before, seq_map(&resolved.gfa));
         assert_eq!(resolved.gfa, gfa);
         assert_eq!(resolved.stats.resolved, 0);
+    }
+
+    #[test]
+    fn indexed_anchor_lookup_rejects_ambiguous_entry_exit_pairs() {
+        let entry = Step {
+            node: 0,
+            rev: false,
+        };
+        let exit = Step {
+            node: 2,
+            rev: false,
+        };
+        let ambiguous = Path {
+            name: "ambiguous".to_string(),
+            steps: vec![
+                entry,
+                Step {
+                    node: 1,
+                    rev: false,
+                },
+                exit,
+                entry,
+                Step {
+                    node: 1,
+                    rev: false,
+                },
+                exit,
+            ],
+        };
+        assert_eq!(
+            unique_anchor_range(&path_step_index(&ambiguous), entry, exit),
+            None
+        );
+
+        let unique = Path {
+            name: "unique".to_string(),
+            steps: vec![
+                entry,
+                Step {
+                    node: 1,
+                    rev: false,
+                },
+                exit,
+                entry,
+            ],
+        };
+        assert_eq!(
+            unique_anchor_range(&path_step_index(&unique), entry, exit),
+            Some((0, 3))
+        );
+    }
+
+    #[test]
+    fn occupied_interval_frontier_only_rejects_overlaps_on_same_path() {
+        let mut occupied_by_path = vec![Vec::new(), Vec::new()];
+        let selected = BubbleCandidate {
+            ranges: vec![
+                PathRange {
+                    path_idx: 0,
+                    begin_step: 10,
+                    end_step: 20,
+                    sequence: Vec::new(),
+                },
+                PathRange {
+                    path_idx: 1,
+                    begin_step: 30,
+                    end_step: 40,
+                    sequence: Vec::new(),
+                },
+            ],
+            signature: "selected".to_string(),
+            within_budget: true,
+            root_start_step: 0,
+            root_end_step: 1,
+            root_span: 10,
+            traversal_stats: TraversalStats::default(),
+        };
+        mark_candidate_occupied(&mut occupied_by_path, &selected);
+
+        let adjacent = BubbleCandidate {
+            ranges: vec![PathRange {
+                path_idx: 0,
+                begin_step: 20,
+                end_step: 25,
+                sequence: Vec::new(),
+            }],
+            signature: "adjacent".to_string(),
+            within_budget: true,
+            root_start_step: 0,
+            root_end_step: 1,
+            root_span: 5,
+            traversal_stats: TraversalStats::default(),
+        };
+        assert!(!candidate_conflicts_with_occupied(
+            &occupied_by_path,
+            &adjacent
+        ));
+
+        let overlapping = BubbleCandidate {
+            ranges: vec![PathRange {
+                path_idx: 0,
+                begin_step: 19,
+                end_step: 25,
+                sequence: Vec::new(),
+            }],
+            signature: "overlapping".to_string(),
+            within_budget: true,
+            root_start_step: 0,
+            root_end_step: 1,
+            root_span: 6,
+            traversal_stats: TraversalStats::default(),
+        };
+        assert!(candidate_conflicts_with_occupied(
+            &occupied_by_path,
+            &overlapping
+        ));
+
+        let same_coordinates_different_path = BubbleCandidate {
+            ranges: vec![PathRange {
+                path_idx: 1,
+                begin_step: 10,
+                end_step: 20,
+                sequence: Vec::new(),
+            }],
+            signature: "different-path".to_string(),
+            within_budget: true,
+            root_start_step: 0,
+            root_end_step: 1,
+            root_span: 10,
+            traversal_stats: TraversalStats::default(),
+        };
+        assert!(!candidate_conflicts_with_occupied(
+            &occupied_by_path,
+            &same_coordinates_different_path
+        ));
     }
 
     #[test]

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -56,7 +56,8 @@ impl ResolutionMethod {
     }
 }
 
-pub const DEFAULT_MAX_ITERATIONS: usize = 64;
+/// One frontier round is the fast default. More rounds are explicit polishing.
+pub const DEFAULT_MAX_ITERATIONS: usize = 1;
 /// By default, do not cap by rooted path span.
 ///
 /// `max_bubble_span` is a POVU root-path coordinate guard. The root is currently

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -194,7 +194,18 @@ struct OutStep {
 /// adjacency and emits `0M` edges. Use `syng:blunt` output, not raw syng overlap
 /// GFA, as input.
 pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<ResolvedGfa> {
+    let parse_start = Instant::now();
+    log::info!(
+        "crush: parsing input GFA ({} bytes) before bubble decomposition",
+        gfa.len()
+    );
     let mut graph = parse_gfa(gfa)?;
+    log::info!(
+        "crush: parsed input GFA into {} segment(s), {} path(s) in {:.2?}",
+        graph.segments.len(),
+        graph.paths.len(),
+        parse_start.elapsed()
+    );
     let mut stats = ResolutionStats::default();
     let mut seen: FxHashSet<String> = FxHashSet::default();
     let mut changed = false;
@@ -601,13 +612,26 @@ fn find_candidate_frontier(
     let root_path = &graph.paths[root_path_idx];
     let root_positions = path_positions(graph, root_path_idx);
     let render_start = Instant::now();
+    log::info!(
+        "crush discovery: rendering working graph with {} segment(s), {} path(s)",
+        graph.segments.len(),
+        graph.paths.len()
+    );
     let rendered = render_graph(graph);
     let render_elapsed = render_start.elapsed();
     let parse_start = Instant::now();
+    log::info!(
+        "crush discovery: parsing rendered graph with POVU ({} bytes)",
+        rendered.len()
+    );
     let native_graph = povu::NativeGfa::parse(&rendered).map_err(povu_to_io_error)?;
     let parse_elapsed = parse_start.elapsed();
     let reference_names = vec![root_path.name.clone()];
     let decompose_start = Instant::now();
+    log::info!(
+        "crush discovery: decomposing rendered graph with POVU using root '{}'",
+        root_path.name
+    );
     let decomposition = native_graph
         .decompose_flubbles(&reference_names)
         .map_err(povu_to_io_error)?;
@@ -1022,30 +1046,16 @@ fn build_poasta_replacement(
         let scoring = GapAffine2Piece::new(mismatch, gap_extend, gap_open, gap_extend2, gap_open2);
         let mut aligner =
             PoastaAligner::new(Affine2PieceMinGapCost(scoring), AlignmentType::Global);
-        add_poasta_sequences(
-            &mut graph,
-            &mut aligner,
-            &headers,
-            &sequences,
-            &weights,
-        )?;
+        add_poasta_sequences(&mut graph, &mut aligner, &headers, &sequences, &weights)?;
     } else {
         let scoring = GapAffine::new(mismatch, gap_extend, gap_open);
         let mut aligner = PoastaAligner::new(AffineMinGapCost(scoring), AlignmentType::Global);
-        add_poasta_sequences(
-            &mut graph,
-            &mut aligner,
-            &headers,
-            &sequences,
-            &weights,
-        )?;
+        add_poasta_sequences(&mut graph, &mut aligner, &headers, &sequences, &weights)?;
     }
 
     let mut gfa = Vec::new();
     graph_to_gfa(&mut gfa, &graph).map_err(|err| {
-        io::Error::other(format!(
-            "POASTA replacement GFA generation failed: {err}"
-        ))
+        io::Error::other(format!("POASTA replacement GFA generation failed: {err}"))
     })?;
     let gfa = String::from_utf8(gfa).map_err(|err| {
         io::Error::new(

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -5237,12 +5237,34 @@ impl SyngIndex {
     /// Uses the same syncmer parameters as this index (or default if
     /// called on a freshly constructed index).
     pub fn build_region_gbwt(&self, sequences: &[(String, &[u8])], prefix: &str) -> io::Result<()> {
+        let total_start = std::time::Instant::now();
+        let total_bp: usize = sequences.iter().map(|(_, seq)| seq.len()).sum();
+        log::info!(
+            "[syng region gbwt] serial build from {} sequence(s), {} bp",
+            sequences.len(),
+            total_bp
+        );
         let mut region_index = SyngIndex::new(self.params);
         region_index.enable_online_sampled_positions(1)?;
+        let replay_start = std::time::Instant::now();
+        let mut total_syncmers = 0usize;
         for (name, seq) in sequences {
-            region_index.add_sequence(name.clone(), seq.to_vec());
+            let stats = region_index.add_sequence(name.clone(), seq.to_vec());
+            total_syncmers += stats.syncmers;
         }
-        region_index.save(prefix)
+        log::info!(
+            "[syng region gbwt] extracted and inserted {} syncmer step(s) into GBWT in {:.3}s",
+            total_syncmers,
+            replay_start.elapsed().as_secs_f64()
+        );
+        let save_start = std::time::Instant::now();
+        region_index.save(prefix)?;
+        log::info!(
+            "[syng region gbwt] saved regional syng files in {:.3}s; total {:.3}s",
+            save_start.elapsed().as_secs_f64(),
+            total_start.elapsed().as_secs_f64()
+        );
+        Ok(())
     }
 
     /// Merge overlapping or adjacent intervals that share the same genome and strand.

--- a/src/syng_transitive.rs
+++ b/src/syng_transitive.rs
@@ -908,10 +908,10 @@ pub fn one_hop_ext_visited_with_seed_filter(
         target_span_cap,
     );
     let pre_filter = hits.len();
-    // Filter chains by anchor count. Default min=2 drops singletons
-    // (one-anchor chains with no mutual-best colinear partner — mostly
-    // noise in repeat-dense regions). Users who want to keep
-    // singletons set --syng-min-chain-anchors 1.
+    // Filter chains by anchor count. The default requires support from
+    // multiple bounded GBWT-walk seed islands, not just a single weak
+    // island in a repeat-dense region. Users who want exploratory local
+    // chains or singletons can lower --syng-min-chain-anchors.
     //
     // Auto-relax for short queries: a query range shorter than
     // 2 × syncmer_len can't physically host a chain of 2 distinct

--- a/src/syng_transitive.rs
+++ b/src/syng_transitive.rs
@@ -758,10 +758,14 @@ fn dedupe_strand_overlaps(
     out
 }
 
-/// Default minimum anchor count per chain for emission. Chains with
-/// fewer anchors (singletons = 1) are filtered out — they have no
-/// mutual-best colinear partner and are the weakest possible evidence.
-pub const DEFAULT_MIN_CHAIN_ANCHORS: usize = 2;
+/// Default minimum anchor count per chain for emission.
+///
+/// Bounded GBWT-walk seeds already carry several consecutive syncmers (the CLI
+/// default is 5), so a threshold of 2 lets one weak exact island through. A
+/// 20-anchor default requires multiple seed islands before a chain can project
+/// a locus-scale interval, which suppresses paralog/repeat noise in loci such
+/// as AMY while still auto-relaxing for very short queries below.
+pub const DEFAULT_MIN_CHAIN_ANCHORS: usize = 20;
 
 /// Run one hop of syng-seeded homology query.
 pub fn one_hop(

--- a/src/syng_transitive.rs
+++ b/src/syng_transitive.rs
@@ -758,14 +758,55 @@ fn dedupe_strand_overlaps(
     out
 }
 
-/// Default minimum anchor count per chain for emission.
+/// Default cap on the adaptive minimum anchor count per chain for emission.
 ///
 /// Bounded GBWT-walk seeds already carry several consecutive syncmers (the CLI
-/// default is 5), so a threshold of 2 lets one weak exact island through. A
-/// 20-anchor default requires multiple seed islands before a chain can project
-/// a locus-scale interval, which suppresses paralog/repeat noise in loci such
-/// as AMY while still auto-relaxing for very short queries below.
+/// default is 5), so a threshold of 2 lets one weak exact island through. The
+/// default cap of 20 requires multiple seed islands for locus-scale queries,
+/// which suppresses paralog/repeat noise in loci such as AMY. The effective
+/// threshold is scaled by the query span in [`effective_min_chain_anchors`], so
+/// short queries do not have to satisfy a fixed 20-anchor floor.
 pub const DEFAULT_MIN_CHAIN_ANCHORS: usize = 20;
+
+/// Target scale for adaptive syng chain support.
+///
+/// The default support threshold grows by roughly one anchor per 5 kb until it
+/// reaches [`DEFAULT_MIN_CHAIN_ANCHORS`]. This keeps small queries usable while
+/// still requiring several bounded exact-walk seed islands for large local
+/// graph queries.
+pub const DEFAULT_MIN_CHAIN_ANCHOR_SPACING_BP: u64 = 5_000;
+
+/// Effective syng chain anchor threshold for a specific query span.
+///
+/// `requested_min` is treated as a user/CLI cap. The returned value scales with
+/// the query span and is additionally capped by a conservative estimate of how
+/// many 63 bp-style syncmer-width anchors can fit in the query. `0` disables
+/// the anchor-count filter.
+pub fn effective_min_chain_anchors(
+    query_range_len: u64,
+    syncmer_len: u64,
+    requested_min: usize,
+) -> usize {
+    if requested_min == 0 {
+        return 0;
+    }
+
+    let span_scaled = query_range_len
+        .saturating_add(DEFAULT_MIN_CHAIN_ANCHOR_SPACING_BP - 1)
+        / DEFAULT_MIN_CHAIN_ANCHOR_SPACING_BP;
+    let span_scaled = (span_scaled as usize).max(1);
+
+    let syncmer_width_cap = if syncmer_len == 0 {
+        requested_min
+    } else {
+        let cap = query_range_len
+            .saturating_add(syncmer_len - 1)
+            / syncmer_len;
+        (cap as usize).max(1)
+    };
+
+    requested_min.min(span_scaled).min(syncmer_width_cap).max(1)
+}
 
 /// Run one hop of syng-seeded homology query.
 pub fn one_hop(
@@ -824,9 +865,9 @@ pub fn one_hop_ext(
 /// ends-only projection per chain.
 ///
 /// Chains are dropped at emission when either:
-///   - anchor count < `min_chain_anchors` (default 2: drop singletons)
+///   - anchor count is below the query-scaled effective `min_chain_anchors`
 ///   - query-extent / query_range_len < `min_chain_fraction`
-///     (default 0.0: no length filter)
+///     (default 0.0 in the library helper: no length filter)
 #[allow(clippy::too_many_arguments)]
 pub fn one_hop_ext_visited(
     syng_index: &SyngIndex,
@@ -913,15 +954,8 @@ pub fn one_hop_ext_visited_with_seed_filter(
     // island in a repeat-dense region. Users who want exploratory local
     // chains or singletons can lower --syng-min-chain-anchors.
     //
-    // Auto-relax for short queries: a query range shorter than
-    // 2 × syncmer_len can't physically host a chain of 2 distinct
-    // syncmer anchors, so filtering would drop everything. Fall back
-    // to min=1 when the range is too small for the requested minimum.
-    let effective_min = if query_range_len < syncmer_len.saturating_mul(min_chain_anchors as u64) {
-        1
-    } else {
-        min_chain_anchors
-    };
+    let effective_min =
+        effective_min_chain_anchors(query_range_len, syncmer_len, min_chain_anchors);
     // Chain query-extent = a_last.query_pos + syncmer_len - a_first.query_pos.
     // Threshold in bp; 0 means "no extent filter".
     let min_chain_extent_bp = (query_range_len as f64 * min_chain_fraction.max(0.0)) as u64;
@@ -1589,6 +1623,19 @@ mod tests {
             span_cap >= query_len + merge_distance as u64,
             "-d should contribute to the pre-refinement target span cap"
         );
+    }
+
+    #[test]
+    fn effective_min_chain_anchors_scales_with_query_span() {
+        assert_eq!(effective_min_chain_anchors(0, TEST_SYNCMER_LEN, 20), 1);
+        assert_eq!(effective_min_chain_anchors(63, TEST_SYNCMER_LEN, 20), 1);
+        assert_eq!(effective_min_chain_anchors(1_000, TEST_SYNCMER_LEN, 20), 1);
+        assert_eq!(effective_min_chain_anchors(10_000, TEST_SYNCMER_LEN, 20), 2);
+        assert_eq!(effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 20), 10);
+        assert_eq!(effective_min_chain_anchors(100_000, TEST_SYNCMER_LEN, 20), 20);
+        assert_eq!(effective_min_chain_anchors(400_000, TEST_SYNCMER_LEN, 20), 20);
+        assert_eq!(effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 3), 3);
+        assert_eq!(effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 0), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route syng gfa/vcf intervals through the same query-interval merge used by normal graph output before graph construction
- make `-d` effective for `gfa:syng` and `vcf:syng` instead of building one path per raw syng interval
- add a regression that adjacent syng intervals merge before graph build

## Validation
- `cargo test test_syng_gfa_intervals_are_merged_before_graph_build`
- `cargo test test_gfa_output_format`
- `cargo build --release`

## Evaluation note
This fixes a real bypass in the syng graph output path, but the Bolognini amylase window still produces 946 BED intervals after the common merge. That means most of the inflation is not same-contig `-d` merging; it is upstream locus fragmentation across sample/haplotype contigs and needs a haplotype-level colinear stitch/chaining step that preserves query-axis anchor spans.