### PR TITLE
Use global SPOA for crush replacements

### DIFF
--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -153,7 +153,9 @@ traverse it. `max-span` is optional and disabled by default; when set, it caps
 the span on the POVU root path, currently the first GFA path, so it is a rooted
 coordinate guard rather than the main runtime budget.
 
-`method=auto` currently tries the POASTA graph builder first and falls back to
-the SPOA-backed `poa` resolver if exact path-sequence validation fails. The
-intended next tier is a SweepGA/FastGA + filtering + seqwish resolver for
-bubbles that are too large for direct POA.
+`method=auto` currently uses the global/end-to-end SPOA-backed `poa` resolver.
+`method=poasta` is available for explicit experiments, but it is not the
+default until the POASTA GFA export path is proven to preserve clipped `W`
+walks exactly through impg's rewrite step. The intended next tier is a
+SweepGA/FastGA + filtering + seqwish resolver for bubbles that are too large
+for direct POA.

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -143,8 +143,9 @@ transform is exposed directly:
 impg crush -g local.blunt.gfa -o local.crushed.gfa
 ```
 
-The defaults are sized for human panels (`64` rounds and `10k` path traversals
-per candidate). Traversal count is deliberately a high safety rail. The main
+The defaults are sized for human panels (`1` frontier round and `10k` path
+traversals per candidate). Traversal count is deliberately a high safety rail.
+The main
 alignment budgets are `max-median-traversal-len` (default `1k`),
 `max-traversal-len` (default `10k`), and `max-total-seq`, because a common
 allele represented by many haplotypes should not fail only because many paths

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -307,10 +307,24 @@ fn format_fasta_alignment_from_msa(
 pub(crate) fn build_spoa_engine(
     scoring_params: (u8, u8, u8, u8, u8, u8),
 ) -> (SpoaGraph, AlignmentEngine) {
+    build_spoa_engine_with_alignment(scoring_params, SpoaAlignmentType::kSW)
+}
+
+/// Build a global/end-to-end SPOA graph and alignment engine.
+pub(crate) fn build_global_spoa_engine(
+    scoring_params: (u8, u8, u8, u8, u8, u8),
+) -> (SpoaGraph, AlignmentEngine) {
+    build_spoa_engine_with_alignment(scoring_params, SpoaAlignmentType::kNW)
+}
+
+fn build_spoa_engine_with_alignment(
+    scoring_params: (u8, u8, u8, u8, u8, u8),
+    alignment_type: SpoaAlignmentType,
+) -> (SpoaGraph, AlignmentEngine) {
     let (match_score, mismatch, gap_open1, gap_extend1, gap_open2, gap_extend2) = scoring_params;
     let graph = SpoaGraph::new();
     let engine = AlignmentEngine::new_convex(
-        SpoaAlignmentType::kSW,
+        alignment_type,
         match_score as i8,
         -(mismatch as i8),
         -(gap_open1 as i8),
@@ -920,6 +934,28 @@ P\tseq2:0-8\t1+,3+\t*
         let gfa = "H\tVN:Z:1.0\n";
         let msa = gfa_to_msa(gfa);
         assert!(msa.is_empty());
+    }
+
+    #[test]
+    fn global_spoa_engine_penalizes_unaligned_ends() {
+        let scoring = (1, 4, 6, 2, 26, 1);
+        let first = "AAAACCCC";
+        let second = "CCCCGGGG";
+
+        let (mut local_graph, mut local_engine) = build_spoa_engine(scoring);
+        let (_, local_alignment) = local_engine.align(first, &local_graph);
+        local_graph.add_alignment(local_alignment, first);
+        let (local_score, _) = local_engine.align(second, &local_graph);
+
+        let (mut global_graph, mut global_engine) = build_global_spoa_engine(scoring);
+        let (_, global_alignment) = global_engine.align(first, &global_graph);
+        global_graph.add_alignment(global_alignment, first);
+        let (global_score, _) = global_engine.align(second, &global_graph);
+
+        assert!(
+            global_score < local_score,
+            "global alignment should penalize terminal sequence absent from the graph"
+        );
     }
 
     #[test]

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1018,7 +1018,7 @@ fn apply_replacement_frontier(graph: &Graph, plans: &[ReplacementPlan]) -> io::R
 
 fn build_replacement(candidate: &BubbleCandidate, config: &ResolutionConfig) -> io::Result<Graph> {
     let method = match config.method {
-        ResolutionMethod::Auto => ResolutionMethod::Poasta,
+        ResolutionMethod::Auto => ResolutionMethod::Poa,
         method => method,
     };
     match method {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -6,7 +6,9 @@
 //! eligible unseen bubbles remain. It intentionally avoids lossy representative
 //! collapse and coordinate sidecars; emitted paths are the coordinate system.
 
-use crate::graph::{build_spoa_engine, feed_sequences_to_graph, reverse_complement, unchop_gfa};
+use crate::graph::{
+    build_global_spoa_engine, feed_sequences_to_graph, reverse_complement, unchop_gfa,
+};
 use povu::native_gfa::{Step as PovuStep, Strand as PovuStrand};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1033,7 +1035,7 @@ fn build_poa_replacement(
     candidate: &BubbleCandidate,
     config: &ResolutionConfig,
 ) -> io::Result<Graph> {
-    let (mut graph, mut engine) = build_spoa_engine(config.scoring_params);
+    let (mut graph, mut engine) = build_global_spoa_engine(config.scoring_params);
     let headers: Vec<String> = candidate
         .ranges
         .iter()
@@ -1524,7 +1526,7 @@ P\touter_alt\t1+,7+,6+\t*
         let resolved = resolve_gfa_bubbles(
             gfa,
             &ResolutionConfig {
-                max_iterations: 4,
+                max_iterations: 1,
                 method: ResolutionMethod::Poa,
                 ..ResolutionConfig::default()
             },


### PR DESCRIPTION
## Summary
- add a global/end-to-end SPOA engine helper
- use global SPOA for crush POA fallback replacements
- document the current one-frontier-round crush default

## Tests
- cargo test --all-targets