### PR TITLE
Add BiWFA seqwish crush condenser

### DIFF
--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -110,6 +110,7 @@ syng,k=63,s=8,seed=7
 seqwish,min-match-len=70,sparse-factor=0.001
 pggb,window=20k
 crush,method=auto,max-median-traversal-len=1k,max-traversal-len=10k
+crush,method=biwfa,max-median-traversal-len=10k,polish-max-median-traversal-len=256
 ```
 
 Unknown parameters should be errors, not warnings. Silent ignoring would make
@@ -156,6 +157,13 @@ coordinate guard rather than the main runtime budget.
 `method=auto` currently uses the global/end-to-end SPOA-backed `poa` resolver.
 `method=poasta` is available for explicit experiments, but it is not the
 default until the POASTA GFA export path is proven to preserve clipped `W`
-walks exactly through impg's rewrite step. The intended next tier is a
-SweepGA/FastGA + filtering + seqwish resolver for bubbles that are too large
-for direct POA.
+walks exactly through impg's rewrite step.
+
+`method=biwfa` is the coarse condenser path. It runs full-length BiWFA on a
+tree/neighbor/random sparse pair set for the selected POVU bubble traversals,
+feeds those PAF alignments to seqwish, then runs one small-scale SPOA polish
+pass over the induced replacement graph. The two scales are intentionally
+separate: `max-median-traversal-len` controls which biological bubble
+traversals may be induced by BiWFA/seqwish, while
+`polish-max-median-traversal-len` controls the tiny STR/indel tangles we are
+willing to clean inside that induced graph.

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -153,7 +153,9 @@ traverse it. `max-span` is optional and disabled by default; when set, it caps
 the span on the POVU root path, currently the first GFA path, so it is a rooted
 coordinate guard rather than the main runtime budget.
 
-`method=auto` currently tries the POASTA graph builder first and falls back to
-the SPOA-backed `poa` resolver if exact path-sequence validation fails. The
-intended next tier is a SweepGA/FastGA + filtering + seqwish resolver for
-bubbles that are too large for direct POA.
+`method=auto` currently uses the global/end-to-end SPOA-backed `poa` resolver.
+`method=poasta` is available for explicit experiments, but it is not the
+default until the POASTA GFA export path is proven to preserve clipped `W`
+walks exactly through impg's rewrite step. The intended next tier is a
+SweepGA/FastGA + filtering + seqwish resolver for bubbles that are too large
+for direct POA.

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -143,8 +143,9 @@ transform is exposed directly:
 impg crush -g local.blunt.gfa -o local.crushed.gfa
 ```
 
-The defaults are sized for human panels (`64` rounds and `10k` path traversals
-per candidate). Traversal count is deliberately a high safety rail. The main
+The defaults are sized for human panels (`1` frontier round and `10k` path
+traversals per candidate). Traversal count is deliberately a high safety rail.
+The main
 alignment budgets are `max-median-traversal-len` (default `1k`),
 `max-traversal-len` (default `10k`), and `max-total-seq`, because a common
 allele represented by many haplotypes should not fail only because many paths

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -307,10 +307,24 @@ fn format_fasta_alignment_from_msa(
 pub(crate) fn build_spoa_engine(
     scoring_params: (u8, u8, u8, u8, u8, u8),
 ) -> (SpoaGraph, AlignmentEngine) {
+    build_spoa_engine_with_alignment(scoring_params, SpoaAlignmentType::kSW)
+}
+
+/// Build a global/end-to-end SPOA graph and alignment engine.
+pub(crate) fn build_global_spoa_engine(
+    scoring_params: (u8, u8, u8, u8, u8, u8),
+) -> (SpoaGraph, AlignmentEngine) {
+    build_spoa_engine_with_alignment(scoring_params, SpoaAlignmentType::kNW)
+}
+
+fn build_spoa_engine_with_alignment(
+    scoring_params: (u8, u8, u8, u8, u8, u8),
+    alignment_type: SpoaAlignmentType,
+) -> (SpoaGraph, AlignmentEngine) {
     let (match_score, mismatch, gap_open1, gap_extend1, gap_open2, gap_extend2) = scoring_params;
     let graph = SpoaGraph::new();
     let engine = AlignmentEngine::new_convex(
-        SpoaAlignmentType::kSW,
+        alignment_type,
         match_score as i8,
         -(mismatch as i8),
         -(gap_open1 as i8),
@@ -920,6 +934,28 @@ P\tseq2:0-8\t1+,3+\t*
         let gfa = "H\tVN:Z:1.0\n";
         let msa = gfa_to_msa(gfa);
         assert!(msa.is_empty());
+    }
+
+    #[test]
+    fn global_spoa_engine_penalizes_unaligned_ends() {
+        let scoring = (1, 4, 6, 2, 26, 1);
+        let first = "AAAACCCC";
+        let second = "CCCCGGGG";
+
+        let (mut local_graph, mut local_engine) = build_spoa_engine(scoring);
+        let (_, local_alignment) = local_engine.align(first, &local_graph);
+        local_graph.add_alignment(local_alignment, first);
+        let (local_score, _) = local_engine.align(second, &local_graph);
+
+        let (mut global_graph, mut global_engine) = build_global_spoa_engine(scoring);
+        let (_, global_alignment) = global_engine.align(first, &global_graph);
+        global_graph.add_alignment(global_alignment, first);
+        let (global_score, _) = global_engine.align(second, &global_graph);
+
+        assert!(
+            global_score < local_score,
+            "global alignment should penalize terminal sequence absent from the graph"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2243,13 +2243,33 @@ fn parse_crush_stage(
                 config.max_traversals =
                     parse_usize_size_engine_param(raw, &param.key, &param.value)?;
             }
+            "polish-rounds" | "polish-iterations" => {
+                config.polish_iterations =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "polish-max-traversal-len" | "polish-max-traversal-length" => {
+                config.polish_max_traversal_len =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "polish-max-median-traversal-len" | "polish-max-median-traversal-length" => {
+                config.polish_max_median_traversal_len =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "polish-max-total-sequence" | "polish-max-total-seq" | "polish-max-sequence" => {
+                config.polish_max_total_sequence =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "polish-max-traversals" => {
+                config.polish_max_traversals =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
             "method" => {
                 let Some(method) = impg::resolution::ResolutionMethod::parse_name(&param.value)
                 else {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!(
-                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected auto, poa, or poasta)",
+                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected auto, poa, poasta, or biwfa)",
                             raw, param.value
                         ),
                     ));
@@ -3939,7 +3959,27 @@ GFA engine shorthand:
         #[clap(long, value_parser = parse_usize_size, default_value = "10k")]
         max_traversals: usize,
 
-        /// Resolver method: auto, poa, or poasta
+        /// Small-tangle SPOA polish rounds after BiWFA/seqwish induction; 0 disables
+        #[clap(long, alias = "polish-iterations", value_parser = parse_usize_size, default_value = "1")]
+        polish_rounds: usize,
+
+        /// Maximum traversal length for the small-tangle polish pass
+        #[clap(long, alias = "polish-max-traversal-length", value_parser = parse_usize_size, default_value = "2k")]
+        polish_max_traversal_len: usize,
+
+        /// Maximum median traversal length for the small-tangle polish pass
+        #[clap(long, alias = "polish-max-median-traversal-length", value_parser = parse_usize_size, default_value = "256")]
+        polish_max_median_traversal_len: usize,
+
+        /// Maximum total sequence across all traversals in one polish candidate
+        #[clap(long, alias = "polish-max-total-seq", value_parser = parse_usize_size, default_value = "1m")]
+        polish_max_total_sequence: usize,
+
+        /// Maximum number of path-supported traversals through one polish candidate
+        #[clap(long, value_parser = parse_usize_size, default_value = "10k")]
+        polish_max_traversals: usize,
+
+        /// Resolver method: auto, poa, poasta, or biwfa
         #[clap(long, value_parser, default_value = "auto")]
         method: String,
 
@@ -6552,6 +6592,11 @@ fn run() -> io::Result<()> {
             max_median_traversal_len,
             max_total_sequence,
             max_traversals,
+            polish_rounds,
+            polish_max_traversal_len,
+            polish_max_median_traversal_len,
+            polish_max_total_sequence,
+            polish_max_traversals,
             method,
             common,
         } => {
@@ -6568,10 +6613,16 @@ fn run() -> io::Result<()> {
                     "--max-traversals must be > 0",
                 ));
             }
+            if polish_max_traversals == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--polish-max-traversals must be > 0",
+                ));
+            }
             let Some(method) = impg::resolution::ResolutionMethod::parse_name(&method) else {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "--method must be one of: auto, poa, poasta",
+                    "--method must be one of: auto, poa, poasta, biwfa",
                 ));
             };
 
@@ -6590,6 +6641,11 @@ fn run() -> io::Result<()> {
                 max_median_traversal_len,
                 max_total_sequence,
                 max_traversals,
+                polish_iterations: polish_rounds,
+                polish_max_traversal_len,
+                polish_max_median_traversal_len,
+                polish_max_total_sequence,
+                polish_max_traversals,
                 ..Default::default()
             };
             let resolved = impg::resolution::resolve_gfa_bubbles(&gfa_text, &config)?;
@@ -10567,7 +10623,7 @@ mod tests {
             "-d",
             "0",
             "-o",
-            "gfa:syng:crush,method=poasta,max-median-traversal-len=2k,max-traversals=64,max-rounds=7",
+            "gfa:syng:crush,method=biwfa,max-median-traversal-len=10k,max-traversals=64,max-rounds=7,polish-max-median-traversal-len=128,polish-rounds=1",
         ])
         .unwrap();
         match args {
@@ -10581,17 +10637,19 @@ mod tests {
                 assert_eq!(output_format, "gfa");
                 assert_eq!(
                     engine_cli.engine_raw,
-                    "syng:crush,method=poasta,max-median-traversal-len=2k,max-traversals=64,max-rounds=7"
+                    "syng:crush,method=biwfa,max-median-traversal-len=10k,max-traversals=64,max-rounds=7,polish-max-median-traversal-len=128,polish-rounds=1"
                 );
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.engine, GfaEngine::SyngNative);
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
                 let crush = parsed.crush_config.unwrap();
-                assert_eq!(crush.method, impg::resolution::ResolutionMethod::Poasta);
+                assert_eq!(crush.method, impg::resolution::ResolutionMethod::Biwfa);
                 assert_eq!(crush.max_bubble_span, 0);
-                assert_eq!(crush.max_median_traversal_len, 2_000);
+                assert_eq!(crush.max_median_traversal_len, 10_000);
                 assert_eq!(crush.max_traversals, 64);
                 assert_eq!(crush.max_iterations, 7);
+                assert_eq!(crush.polish_max_median_traversal_len, 128);
+                assert_eq!(crush.polish_iterations, 1);
             }
             _ => panic!("expected query command"),
         }
@@ -10621,6 +10679,8 @@ mod tests {
                 assert_eq!(crush.max_traversal_len, 10_000);
                 assert_eq!(crush.max_traversals, 10_000);
                 assert_eq!(crush.max_iterations, 1);
+                assert_eq!(crush.polish_iterations, 1);
+                assert_eq!(crush.polish_max_median_traversal_len, 256);
             }
             _ => panic!("expected query command"),
         }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1018,7 +1018,7 @@ fn apply_replacement_frontier(graph: &Graph, plans: &[ReplacementPlan]) -> io::R
 
 fn build_replacement(candidate: &BubbleCandidate, config: &ResolutionConfig) -> io::Result<Graph> {
     let method = match config.method {
-        ResolutionMethod::Auto => ResolutionMethod::Poasta,
+        ResolutionMethod::Auto => ResolutionMethod::Poa,
         method => method,
     };
     match method {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -14,6 +14,7 @@ use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
 use std::io;
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 /// Configuration for exact path-preserving bubble resolution.
@@ -36,6 +37,17 @@ pub struct ResolutionConfig {
     pub max_total_sequence: usize,
     /// Maximum number of path-supported traversals through one replacement.
     pub max_traversals: usize,
+    /// One-pass small-tangle polish rounds after BiWFA/seqwish induction.
+    ///
+    /// This pass is deliberately scale-limited: small STR / indel tangles are
+    /// implementation artifacts, while larger VNTR / recombination structures
+    /// are often biological signal and should remain represented unless the
+    /// user explicitly raises these budgets.
+    pub polish_iterations: usize,
+    pub polish_max_traversal_len: usize,
+    pub polish_max_median_traversal_len: usize,
+    pub polish_max_total_sequence: usize,
+    pub polish_max_traversals: usize,
     /// SPOA scoring parameters: (match, mismatch, gap_open, gap_ext, gap_open2, gap_ext2).
     pub scoring_params: (u8, u8, u8, u8, u8, u8),
 }
@@ -45,6 +57,7 @@ pub enum ResolutionMethod {
     Auto,
     Poa,
     Poasta,
+    Biwfa,
 }
 
 impl ResolutionMethod {
@@ -53,6 +66,7 @@ impl ResolutionMethod {
             "auto" => Some(Self::Auto),
             "poa" | "spoa" => Some(Self::Poa),
             "poasta" => Some(Self::Poasta),
+            "biwfa" | "wfa" | "seqwish" | "biwfa-seqwish" | "allwave" => Some(Self::Biwfa),
             _ => None,
         }
     }
@@ -70,6 +84,13 @@ pub const DEFAULT_MAX_TRAVERSAL_LEN: usize = 10_000;
 pub const DEFAULT_MAX_MEDIAN_TRAVERSAL_LEN: usize = 1_000;
 pub const DEFAULT_MAX_TOTAL_SEQUENCE: usize = 1_000_000;
 pub const DEFAULT_MAX_TRAVERSALS: usize = 10_000;
+pub const DEFAULT_POLISH_ITERATIONS: usize = 1;
+pub const DEFAULT_POLISH_MAX_TRAVERSAL_LEN: usize = 2_000;
+pub const DEFAULT_POLISH_MAX_MEDIAN_TRAVERSAL_LEN: usize = 256;
+pub const DEFAULT_POLISH_MAX_TOTAL_SEQUENCE: usize = 1_000_000;
+pub const DEFAULT_POLISH_MAX_TRAVERSALS: usize = 10_000;
+
+static SEQWISH_REPLACEMENT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 impl Default for ResolutionConfig {
     fn default() -> Self {
@@ -81,6 +102,11 @@ impl Default for ResolutionConfig {
             max_median_traversal_len: DEFAULT_MAX_MEDIAN_TRAVERSAL_LEN,
             max_total_sequence: DEFAULT_MAX_TOTAL_SEQUENCE,
             max_traversals: DEFAULT_MAX_TRAVERSALS,
+            polish_iterations: DEFAULT_POLISH_ITERATIONS,
+            polish_max_traversal_len: DEFAULT_POLISH_MAX_TRAVERSAL_LEN,
+            polish_max_median_traversal_len: DEFAULT_POLISH_MAX_MEDIAN_TRAVERSAL_LEN,
+            polish_max_total_sequence: DEFAULT_POLISH_MAX_TOTAL_SEQUENCE,
+            polish_max_traversals: DEFAULT_POLISH_MAX_TRAVERSALS,
             scoring_params: (1, 4, 6, 2, 26, 1),
         }
     }
@@ -202,13 +228,27 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
         "crush: parsing input GFA ({} bytes) before bubble decomposition",
         gfa.len()
     );
-    let mut graph = parse_gfa(gfa)?;
+    let graph = parse_gfa(gfa)?;
     log::info!(
         "crush: parsed input GFA into {} segment(s), {} path(s) in {:.2?}",
         graph.segments.len(),
         graph.paths.len(),
         parse_start.elapsed()
     );
+    resolve_graph_bubbles(graph, Some(gfa), config, true)
+}
+
+fn resolve_gfa_bubbles_quiet(gfa: &str, config: &ResolutionConfig) -> io::Result<ResolvedGfa> {
+    let graph = parse_gfa(gfa)?;
+    resolve_graph_bubbles(graph, Some(gfa), config, false)
+}
+
+fn resolve_graph_bubbles(
+    mut graph: Graph,
+    original_gfa: Option<&str>,
+    config: &ResolutionConfig,
+    emit_logs: bool,
+) -> io::Result<ResolvedGfa> {
     let mut stats = ResolutionStats::default();
     let mut seen: FxHashSet<String> = FxHashSet::default();
     let mut changed = false;
@@ -216,34 +256,38 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
     for round in 0..config.max_iterations {
         let round_start = Instant::now();
         let discovery_start = Instant::now();
-        let frontier = find_candidate_frontier(&graph, config, &seen)?;
+        let frontier = find_candidate_frontier(&graph, config, &seen, emit_logs)?;
         let discovery_elapsed = discovery_start.elapsed();
         if frontier.selected.is_empty() && frontier.bailed.is_empty() {
-            log::info!(
-                "crush round {}: no eligible candidates from {} POVU site(s) in {:.2?}",
-                round + 1,
-                frontier.sites_seen,
-                discovery_elapsed
-            );
+            if emit_logs {
+                log::info!(
+                    "crush round {}: no eligible candidates from {} POVU site(s) in {:.2?}",
+                    round + 1,
+                    frontier.sites_seen,
+                    discovery_elapsed
+                );
+            }
             break;
         }
         stats.iterations = round + 1;
 
-        log::info!(
-            "crush round {}: {} POVU site(s), {} unseen polymorphic candidate(s), {} selected, {} over budget in {:.2?}",
-            round + 1,
-            frontier.sites_seen,
-            frontier.candidates_seen,
-            frontier.selected.len(),
-            frontier.bailed.len(),
-            discovery_elapsed
-        );
-        log::info!(
-            "crush round {} traversal stats: {}; {}",
-            round + 1,
-            format_candidate_length_summary("selected", &frontier.selected),
-            format_candidate_length_summary("over-budget", &frontier.bailed)
-        );
+        if emit_logs {
+            log::info!(
+                "crush round {}: {} POVU site(s), {} unseen polymorphic candidate(s), {} selected, {} over budget in {:.2?}",
+                round + 1,
+                frontier.sites_seen,
+                frontier.candidates_seen,
+                frontier.selected.len(),
+                frontier.bailed.len(),
+                discovery_elapsed
+            );
+            log::info!(
+                "crush round {} traversal stats: {}; {}",
+                round + 1,
+                format_candidate_length_summary("selected", &frontier.selected),
+                format_candidate_length_summary("over-budget", &frontier.bailed)
+            );
+        }
 
         for candidate in frontier.bailed {
             seen.insert(candidate.signature);
@@ -291,12 +335,14 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
         }
 
         if plans.is_empty() {
-            log::info!(
-                "crush round {}: 0/{} replacement(s) built in {:.2?}",
-                round + 1,
-                selected_count,
-                build_elapsed
-            );
+            if emit_logs {
+                log::info!(
+                    "crush round {}: 0/{} replacement(s) built in {:.2?}",
+                    round + 1,
+                    selected_count,
+                    build_elapsed
+                );
+            }
             continue;
         }
 
@@ -306,22 +352,26 @@ pub fn resolve_gfa_bubbles(gfa: &str, config: &ResolutionConfig) -> io::Result<R
         let rewrite_elapsed = rewrite_start.elapsed();
         changed = true;
         stats.resolved += resolved_count;
-        log::info!(
-            "crush round {}: resolved {}/{} replacement(s) in {:.2?}; rewrite+validate {:.2?}; total {:.2?}",
-            round + 1,
-            resolved_count,
-            selected_count,
-            build_elapsed,
-            rewrite_elapsed,
-            round_start.elapsed()
-        );
+        if emit_logs {
+            log::info!(
+                "crush round {}: resolved {}/{} replacement(s) in {:.2?}; rewrite+validate {:.2?}; total {:.2?}",
+                round + 1,
+                resolved_count,
+                selected_count,
+                build_elapsed,
+                rewrite_elapsed,
+                round_start.elapsed()
+            );
+        }
     }
 
     Ok(ResolvedGfa {
         gfa: if changed {
             render_graph(&graph)
         } else {
-            gfa.to_string()
+            original_gfa
+                .map(str::to_string)
+                .unwrap_or_else(|| render_graph(&graph))
         },
         stats,
     })
@@ -602,6 +652,7 @@ fn find_candidate_frontier(
     graph: &Graph,
     config: &ResolutionConfig,
     seen: &FxHashSet<String>,
+    emit_logs: bool,
 ) -> io::Result<CandidateFrontier> {
     if graph.paths.is_empty() || graph.paths[0].steps.len() < 2 {
         return Ok(CandidateFrontier::default());
@@ -616,26 +667,32 @@ fn find_candidate_frontier(
         .collect();
     let root_positions = &path_positions_by_path[root_path_idx];
     let render_start = Instant::now();
-    log::info!(
-        "crush discovery: rendering working graph with {} segment(s), {} path(s)",
-        graph.segments.len(),
-        graph.paths.len()
-    );
+    if emit_logs {
+        log::info!(
+            "crush discovery: rendering working graph with {} segment(s), {} path(s)",
+            graph.segments.len(),
+            graph.paths.len()
+        );
+    }
     let rendered = render_graph(graph);
     let render_elapsed = render_start.elapsed();
     let parse_start = Instant::now();
-    log::info!(
-        "crush discovery: parsing rendered graph with POVU ({} bytes)",
-        rendered.len()
-    );
+    if emit_logs {
+        log::info!(
+            "crush discovery: parsing rendered graph with POVU ({} bytes)",
+            rendered.len()
+        );
+    }
     let native_graph = povu::NativeGfa::parse(&rendered).map_err(povu_to_io_error)?;
     let parse_elapsed = parse_start.elapsed();
     let reference_names = vec![root_path.name.clone()];
     let decompose_start = Instant::now();
-    log::info!(
-        "crush discovery: decomposing rendered graph with POVU using root '{}'",
-        root_path.name
-    );
+    if emit_logs {
+        log::info!(
+            "crush discovery: decomposing rendered graph with POVU using root '{}'",
+            root_path.name
+        );
+    }
     let decomposition = native_graph
         .decompose_flubbles(&reference_names)
         .map_err(povu_to_io_error)?;
@@ -764,19 +821,21 @@ fn find_candidate_frontier(
     let materialize_elapsed = materialize_start.elapsed();
     let select_elapsed = select_start.elapsed();
 
-    log::info!(
-        "crush discovery detail: render {:.2?}, povu-parse {:.2?}, povu-decompose {:.2?}, id-map {:.2?}, path-index {:.2?}, candidate-build {:.2?}, select+materialize {:.2?} ({} -> {} selected, materialize {:.2?})",
-        render_elapsed,
-        parse_elapsed,
-        decompose_elapsed,
-        id_map_elapsed,
-        path_index_elapsed,
-        candidate_elapsed,
-        select_elapsed,
-        selected_before_materialize,
-        frontier.selected.len(),
-        materialize_elapsed
-    );
+    if emit_logs {
+        log::info!(
+            "crush discovery detail: render {:.2?}, povu-parse {:.2?}, povu-decompose {:.2?}, id-map {:.2?}, path-index {:.2?}, candidate-build {:.2?}, select+materialize {:.2?} ({} -> {} selected, materialize {:.2?})",
+            render_elapsed,
+            parse_elapsed,
+            decompose_elapsed,
+            id_map_elapsed,
+            path_index_elapsed,
+            candidate_elapsed,
+            select_elapsed,
+            selected_before_materialize,
+            frontier.selected.len(),
+            materialize_elapsed
+        );
+    }
 
     Ok(frontier)
 }
@@ -1028,6 +1087,7 @@ fn build_replacement(candidate: &BubbleCandidate, config: &ResolutionConfig) -> 
             log::debug!("POASTA replacement failed; falling back to SPOA: {err}");
             build_poa_replacement(candidate, config)
         }),
+        ResolutionMethod::Biwfa => build_biwfa_seqwish_replacement(candidate, config),
     }
 }
 
@@ -1153,6 +1213,98 @@ fn build_poasta_replacement(
     }
 
     Ok(replacement)
+}
+
+fn build_biwfa_seqwish_replacement(
+    candidate: &BubbleCandidate,
+    config: &ResolutionConfig,
+) -> io::Result<Graph> {
+    let headers: Vec<String> = candidate
+        .ranges
+        .iter()
+        .enumerate()
+        .map(|(i, range)| format!("__impg_bubble_path{}_{}", range.path_idx, i))
+        .collect();
+    let sequences = headers
+        .iter()
+        .cloned()
+        .zip(candidate.ranges.iter().map(|range| range.sequence.clone()))
+        .collect::<Vec<_>>();
+
+    let mut graph_config = crate::commands::graph::GraphBuildConfig::default();
+    graph_config.num_threads = rayon::current_num_threads().max(1);
+    graph_config.show_progress = false;
+    graph_config.no_filter = true;
+    graph_config.min_match_len = 1;
+    graph_config.repeat_max = 0;
+    graph_config.min_repeat_dist = 0;
+    graph_config.transclose_batch = 1_000_000;
+
+    // seqwish keeps process-global tempfile state, so replacement graph
+    // induction must be serialized even while candidate discovery/materialize
+    // remains parallel. The expensive BiWFA pair alignment inside the helper is
+    // still rayon-parallel.
+    let lock = SEQWISH_REPLACEMENT_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock
+        .lock()
+        .map_err(|_| io::Error::other("seqwish replacement lock is poisoned"))?;
+    let gfa = crate::syng_graph::build_gfa_syng_native_from_sequences(&sequences, &graph_config)?;
+    drop(_guard);
+
+    let polished = polish_replacement_gfa(&gfa, config)?;
+    let mut replacement = parse_gfa(&polished)?;
+    order_replacement_paths(&mut replacement, &headers)?;
+    validate_replacement_paths(&replacement, candidate, "BiWFA/seqwish")?;
+    Ok(replacement)
+}
+
+fn polish_replacement_gfa(gfa: &str, config: &ResolutionConfig) -> io::Result<String> {
+    if config.polish_iterations == 0 {
+        return Ok(gfa.to_string());
+    }
+    let polish_config = ResolutionConfig {
+        max_iterations: config.polish_iterations,
+        method: ResolutionMethod::Poa,
+        max_bubble_span: 0,
+        max_traversal_len: config.polish_max_traversal_len,
+        max_median_traversal_len: config.polish_max_median_traversal_len,
+        max_total_sequence: config.polish_max_total_sequence,
+        max_traversals: config.polish_max_traversals,
+        polish_iterations: 0,
+        polish_max_traversal_len: config.polish_max_traversal_len,
+        polish_max_median_traversal_len: config.polish_max_median_traversal_len,
+        polish_max_total_sequence: config.polish_max_total_sequence,
+        polish_max_traversals: config.polish_max_traversals,
+        scoring_params: config.scoring_params,
+    };
+    resolve_gfa_bubbles_quiet(gfa, &polish_config).map(|resolved| resolved.gfa)
+}
+
+fn validate_replacement_paths(
+    replacement: &Graph,
+    candidate: &BubbleCandidate,
+    method: &str,
+) -> io::Result<()> {
+    if replacement.paths.len() != candidate.ranges.len() {
+        return Err(io::Error::other(format!(
+            "{method} replacement emitted {} paths for {} traversals",
+            replacement.paths.len(),
+            candidate.ranges.len()
+        )));
+    }
+
+    for (idx, range) in candidate.ranges.iter().enumerate() {
+        let observed = path_sequence(replacement, &replacement.paths[idx])?;
+        if observed != range.sequence {
+            return Err(io::Error::other(format!(
+                "{method} replacement path {} changed sequence length {} -> {}",
+                idx,
+                range.sequence.len(),
+                observed.len()
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn add_poasta_sequences<C>(
@@ -1432,6 +1584,33 @@ P\tins\t1+,2+,3+\t*
             gfa,
             &ResolutionConfig {
                 method: ResolutionMethod::Poasta,
+                ..ResolutionConfig::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(before, seq_map(&resolved.gfa));
+        assert_eq!(resolved.stats.resolved, 1);
+    }
+
+    #[test]
+    fn resolves_insertion_bubble_with_biwfa_seqwish_without_changing_path_sequences() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tAC
+S\t2\tGGG
+S\t3\tTA
+L\t1\t+\t3\t+\t0M
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+P\tref\t1+,3+\t*
+P\tins\t1+,2+,3+\t*
+";
+        let before = seq_map(gfa);
+        let resolved = resolve_gfa_bubbles(
+            gfa,
+            &ResolutionConfig {
+                method: ResolutionMethod::Biwfa,
+                max_median_traversal_len: 10_000,
                 ..ResolutionConfig::default()
             },
         )

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -6,7 +6,9 @@
 //! eligible unseen bubbles remain. It intentionally avoids lossy representative
 //! collapse and coordinate sidecars; emitted paths are the coordinate system.
 
-use crate::graph::{build_spoa_engine, feed_sequences_to_graph, reverse_complement, unchop_gfa};
+use crate::graph::{
+    build_global_spoa_engine, feed_sequences_to_graph, reverse_complement, unchop_gfa,
+};
 use povu::native_gfa::{Step as PovuStep, Strand as PovuStrand};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1033,7 +1035,7 @@ fn build_poa_replacement(
     candidate: &BubbleCandidate,
     config: &ResolutionConfig,
 ) -> io::Result<Graph> {
-    let (mut graph, mut engine) = build_spoa_engine(config.scoring_params);
+    let (mut graph, mut engine) = build_global_spoa_engine(config.scoring_params);
     let headers: Vec<String> = candidate
         .ranges
         .iter()
@@ -1524,7 +1526,7 @@ P\touter_alt\t1+,7+,6+\t*
         let resolved = resolve_gfa_bubbles(
             gfa,
             &ResolutionConfig {
-                max_iterations: 4,
+                max_iterations: 1,
                 method: ResolutionMethod::Poa,
                 ..ResolutionConfig::default()
             },


### PR DESCRIPTION
## Summary
- add explicit  /  crush resolver
- induce selected POVU bubble traversals with sparse full-length BiWFA PAFs plus seqwish
- run a separate scale-limited SPOA polish pass for tiny STR/indel tangles
- add CLI/DSL polish budget parameters so biological bubble scale and tangle-cleanup scale are independent

## Tests
- cargo test --all-targets