### PR TITLE
Sort syng GFA query output by default

### DIFF
--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -111,6 +111,11 @@ impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o gfa --gfa-engine syng \
   --sequence-files panel.agc --force-large-region -O c4.syng-blunt
 
+# Syng-native crush graph, sorted with the default gfasort Ygs pipeline
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa:syng:crush \
+  --sequence-files panel.agc --force-large-region -O c4.syng-crush
+
 # VCF calls from the same local syng graph, using POVU
 impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o vcf:syng \
@@ -125,6 +130,11 @@ impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
 impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
   -d 50k -x -o gfa --gfa-engine syng:raw \
   --sequence-files panel.agc --force-large-region -O c4.syng-raw
+
+# Faster visualization-oriented order; use :nosort to preserve construction order
+impg query -a panel.syng -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k -x -o gfa:syng:crush:sort,pipeline=Yg \
+  --sequence-files panel.agc --force-large-region -O c4.syng-crush.yg
 
 # Syng-native blunt graph for every discovered partition
 impg partition -a panel.syng -w 1m -d 50k -o gfa --gfa-engine syng \
@@ -141,6 +151,11 @@ pggb:10000    partitioned mode with 10 kb windows
 syng          syng syncmer graph, defaults to syng:blunt
 syng:blunt    syng graph processed through pangenome/bluntg; links are 0M
 syng:raw      native syng overlap graph
+syng:crush    syng:blunt plus exact path-preserving bubble resolution
+syng:...:sort,pipeline=Ygs
+              final gfasort ordering; Ygs is the default for syng GFA output
+syng:...:nosort
+              disable final gfasort ordering
 ```
 
 `query` and `partition` differ only in how they gather local intervals. Once
@@ -167,6 +182,10 @@ same staged syntax.
 `gfa:syng:crush,method=auto,max-median-traversal-len=1k` emits blunt syng GFA
 and then runs exact path-preserving bubble resolution; see
 `docs/graph-pipeline-dsl.md`.
+For syng GFA output, `impg` then runs an internal gfasort pass by default using
+pipeline `Ygs` (path-guided SGD, grooming, topological ordering). The pipeline
+can be changed with a sort stage, for example
+`gfa:syng:crush:sort,pipeline=Yg`, or disabled with `gfa:syng:crush:nosort`.
 
 The transform can also be run on an existing blunt GFA:
 

--- a/src/commands/infer.rs
+++ b/src/commands/infer.rs
@@ -300,6 +300,7 @@ fn discover_partitions(
         poa_padding_fraction: 0.001,
         partition_size: None,
         crush_config: None,
+        graph_sort_pipeline: None,
     };
 
     info!(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,7 +6,10 @@ use std::io::{self, BufWriter, Write};
 
 // Gfasort imports for graph sorting
 use gfasort::gfa_parser::load_gfa_from_str;
-use gfasort::ygs::{unchop_only, ygs_sort, YgsParams};
+use gfasort::ygs::{
+    groom_only, priority_topological_sort_only, sgd_sort_only, topological_sort_only, unchop_only,
+    ygs_sort, YgsParams,
+};
 
 #[derive(Clone)]
 pub struct SequenceMetadata {
@@ -758,6 +761,19 @@ pub fn normalize_and_sort(gfa: String, num_threads: usize) -> io::Result<String>
 }
 
 pub fn sort_gfa(gfa_content: &str, num_threads: usize) -> io::Result<String> {
+    sort_gfa_pipeline(gfa_content, "Ygs", num_threads)
+}
+
+pub fn sort_gfa_pipeline(
+    gfa_content: &str,
+    pipeline: &str,
+    num_threads: usize,
+) -> io::Result<String> {
+    let pipeline = pipeline.trim();
+    if pipeline.is_empty() {
+        return Ok(gfa_content.to_string());
+    }
+
     // Load GFA directly from string (no temp file round-trip)
     let mut graph = load_gfa_from_str(gfa_content)
         .map_err(|e| io::Error::other(format!("Failed to load GFA for sorting: {}", e)))?;
@@ -768,11 +784,38 @@ pub fn sort_gfa(gfa_content: &str, num_threads: usize) -> io::Result<String> {
         return Ok(gfa_content.to_string());
     }
 
-    // Create Ygs parameters from the graph
-    let params = YgsParams::from_graph(&graph, 0, num_threads);
+    for c in pipeline.chars() {
+        match c {
+            'Y' | 'g' | 's' | 'S' | 'u' => {}
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "unsupported gfasort pipeline step '{other}' in '{pipeline}' (expected any of: Y, g, s, S, u)"
+                    ),
+                ));
+            }
+        }
+    }
 
-    // Sort the graph using Ygs pipeline (path-guided SGD + grooming + topological sort)
-    ygs_sort(&mut graph, &params);
+    // Create Ygs parameters from the initial graph, matching the gfasort CLI.
+    let params = YgsParams::from_graph(&graph, 0, num_threads);
+    let sgd_params = params.path_sgd.clone();
+
+    if pipeline == "Ygs" {
+        ygs_sort(&mut graph, &params);
+    } else {
+        for c in pipeline.chars() {
+            match c {
+                'Y' => sgd_sort_only(&mut graph, sgd_params.clone(), 0),
+                'g' => groom_only(&mut graph, 0),
+                's' => topological_sort_only(&mut graph, 0),
+                'S' => priority_topological_sort_only(&mut graph, 0),
+                'u' => unchop_only(&mut graph, 0),
+                _ => unreachable!("gfasort pipeline was validated"),
+            }
+        }
+    }
 
     // Write sorted GFA to string
     let mut sorted_output = Vec::new();
@@ -786,6 +829,10 @@ pub fn sort_gfa(gfa_content: &str, num_threads: usize) -> io::Result<String> {
             format!("Invalid UTF-8 in sorted GFA: {}", e),
         )
     })
+}
+
+pub fn sort_gfa_yg(gfa_content: &str, num_threads: usize) -> io::Result<String> {
+    sort_gfa_pipeline(gfa_content, "Yg", num_threads)
 }
 
 /// Run gfaffix graph normalization on a GFA string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ pub enum GfaEngine {
     SyngNative,
 }
 
+pub const DEFAULT_SYNG_GFA_SORT_PIPELINE: &str = "Ygs";
+
 /// Resolved engine configuration passed to subcommand functions.
 pub struct EngineOpts {
     pub engine: GfaEngine,
@@ -74,6 +76,10 @@ pub struct EngineOpts {
     pub partition_size: Option<usize>,
     /// Optional exact path-preserving blunt-graph resolution pass.
     pub crush_config: Option<resolution::ResolutionConfig>,
+    /// Optional final gfasort pipeline, e.g. `Ygs` or `Yg`. Currently enabled
+    /// by default for syng-native GFA output and disabled for already-normalized
+    /// alignment engines.
+    pub graph_sort_pipeline: Option<String>,
 }
 
 /// Minimal ImpgIndex wrapper around a SequenceIndex for syng query path.
@@ -630,21 +636,33 @@ pub fn dispatch_gfa_engine(
 }
 
 fn apply_graph_transforms(
-    gfa: String,
+    mut gfa: String,
     engine_opts: &EngineOpts,
 ) -> std::io::Result<String> {
-    let Some(config) = &engine_opts.crush_config else {
-        return Ok(gfa);
-    };
-    let resolved = resolution::resolve_gfa_bubbles(&gfa, config)?;
-    log::info!(
-        "crush: {} resolved, {} bailed, {} candidates seen across {} rounds",
-        resolved.stats.resolved,
-        resolved.stats.bailed,
-        resolved.stats.candidates_seen,
-        resolved.stats.iterations
-    );
-    Ok(resolved.gfa)
+    if let Some(config) = &engine_opts.crush_config {
+        let resolved = resolution::resolve_gfa_bubbles(&gfa, config)?;
+        log::info!(
+            "crush: {} resolved, {} bailed, {} candidates seen across {} rounds",
+            resolved.stats.resolved,
+            resolved.stats.bailed,
+            resolved.stats.candidates_seen,
+            resolved.stats.iterations
+        );
+        gfa = resolved.gfa;
+    }
+
+    if let Some(pipeline) = &engine_opts.graph_sort_pipeline {
+        let t0 = std::time::Instant::now();
+        let sorted = graph::sort_gfa_pipeline(&gfa, pipeline, engine_opts.pipeline.num_threads)?;
+        log::info!(
+            "gfasort: pipeline '{}' sorted graph in {:.3}s",
+            pipeline,
+            t0.elapsed().as_secs_f64()
+        );
+        Ok(sorted)
+    } else {
+        Ok(gfa)
+    }
 }
 
 /// Convert an in-memory GFA string to VCF using the native Rust POVU path.
@@ -1199,6 +1217,7 @@ P\talt\t1+,3+,4+\t*
             poa_padding_fraction: 0.001,
             partition_size: None,
             crush_config: Some(resolution::ResolutionConfig::default()),
+            graph_sort_pipeline: None,
         };
         let out = super::apply_graph_transforms(gfa.to_string(), &opts).unwrap();
         let after = resolution::path_sequences(&out).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2153,6 +2153,7 @@ struct ParsedGfaEngine {
     syng_gfa_mode: Option<SyngGfaMode>,
     syng_params: Option<impg::syng::SyncmerParams>,
     crush_config: Option<impg::resolution::ResolutionConfig>,
+    graph_sort_pipeline: Option<String>,
 }
 
 fn set_syng_gfa_mode(
@@ -2304,6 +2305,60 @@ fn parse_crush_stage(
         ));
     }
     Ok(config)
+}
+
+fn parse_graph_sort_stage(
+    raw: &str,
+    stage: &GraphPipelineStage,
+) -> io::Result<Option<String>> {
+    let mut pipeline = Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE.to_string());
+    for param in &stage.params {
+        match param.key.as_str() {
+            "mode" | "pipeline" => {
+                let value = param.value.trim();
+                if matches!(
+                    value.to_ascii_lowercase().as_str(),
+                    "none" | "no" | "off" | "false" | "unsorted" | "nosort" | "no-sort"
+                ) {
+                    pipeline = None;
+                } else {
+                    validate_gfasort_pipeline_param(raw, value)?;
+                    pipeline = Some(value.to_string());
+                };
+            }
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Invalid --gfa-engine '{}': unknown sort parameter '{}'",
+                        raw, other
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(pipeline)
+}
+
+fn validate_gfasort_pipeline_param(raw: &str, value: &str) -> io::Result<()> {
+    if value.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid --gfa-engine '{}': sort pipeline is empty", raw),
+        ));
+    }
+    for c in value.chars() {
+        if !matches!(c, 'Y' | 'g' | 's' | 'S' | 'u') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid --gfa-engine '{}': unsupported sort pipeline step '{}' in '{}' (expected any of: Y, g, s, S, u)",
+                    raw, c, value
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn parse_syng_assertion_params(
@@ -2493,6 +2548,11 @@ impl EngineCliOpts {
         let mut syncmer_seed: Option<u32> = None;
         let mut saw_syng_param = false;
         let mut crush_config = None;
+        let mut graph_sort_pipeline = if is_syng {
+            Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE.to_string())
+        } else {
+            None
+        };
 
         parse_engine_stage_params(
             raw,
@@ -2528,6 +2588,21 @@ impl EngineCliOpts {
                         ));
                     }
                     crush_config = Some(parse_crush_stage(raw, stage)?);
+                }
+                "sort" if is_syng => {
+                    graph_sort_pipeline = parse_graph_sort_stage(raw, stage)?;
+                }
+                "nosort" | "no-sort" | "unsorted" if is_syng => {
+                    if !stage.params.is_empty() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!(
+                                "Invalid --gfa-engine '{}': '{}' does not take parameters",
+                                raw, stage.name
+                            ),
+                        ));
+                    }
+                    graph_sort_pipeline = None;
                 }
                 stage_name if !is_syng && stage.params.is_empty() => {
                     partition_size = Some(parse_window(stage_name)?);
@@ -2574,6 +2649,7 @@ impl EngineCliOpts {
             syng_gfa_mode,
             syng_params,
             crush_config,
+            graph_sort_pipeline,
         })
     }
 
@@ -2660,6 +2736,7 @@ impl EngineCliOpts {
             parsed.syng_gfa_mode,
             parsed.syng_params,
             parsed.crush_config,
+            parsed.graph_sort_pipeline,
         )
     }
 }
@@ -3473,9 +3550,10 @@ Syng notes:
   With -a/--alignment pointing to a syng index, supported query outputs are
   bed, bedpe, gfa, vcf, fasta, and gbwt. Use -o gfa for a local sequence GFA from
   query-selected intervals. `--gfa-engine syng` emits a syng syncmer GFA and
-  defaults to syng:blunt; use syng:raw to preserve native overlaps. The compact
-  forms `-o gfa:syng:blunt,k=63,s=8,seed=7`, `-o gfa:syng:crush`,
-  and `-o vcf:syng` are accepted
+  defaults to syng:blunt plus gfasort pipeline Ygs; use syng:raw to preserve
+  native overlaps and `:nosort` to skip final ordering. The compact forms
+  `-o gfa:syng:blunt,k=63,s=8,seed=7`, `-o gfa:syng:crush`,
+  `-o gfa:syng:crush:sort,pipeline=Yg`, and `-o vcf:syng` are accepted
   as shorthand. Use
   `impg syng2gfa` to dump the whole syng syncmer graph instead.
 
@@ -4514,7 +4592,10 @@ fn run() -> io::Result<()> {
                     None
                 };
 
-                let engine_config = engine_cli.build(common.threads.get())?;
+                let mut engine_config = engine_cli.build(common.threads.get())?;
+                if output_format != "gfa" {
+                    engine_config.graph_sort_pipeline = None;
+                }
                 let wrapper = {
                     let base = impg::SyngImpgWrapper::new(syng_index, seq_index, syng_padding);
                     if syng_min_chain_anchors > 0 {
@@ -4568,7 +4649,10 @@ fn run() -> io::Result<()> {
             )?;
 
             // Build engine config (resolves temp_dir and sparsify internally)
-            let engine_config = engine_cli.build(common.threads.get())?;
+            let mut engine_config = engine_cli.build(common.threads.get())?;
+            if output_format != "gfa" {
+                engine_config.graph_sort_pipeline = None;
+            }
 
             // Initialize impg after validation
             let impg = initialize_index(
@@ -4892,7 +4976,10 @@ fn run() -> io::Result<()> {
                             }
                         }
                         "gfa" | "vcf" => {
-                            let engine_opts = engine_cli.build(common.threads.get())?;
+                            let mut engine_opts = engine_cli.build(common.threads.get())?;
+                            if resolved_format != "gfa" {
+                                engine_opts.graph_sort_pipeline = None;
+                            }
                             let output_ext = graph_output_extension(resolved_format);
                             let reference_names = vcf_reference_names(name, target_name);
 
@@ -7722,6 +7809,7 @@ fn build_engine_opts(
     syng_gfa_mode: Option<SyngGfaMode>,
     syng_params: Option<impg::syng::SyncmerParams>,
     crush_config: Option<impg::resolution::ResolutionConfig>,
+    graph_sort_pipeline: Option<String>,
 ) -> io::Result<EngineOpts> {
     let pipeline = graph::GraphBuildConfig {
         num_threads,
@@ -7761,6 +7849,7 @@ fn build_engine_opts(
         pipeline,
         partition_size,
         crush_config,
+        graph_sort_pipeline,
         target_poa_lengths: smooth.parse_target_poa_lengths()?,
         max_node_length: smooth.max_node_length,
         poa_padding_fraction: smooth.poa_padding_fraction,
@@ -10487,9 +10576,11 @@ mod tests {
             "For BED graph output (`-b regions.bed -o gfa|vcf|gbwt`)",
             "named from BED column 4",
             "`--gfa-engine syng` emits a syng syncmer GFA",
-            "defaults to syng:blunt; use syng:raw",
+            "defaults to syng:blunt plus gfasort pipeline Ygs",
+            "`:nosort` to skip final ordering",
             "-o gfa:syng:blunt,k=63,s=8,seed=7",
             "-o gfa:syng:crush",
+            "-o gfa:syng:crush:sort,pipeline=Yg",
             "-o vcf:syng",
             "-o gfa:wfmash:seqwish",
             "`impg syng2gfa` to dump the whole syng syncmer graph",
@@ -10520,6 +10611,10 @@ mod tests {
                 assert_eq!(parsed.engine, GfaEngine::SyngNative);
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
                 assert_eq!(parsed.syng_params, None);
+                assert_eq!(
+                    parsed.graph_sort_pipeline.as_deref(),
+                    Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE)
+                );
             }
             _ => panic!("expected query command"),
         }
@@ -10543,6 +10638,10 @@ mod tests {
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.engine, GfaEngine::SyngNative);
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Raw));
+                assert_eq!(
+                    parsed.graph_sort_pipeline.as_deref(),
+                    Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE)
+                );
                 assert_eq!(
                     parsed.syng_params,
                     Some(impg::syng::SyncmerParams { k: 8, w: 55, seed: 7 })
@@ -10575,6 +10674,10 @@ mod tests {
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
                 assert_eq!(
+                    parsed.graph_sort_pipeline.as_deref(),
+                    Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE)
+                );
+                assert_eq!(
                     parsed.syng_params,
                     Some(impg::syng::SyncmerParams { k: 8, w: 55, seed: 7 })
                 );
@@ -10606,6 +10709,10 @@ mod tests {
                 assert_eq!(engine_cli.engine_raw, "syng,k=63,s=8,seed=7:blunt");
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                assert_eq!(
+                    parsed.graph_sort_pipeline.as_deref(),
+                    Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE)
+                );
                 assert_eq!(
                     parsed.syng_params,
                     Some(impg::syng::SyncmerParams { k: 8, w: 55, seed: 7 })
@@ -10642,6 +10749,10 @@ mod tests {
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.engine, GfaEngine::SyngNative);
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                assert_eq!(
+                    parsed.graph_sort_pipeline.as_deref(),
+                    Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE)
+                );
                 let crush = parsed.crush_config.unwrap();
                 assert_eq!(crush.method, impg::resolution::ResolutionMethod::Biwfa);
                 assert_eq!(crush.max_bubble_span, 0);
@@ -10672,6 +10783,10 @@ mod tests {
                 let parsed = engine_cli.parse_engine().unwrap();
                 assert_eq!(parsed.engine, GfaEngine::SyngNative);
                 assert_eq!(parsed.syng_gfa_mode, Some(SyngGfaMode::Blunt));
+                assert_eq!(
+                    parsed.graph_sort_pipeline.as_deref(),
+                    Some(impg::DEFAULT_SYNG_GFA_SORT_PIPELINE)
+                );
                 let crush = parsed.crush_config.unwrap();
                 assert_eq!(crush.method, impg::resolution::ResolutionMethod::Auto);
                 assert_eq!(crush.max_bubble_span, 0);
@@ -10681,6 +10796,62 @@ mod tests {
                 assert_eq!(crush.max_iterations, 1);
                 assert_eq!(crush.polish_iterations, 1);
                 assert_eq!(crush.polish_max_median_traversal_len, 256);
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_accepts_syng_sort_stage() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:crush:sort,pipeline=sYgs",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.graph_sort_pipeline.as_deref(), Some("sYgs"));
+                assert!(parsed.crush_config.is_some());
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_accepts_syng_nosort_stage() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:crush:nosort",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                let parsed = engine_cli.parse_engine().unwrap();
+                assert_eq!(parsed.graph_sort_pipeline, None);
+                assert!(parsed.crush_config.is_some());
             }
             _ => panic!("expected query command"),
         }


### PR DESCRIPTION
## Summary
- add an internal gfasort pipeline pass for syng GFA query/partition output
- default syng GFA sorting to pipeline `Ygs`, with `:sort,pipeline=<PIPELINE>` and `:nosort` controls
- document the syng GFA query/crush/sort CLI patterns

## Validation
- cargo check
- cargo test gfa_output_format
- cargo test syng_gfa --test test_syng_integration
- cargo build --release
- cargo install --path . --force

## AMY measurement
- existing AMY syng crush GFA: 73,402 segments, 83,193 edges, 470 paths
- gfasort `Yg`: 52.9s wall, 26 GB RSS
- gfasort `Ygs`: 5:13.8 wall, 26 GB RSS
- gfalook render from `Ygs`: 4.6s wall