### PR TITLE
Use adaptive syng chain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,17 @@ relative to cwd, so either `cd` to the index directory or pass an absolute
 path. For a focused syng-backed local GFA recipe, see
 [`docs/syng-gfa-query.md`](docs/syng-gfa-query.md).
 
+For graph outputs, `query -o gfa|vcf --render-graph` also renders the final
+1D graph with `gfalook`. The default image is PNG beside the `-O` output prefix
+(`<prefix>.png`); `--render-graph-output` overrides the image path, and
+`--render-graph-format svg` or a `.svg` suffix emits SVG. With `-b regions.bed`
+graph output, `-O` is a directory for the graph files and the render output is
+written per BED row using the sanitized BED column 4 name.
+
+If you already have a local GFA, call variants directly with POVU via
+`impg gfa2vcf -g local.gfa -o local.vcf -r ref_path`. This is the same
+GFA-to-VCF conversion used internally by `query -o vcf` and `partition -o vcf`.
+
 ## GFA engines
 
 The `graph`, `query -o gfa`, and `partition -o gfa` commands share

--- a/README.md
+++ b/README.md
@@ -412,8 +412,9 @@ fails.
 Default query mode runs BiWFA boundary refinement and so requires
 `--sequence-files`. Pass `--syng-raw` for the raw syncmer-resolution
 pass-through. Tune via `--syng-padding`, `--syng-min-chain-anchors`
-(lower -> more paralog hits; default `2` is conservative on duplicated
-loci like C4), `--syng-min-chain-fraction` (default `0.5`; set `0` for
+(lower -> more paralog hits; default is an adaptive cap derived from
+query length, syncmer density, and expected exact-syncmer survival at
+95% identity), `--syng-min-chain-fraction` (default `0.5`; set `0` for
 exploratory local-chain discovery), and the seed-frequency filters
 `--syng-seed-max-occurrences` / `--syng-seed-drop-top-fraction`.
 By default syng query drops the top 0.05% most frequent query-local seed

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -159,11 +159,12 @@ coordinate guard rather than the main runtime budget.
 default until the POASTA GFA export path is proven to preserve clipped `W`
 walks exactly through impg's rewrite step.
 
-`method=biwfa` is the coarse condenser path. It runs full-length BiWFA on a
-tree/neighbor/random sparse pair set for the selected POVU bubble traversals,
-feeds those PAF alignments to seqwish, then runs one small-scale SPOA polish
-pass over the induced replacement graph. The two scales are intentionally
-separate: `max-median-traversal-len` controls which biological bubble
-traversals may be induced by BiWFA/seqwish, while
+`method=biwfa` is the coarse condenser path. It aligns every selected POVU
+bubble traversal end-to-end against the longest traversal with BiWFA, induces a
+path-preserving in-memory column graph from those root alignments, then runs one
+small-scale SPOA polish pass over the induced replacement graph. This avoids a
+seqwish transitive-closure step inside bounded bubble replacement. The two
+scales are intentionally separate: `max-median-traversal-len` controls which
+biological bubble traversals may be induced by BiWFA, while
 `polish-max-median-traversal-len` controls the tiny STR/indel tangles we are
 willing to clean inside that induced graph.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -44,6 +44,27 @@ impg query \
 
 This writes `c4.query.gfa`.
 
+Add `--render-graph` to also write a 1D `gfalook` rendering of the final graph:
+
+```bash
+impg query \
+  -a panel.syng \
+  -r 'GRCh38#0#chr6:31982056-32035418' \
+  -d 50k \
+  -x \
+  -o gfa:syng:crush \
+  --sequence-files panel.agc \
+  --force-large-region \
+  --render-graph \
+  -O c4.syng-crush
+```
+
+This writes `c4.syng-crush.gfa` and `c4.syng-crush.png`. PNG is the default;
+use `--render-graph-format svg` or `--render-graph-output c4.svg` for SVG.
+The renderer consumes the final graph after the configured graph transforms,
+so syng output is rendered after the default `Ygs` sort unless `:nosort` is
+explicitly requested.
+
 Important flags:
 
 - `-d 50k` is required. It merges query-gathered ranges separated by at most
@@ -70,6 +91,10 @@ impg query \
   --force-large-region \
   -O regions
 ```
+
+With `--render-graph`, images are written per BED row as well. By default they
+go beside the graph outputs under `regions`; `--render-graph-output renders`
+uses a separate render directory. Filenames are sanitized from BED column 4.
 
 BED rows use the syng path name in column 1:
 
@@ -196,6 +221,15 @@ impg crush -g local.blunt.gfa -o local.crushed.gfa
 VCF output uses the same engine dispatch and passes the local GFA to POVU:
 `-o vcf:syng`, `-o vcf:pggb`, `-o vcf:seqwish`, and `-o vcf:poa` are
 equivalent to `-o vcf --gfa-engine <engine>`.
+
+If the graph already exists, call POVU directly through impg:
+
+```bash
+impg gfa2vcf -g c4.syng-crush.gfa -o c4.syng-crush.vcf -r ref_path_name
+```
+
+`-r/--reference-name` is a path/name hint for POVU and can be repeated. This
+uses the same Rust POVU conversion as `query -o vcf`.
 
 ## Raw Syng Graph Dump
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,9 +284,10 @@ impl SyngImpgWrapper {
             syncmer_len,
         );
         let query_range_len = (range_end - range_start).max(0) as u64;
-        let effective_min = syng_transitive::effective_min_chain_anchors(
+        let effective_min = syng_transitive::effective_min_chain_anchors_for_syncmer(
             query_range_len,
             syncmer_len,
+            self.syng_index.params.k as u64,
             min_anchors,
         );
         let min_extent_bp = (query_range_len as f64 * min_fraction.max(0.0)) as u64;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::num::NonZeroUsize;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{
     atomic::{AtomicU64, AtomicUsize, Ordering},
     Arc,
@@ -2146,6 +2147,53 @@ struct EngineCliOpts {
     debug_dir: Option<String>,
 }
 
+/// Optional 1D graph rendering for query GFA/VCF outputs.
+#[derive(Parser, Debug, Clone)]
+#[command(next_help_heading = "Graph rendering")]
+struct GraphRenderOpts {
+    /// Render the final query graph with gfalook. Defaults to PNG beside the
+    /// graph output when -O is set; use --render-graph-output to override.
+    #[clap(long, action)]
+    render_graph: bool,
+
+    /// Output image file or, for BED graph output, output directory. Extension
+    /// selects png/svg; extensionless paths use --render-graph-format.
+    #[clap(long, value_parser)]
+    render_graph_output: Option<String>,
+
+    /// Default render image format when the render path has no .png/.svg extension.
+    #[clap(long, value_parser = parse_graph_render_format, default_value = "png")]
+    render_graph_format: String,
+
+    /// Render width in pixels.
+    #[clap(long, value_parser, default_value_t = 3200)]
+    render_graph_width: u32,
+
+    /// Render height in pixels.
+    #[clap(long, value_parser, default_value_t = 1800)]
+    render_graph_height: u32,
+
+    /// Pixel height for each path row.
+    #[clap(long, value_parser, default_value_t = 3)]
+    render_graph_path_height: u32,
+}
+
+impl GraphRenderOpts {
+    fn requested(&self) -> bool {
+        self.render_graph || self.render_graph_output.is_some()
+    }
+}
+
+fn parse_graph_render_format(value: &str) -> Result<String, String> {
+    let value = value.trim().to_ascii_lowercase();
+    match value.as_str() {
+        "png" | "svg" => Ok(value),
+        _ => Err(format!(
+            "invalid graph render format '{value}' (expected png or svg)"
+        )),
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ParsedGfaEngine {
     engine: GfaEngine,
@@ -3545,6 +3593,10 @@ Output formats:
 
 For BED graph output (`-b regions.bed -o gfa|vcf|gbwt`), `-O` is an output
 directory and each BED row is written to its own file named from BED column 4.
+Use `--render-graph` with `-o gfa|vcf` to also write a gfalook 1D rendering
+of the final graph. PNG is the default; use `--render-graph-format svg` or a
+`.svg` output path for SVG. With BED graph output the render output is a
+directory and receives one image per BED row.
 
 Syng notes:
   With -a/--alignment pointing to a syng index, supported query outputs are
@@ -3681,6 +3733,9 @@ GFA engine shorthand:
 
         #[clap(flatten)]
         engine_cli: EngineCliOpts,
+
+        #[clap(flatten)]
+        graph_render: GraphRenderOpts,
 
         // --- General ---
         #[clap(flatten)]
@@ -4061,6 +4116,26 @@ GFA engine shorthand:
         /// Resolver method: auto, poa, poasta, or biwfa
         #[clap(long, value_parser, default_value = "auto")]
         method: String,
+
+        #[clap(flatten)]
+        common: CommonOpts,
+    },
+
+    /// Call VCF variants from an existing GFA using POVU
+    #[command(alias = "gfa-to-vcf", alias = "povu")]
+    Gfa2vcf {
+        /// Input GFA path, or '-' for stdin
+        #[clap(short = 'g', long, value_parser)]
+        gfa: String,
+
+        /// Output VCF path, or '-' for stdout
+        #[clap(short = 'o', long, value_parser, default_value = "-")]
+        output: String,
+
+        /// Reference path/name hint for POVU. May be repeated; if omitted,
+        /// POVU uses its default reference selection.
+        #[clap(short = 'r', long = "reference-name", alias = "ref", value_parser)]
+        reference_names: Vec<String>,
 
         #[clap(flatten)]
         common: CommonOpts,
@@ -4706,6 +4781,7 @@ fn run() -> io::Result<()> {
             output_prefix,
             gfa_maf_fasta,
             engine_cli,
+            graph_render,
         } => {
             initialize_threads_and_log(&common);
             let mut engine_cli = engine_cli;
@@ -4777,6 +4853,12 @@ fn run() -> io::Result<()> {
                             "syng index queries currently support 'bed', 'bedpe', 'gfa', 'vcf', 'fasta', and 'gbwt' output formats, not '{}'",
                             resolved_format
                         ),
+                    ));
+                }
+                if graph_render.requested() && !matches!(resolved_format, "gfa" | "vcf") {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--render-graph is only supported with query graph output (-o gfa or -o vcf)",
                     ));
                 }
 
@@ -5028,12 +5110,16 @@ fn run() -> io::Result<()> {
                                 );
 
                                 if query_intervals.is_empty() {
-                                    let mut out = find_output_stream(&target_output_prefix, output_ext)?;
-                                    write_graph_output(
-                                        String::from("H\tVN:Z:1.0\n"),
+                                    write_graph_output_and_render(
+                                        "H\tVN:Z:1.0\n",
                                         resolved_format,
-                                        &mut out,
+                                        &target_output_prefix,
+                                        output_ext,
                                         &reference_names,
+                                        &graph_render,
+                                        bed_graph_dir.as_deref(),
+                                        name,
+                                        common.threads.get(),
                                     )?;
                                     info!(
                                         "Syng query complete: {} ({}:{}-{}) in {}",
@@ -5053,12 +5139,16 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&target_output_prefix, output_ext)?;
-                                write_graph_output(
-                                    gfa_output,
+                                write_graph_output_and_render(
+                                    &gfa_output,
                                     resolved_format,
-                                    &mut out,
+                                    &target_output_prefix,
+                                    output_ext,
                                     &reference_names,
+                                    &graph_render,
+                                    bed_graph_dir.as_deref(),
+                                    name,
+                                    common.threads.get(),
                                 )?;
                             } else if let Some(partition_size) = engine_opts.partition_size {
                                 // ─── Sub-windowed path: syng-at-the-outer-level ───
@@ -5119,12 +5209,16 @@ fn run() -> io::Result<()> {
                                 }
 
                                 if partitions.is_empty() {
-                                    let mut out = find_output_stream(&target_output_prefix, output_ext)?;
-                                    write_graph_output(
-                                        String::from("H\tVN:Z:1.0\n"),
+                                    write_graph_output_and_render(
+                                        "H\tVN:Z:1.0\n",
                                         resolved_format,
-                                        &mut out,
+                                        &target_output_prefix,
+                                        output_ext,
                                         &reference_names,
+                                        &graph_render,
+                                        bed_graph_dir.as_deref(),
+                                        name,
+                                        common.threads.get(),
                                     )?;
                                     info!(
                                         "Syng query complete: {} ({}:{}-{}) in {}",
@@ -5144,12 +5238,16 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&target_output_prefix, output_ext)?;
-                                write_graph_output(
-                                    gfa_output,
+                                write_graph_output_and_render(
+                                    &gfa_output,
                                     resolved_format,
-                                    &mut out,
+                                    &target_output_prefix,
+                                    output_ext,
                                     &reference_names,
+                                    &graph_render,
+                                    bed_graph_dir.as_deref(),
+                                    name,
+                                    common.threads.get(),
                                 )?;
                             } else {
                                 // ─── Flat path: one query_region, one engine run ───
@@ -5183,12 +5281,16 @@ fn run() -> io::Result<()> {
                                 );
 
                                 if query_intervals.is_empty() {
-                                    let mut out = find_output_stream(&target_output_prefix, output_ext)?;
-                                    write_graph_output(
-                                        String::from("H\tVN:Z:1.0\n"),
+                                    write_graph_output_and_render(
+                                        "H\tVN:Z:1.0\n",
                                         resolved_format,
-                                        &mut out,
+                                        &target_output_prefix,
+                                        output_ext,
                                         &reference_names,
+                                        &graph_render,
+                                        bed_graph_dir.as_deref(),
+                                        name,
+                                        common.threads.get(),
                                     )?;
                                     info!(
                                         "Syng query complete: {} ({}:{}-{}) in {}",
@@ -5208,12 +5310,16 @@ fn run() -> io::Result<()> {
                                     scoring_params,
                                     &engine_opts,
                                 )?;
-                                let mut out = find_output_stream(&target_output_prefix, output_ext)?;
-                                write_graph_output(
-                                    gfa_output,
+                                write_graph_output_and_render(
+                                    &gfa_output,
                                     resolved_format,
-                                    &mut out,
+                                    &target_output_prefix,
+                                    output_ext,
                                     &reference_names,
+                                    &graph_render,
+                                    bed_graph_dir.as_deref(),
+                                    name,
+                                    common.threads.get(),
                                 )?;
                             }
                         }
@@ -5442,6 +5548,12 @@ fn run() -> io::Result<()> {
             } else {
                 output_format.as_str()
             };
+            if graph_render.requested() && !matches!(resolved_output_format, "gfa" | "vcf") {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--render-graph is only supported with query graph output (-o gfa or -o vcf)",
+                ));
+            }
 
             // Validate --approximate mode output format compatibility
             if query.approximate
@@ -5556,7 +5668,7 @@ fn run() -> io::Result<()> {
                             // Partitioned mode: split query region into sub-windows
                             output_results_gfa_partitioned(
                                 &impg,
-                                &mut find_output_stream(&target_output_prefix, "gfa")?,
+                                &target_output_prefix,
                                 sequence_index.as_ref().unwrap(),
                                 scoring_params,
                                 &engine_opts,
@@ -5565,18 +5677,25 @@ fn run() -> io::Result<()> {
                                 ps,
                                 &query,
                                 subset_filter.as_ref(),
+                                &graph_render,
+                                bed_graph_dir.as_deref(),
+                                &name,
+                                common.threads.get(),
                             )?;
                         } else {
                             output_results_gfa(
                                 &impg,
                                 &mut results,
-                                &mut find_output_stream(&target_output_prefix, "gfa")?,
+                                &target_output_prefix,
                                 sequence_index.as_ref().unwrap(),
                                 &name,
                                 query.effective_merge_distance(),
                                 query.merge_strands_for_output("gfa"),
                                 scoring_params,
                                 &engine_opts,
+                                &graph_render,
+                                bed_graph_dir.as_deref(),
+                                common.threads.get(),
                             )?;
                         }
                     }
@@ -5586,7 +5705,7 @@ fn run() -> io::Result<()> {
                         if let Some(ps) = engine_opts.partition_size {
                             output_results_vcf_partitioned(
                                 &impg,
-                                &mut find_output_stream(&target_output_prefix, "vcf")?,
+                                &target_output_prefix,
                                 sequence_index.as_ref().unwrap(),
                                 scoring_params,
                                 &engine_opts,
@@ -5596,18 +5715,26 @@ fn run() -> io::Result<()> {
                                 &query,
                                 subset_filter.as_ref(),
                                 &reference_names,
+                                &name,
+                                &graph_render,
+                                bed_graph_dir.as_deref(),
+                                common.threads.get(),
                             )?;
                         } else {
                             output_results_vcf(
                                 &impg,
                                 &mut results,
-                                &mut find_output_stream(&target_output_prefix, "vcf")?,
+                                &target_output_prefix,
                                 sequence_index.as_ref().unwrap(),
                                 &reference_names,
+                                &name,
                                 query.effective_merge_distance(),
                                 query.merge_strands_for_output("vcf"),
                                 scoring_params,
                                 &engine_opts,
+                                &graph_render,
+                                bed_graph_dir.as_deref(),
+                                common.threads.get(),
                             )?;
                         }
                     }
@@ -6753,6 +6880,34 @@ fn run() -> io::Result<()> {
             } else {
                 let mut out = BufWriter::with_capacity(1024 * 1024, File::create(&output)?);
                 out.write_all(resolved.gfa.as_bytes())?;
+                out.flush()?;
+            }
+        }
+        Args::Gfa2vcf {
+            gfa,
+            output,
+            reference_names,
+            common,
+        } => {
+            initialize_threads_and_log(&common);
+            let mut gfa_text = String::new();
+            if gfa == "-" {
+                io::stdin().read_to_string(&mut gfa_text)?;
+            } else {
+                File::open(&gfa)?.read_to_string(&mut gfa_text)?;
+            }
+
+            let vcf = impg::gfa_to_vcf_string(&gfa_text, &reference_names)?;
+            if output == "-" {
+                let stdout = io::stdout();
+                let mut out = BufWriter::with_capacity(1024 * 1024, stdout.lock());
+                out.write_all(vcf.as_bytes())?;
+                out.flush()?;
+            } else {
+                let output_path = Path::new(&output);
+                ensure_parent_dir(output_path)?;
+                let mut out = BufWriter::with_capacity(1024 * 1024, File::create(output_path)?);
+                out.write_all(vcf.as_bytes())?;
                 out.flush()?;
             }
         }
@@ -8144,13 +8299,28 @@ fn get_auto_reader(path: &str) -> io::Result<Box<dyn BufRead>> {
     Ok(Box::new(BufReader::new(reader)))
 }
 
+fn output_path_for_basename(basename: &Option<String>, extension: &str) -> Option<PathBuf> {
+    basename
+        .as_ref()
+        .map(|name| PathBuf::from(format!("{}.{}", name, extension)))
+}
+
+fn ensure_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
+}
+
 /// Helper function to return a Write implementer that is either standard output or a file with the
 /// appropriate basename and extension. When no basename is provided, uses standard output.
 fn find_output_stream(basename: &Option<String>, extension: &str) -> io::Result<Box<dyn Write>> {
-    match basename {
-        Some(name) => {
-            let filename = format!("{}.{}", name, extension);
-            let file = File::create(filename)?;
+    match output_path_for_basename(basename, extension) {
+        Some(path) => {
+            ensure_parent_dir(&path)?;
+            let file = File::create(path)?;
             Ok(Box::new(BufWriter::new(file)))
         }
         None => Ok(Box::new(BufWriter::new(io::stdout()))),
@@ -8238,15 +8408,156 @@ fn vcf_reference_names(range_name: &str, target_name: &str) -> Vec<String> {
 }
 
 fn write_graph_output(
-    mut gfa_output: String,
+    gfa_output: &str,
     output_format: &str,
     out: &mut dyn Write,
     reference_names: &[String],
 ) -> io::Result<()> {
     if output_format == "vcf" {
-        gfa_output = impg::gfa_to_vcf_string(&gfa_output, reference_names)?;
+        let vcf_output = impg::gfa_to_vcf_string(gfa_output, reference_names)?;
+        out.write_all(vcf_output.as_bytes())
+    } else {
+        out.write_all(gfa_output.as_bytes())
     }
-    out.write_all(gfa_output.as_bytes())
+}
+
+fn write_graph_output_and_render(
+    gfa_output: &str,
+    output_format: &str,
+    target_output_prefix: &Option<String>,
+    output_ext: &str,
+    reference_names: &[String],
+    graph_render: &GraphRenderOpts,
+    bed_graph_dir: Option<&Path>,
+    range_name: &str,
+    threads: usize,
+) -> io::Result<()> {
+    let output_path = output_path_for_basename(target_output_prefix, output_ext);
+    {
+        let mut out = find_output_stream(target_output_prefix, output_ext)?;
+        write_graph_output(gfa_output, output_format, &mut out, reference_names)?;
+        out.flush()?;
+    }
+
+    if let Some(render_path) =
+        graph_render_path_for_target(graph_render, target_output_prefix, bed_graph_dir, range_name)?
+    {
+        let gfa_input_path = if output_format == "gfa" {
+            output_path.as_deref()
+        } else {
+            None
+        };
+        render_graph_image(gfa_output, gfa_input_path, &render_path, graph_render, threads)?;
+    }
+    Ok(())
+}
+
+fn graph_render_path_for_target(
+    graph_render: &GraphRenderOpts,
+    output_prefix: &Option<String>,
+    bed_graph_dir: Option<&Path>,
+    range_name: &str,
+) -> io::Result<Option<PathBuf>> {
+    if !graph_render.requested() {
+        return Ok(None);
+    }
+
+    let mut path = if let Some(raw) = &graph_render.render_graph_output {
+        let raw_path = PathBuf::from(raw);
+        if bed_graph_dir.is_some() || raw_path.is_dir() || raw.ends_with(std::path::MAIN_SEPARATOR)
+        {
+            raw_path.join(sanitize_output_stem(range_name))
+        } else {
+            raw_path
+        }
+    } else if let Some(prefix) = output_prefix_for_target(output_prefix, bed_graph_dir, range_name) {
+        PathBuf::from(prefix)
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--render-graph needs -O/--output-prefix or --render-graph-output",
+        ));
+    };
+
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some(ext)
+            if ext.eq_ignore_ascii_case("png") || ext.eq_ignore_ascii_case("svg") => {}
+        _ => {
+            path.set_extension(&graph_render.render_graph_format);
+        }
+    }
+    ensure_parent_dir(&path)?;
+    Ok(Some(path))
+}
+
+fn render_graph_image(
+    gfa_output: &str,
+    gfa_input_path: Option<&Path>,
+    render_path: &Path,
+    graph_render: &GraphRenderOpts,
+    threads: usize,
+) -> io::Result<()> {
+    if !gfa_output.lines().any(|line| line.starts_with("S\t")) {
+        warn!(
+            "Skipping graph render to {} because the query graph has no segment records",
+            render_path.display()
+        );
+        return Ok(());
+    }
+
+    let mut temp_gfa = None;
+    let input_path = if let Some(path) = gfa_input_path {
+        path.to_path_buf()
+    } else {
+        let mut temp = tempfile::Builder::new()
+            .prefix("impg-render-")
+            .suffix(".gfa")
+            .tempfile()?;
+        temp.write_all(gfa_output.as_bytes())?;
+        temp.flush()?;
+        let path = temp.path().to_path_buf();
+        temp_gfa = Some(temp);
+        path
+    };
+
+    let t0 = Instant::now();
+    let status = Command::new("gfalook")
+        .arg("-i")
+        .arg(&input_path)
+        .arg("-o")
+        .arg(render_path)
+        .arg("-x")
+        .arg(graph_render.render_graph_width.to_string())
+        .arg("-y")
+        .arg(graph_render.render_graph_height.to_string())
+        .arg("-a")
+        .arg(graph_render.render_graph_path_height.to_string())
+        .arg("-t")
+        .arg(threads.max(1).to_string())
+        .status()
+        .map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "Could not run gfalook for --render-graph; install gfalook or omit --render-graph",
+                )
+            } else {
+                io::Error::other(format!("Failed to run gfalook: {e}"))
+            }
+        })?;
+    drop(temp_gfa);
+    if !status.success() {
+        return Err(io::Error::other(format!(
+            "gfalook failed while rendering {}",
+            render_path.display()
+        )));
+    }
+    info!(
+        "Rendered query graph image {} in {}",
+        render_path.display(),
+        format_duration(t0.elapsed())
+    );
+    Ok(())
 }
 
 /// Load/generate index based on common and alignment options
@@ -9236,13 +9547,16 @@ fn output_results_paf(
 fn output_results_gfa(
     impg: &impl ImpgIndex,
     results: &mut Vec<AdjustedInterval>,
-    out: &mut dyn Write,
+    target_output_prefix: &Option<String>,
     sequence_index: &UnifiedSequenceIndex,
-    _name: &str,
+    name: &str,
     merge_distance: i32,
     merge_strands: bool,
     scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
     engine_opts: &EngineOpts,
+    graph_render: &GraphRenderOpts,
+    bed_graph_dir: Option<&Path>,
+    threads: usize,
 ) -> io::Result<()> {
     // Merge intervals if needed
     merge_query_adjusted_intervals(results, merge_distance, merge_strands);
@@ -9260,21 +9574,33 @@ fn output_results_gfa(
         scoring_params,
         engine_opts,
     )?;
-    out.write_all(gfa_output.as_bytes())?;
-
-    Ok(())
+    write_graph_output_and_render(
+        &gfa_output,
+        "gfa",
+        target_output_prefix,
+        "gfa",
+        &[],
+        graph_render,
+        bed_graph_dir,
+        name,
+        threads,
+    )
 }
 
 fn output_results_vcf(
     impg: &impl ImpgIndex,
     results: &mut Vec<AdjustedInterval>,
-    out: &mut dyn Write,
+    target_output_prefix: &Option<String>,
     sequence_index: &UnifiedSequenceIndex,
     reference_names: &[String],
+    range_name: &str,
     merge_distance: i32,
     merge_strands: bool,
     scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
     engine_opts: &EngineOpts,
+    graph_render: &GraphRenderOpts,
+    bed_graph_dir: Option<&Path>,
+    threads: usize,
 ) -> io::Result<()> {
     merge_query_adjusted_intervals(results, merge_distance, merge_strands);
 
@@ -9290,10 +9616,17 @@ fn output_results_vcf(
         scoring_params,
         engine_opts,
     )?;
-    let vcf_output = impg::gfa_to_vcf_string(&gfa_output, reference_names)?;
-    out.write_all(vcf_output.as_bytes())?;
-
-    Ok(())
+    write_graph_output_and_render(
+        &gfa_output,
+        "vcf",
+        target_output_prefix,
+        "vcf",
+        reference_names,
+        graph_render,
+        bed_graph_dir,
+        range_name,
+        threads,
+    )
 }
 
 /// Partitioned GFA output for the query command: splits the query region into
@@ -9301,7 +9634,7 @@ fn output_results_vcf(
 /// GFA pipeline (per-partition engine → lace → gfaffix).
 fn output_results_gfa_partitioned(
     impg: &impl ImpgIndex,
-    out: &mut dyn Write,
+    target_output_prefix: &Option<String>,
     sequence_index: &UnifiedSequenceIndex,
     scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
     engine_opts: &EngineOpts,
@@ -9310,6 +9643,10 @@ fn output_results_gfa_partitioned(
     partition_size: usize,
     query: &QueryOpts,
     subset_filter: Option<&SubsetFilter>,
+    graph_render: &GraphRenderOpts,
+    bed_graph_dir: Option<&Path>,
+    range_name: &str,
+    threads: usize,
 ) -> io::Result<()> {
     let (start, end) = target_range;
     let ps = partition_size as i32;
@@ -9362,14 +9699,22 @@ fn output_results_gfa_partitioned(
         scoring_params,
         engine_opts,
     )?;
-    out.write_all(gfa_output.as_bytes())?;
-
-    Ok(())
+    write_graph_output_and_render(
+        &gfa_output,
+        "gfa",
+        target_output_prefix,
+        "gfa",
+        &[],
+        graph_render,
+        bed_graph_dir,
+        range_name,
+        threads,
+    )
 }
 
 fn output_results_vcf_partitioned(
     impg: &impl ImpgIndex,
-    out: &mut dyn Write,
+    target_output_prefix: &Option<String>,
     sequence_index: &UnifiedSequenceIndex,
     scoring_params: Option<(u8, u8, u8, u8, u8, u8)>,
     engine_opts: &EngineOpts,
@@ -9379,29 +9724,62 @@ fn output_results_vcf_partitioned(
     query: &QueryOpts,
     subset_filter: Option<&SubsetFilter>,
     reference_names: &[String],
+    range_name: &str,
+    graph_render: &GraphRenderOpts,
+    bed_graph_dir: Option<&Path>,
+    threads: usize,
 ) -> io::Result<()> {
-    let mut gfa = Vec::new();
-    output_results_gfa_partitioned(
+    let (start, end) = target_range;
+    let ps = partition_size as i32;
+    let mut partitions: Vec<Vec<Interval<u32>>> = Vec::new();
+    let mut window_start = start;
+    while window_start < end {
+        let window_end = (window_start + ps).min(end);
+        let mut results = perform_query(
+            impg,
+            target_name,
+            (window_start, window_end),
+            false,
+            query.min_result_identity,
+            query.min_output_length,
+            query.transitive,
+            query.transitive_opts.transitive_dfs,
+            &query.transitive_opts,
+            Some(sequence_index),
+            query.approximate,
+            subset_filter,
+        )?;
+        if !results.is_empty() {
+            merge_query_adjusted_intervals(
+                &mut results,
+                query.effective_merge_distance(),
+                query.merge_strands_for_output("gfa"),
+            );
+            let query_intervals: Vec<Interval<u32>> =
+                results.drain(..).map(|(qi, _, _)| qi).collect();
+            partitions.push(query_intervals);
+        }
+        window_start = window_end;
+    }
+
+    let gfa_output = impg::partitioned_gfa_pipeline(
+        &partitions,
         impg,
-        &mut gfa,
         sequence_index,
         scoring_params,
         engine_opts,
-        target_name,
-        target_range,
-        partition_size,
-        query,
-        subset_filter,
     )?;
-    let gfa_output = String::from_utf8(gfa).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("partitioned GFA output is not UTF-8: {e}"),
-        )
-    })?;
-    let vcf_output = impg::gfa_to_vcf_string(&gfa_output, reference_names)?;
-    out.write_all(vcf_output.as_bytes())?;
-    Ok(())
+    write_graph_output_and_render(
+        &gfa_output,
+        "vcf",
+        target_output_prefix,
+        "vcf",
+        reference_names,
+        graph_render,
+        bed_graph_dir,
+        range_name,
+        threads,
+    )
 }
 
 fn output_results_fasta(
@@ -10480,6 +10858,81 @@ mod tests {
             .is_none());
     }
 
+    fn test_graph_render_opts() -> GraphRenderOpts {
+        GraphRenderOpts {
+            render_graph: true,
+            render_graph_output: None,
+            render_graph_format: "png".to_string(),
+            render_graph_width: 800,
+            render_graph_height: 300,
+            render_graph_path_height: 4,
+        }
+    }
+
+    #[test]
+    fn test_graph_render_path_defaults_beside_output_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = Some(dir.path().join("amy").to_string_lossy().to_string());
+        let render = test_graph_render_opts();
+        let path = graph_render_path_for_target(&render, &prefix, None, "AMY locus")
+            .unwrap()
+            .unwrap();
+        assert_eq!(path, dir.path().join("amy.png"));
+    }
+
+    #[test]
+    fn test_graph_render_path_uses_bed_row_stems_under_render_dir() {
+        let out_dir = tempfile::tempdir().unwrap();
+        let graph_dir = tempfile::tempdir().unwrap();
+        let mut render = test_graph_render_opts();
+        render.render_graph = false;
+        render.render_graph_output = Some(out_dir.path().to_string_lossy().to_string());
+        let path = graph_render_path_for_target(
+            &render,
+            &Some("ignored".to_string()),
+            Some(graph_dir.path()),
+            "C4A/C4B locus",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(path, out_dir.path().join("C4A_C4B_locus.png"));
+    }
+
+    #[test]
+    fn test_graph_render_path_svg_extension_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut render = test_graph_render_opts();
+        render.render_graph_output = Some(dir.path().join("view.svg").to_string_lossy().to_string());
+        let path = graph_render_path_for_target(&render, &None, None, "x")
+            .unwrap()
+            .unwrap();
+        assert_eq!(path, dir.path().join("view.svg"));
+    }
+
+    #[test]
+    fn test_find_output_stream_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = Some(dir.path().join("nested/out").to_string_lossy().to_string());
+        {
+            let mut out = find_output_stream(&prefix, "bed").unwrap();
+            writeln!(out, "chr1\t0\t1").unwrap();
+        }
+        assert!(dir.path().join("nested/out.bed").exists());
+    }
+
+    #[test]
+    fn test_render_graph_image_with_gfalook_when_available() {
+        if Command::new("gfalook").arg("--help").output().is_err() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("tiny.png");
+        let render = test_graph_render_opts();
+        let gfa = "H\tVN:Z:1.0\nS\t1\tACGT\nP\tpath\t1+\t*\n";
+        render_graph_image(gfa, None, &out, &render, 1).unwrap();
+        assert!(out.metadata().unwrap().len() > 0);
+    }
+
     #[test]
     fn test_syng_gfa_intervals_are_merged_before_graph_build() {
         let mut seq_index = SequenceIndex::new();
@@ -10983,6 +11436,42 @@ mod tests {
             }
             _ => panic!("expected query command"),
         }
+    }
+
+    #[test]
+    fn test_gfa2vcf_cli_accepts_reference_names() {
+        let args = Args::try_parse_from([
+            "impg",
+            "gfa2vcf",
+            "-g",
+            "graph.gfa",
+            "-o",
+            "calls.vcf",
+            "-r",
+            "ref",
+            "--reference-name",
+            "GRCh38#0#chr1",
+        ])
+        .unwrap();
+        match args {
+            Args::Gfa2vcf {
+                gfa,
+                output,
+                reference_names,
+                ..
+            } => {
+                assert_eq!(gfa, "graph.gfa");
+                assert_eq!(output, "calls.vcf");
+                assert_eq!(reference_names, vec!["ref", "GRCh38#0#chr1"]);
+            }
+            _ => panic!("expected gfa2vcf command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_to_vcf_alias_parses() {
+        let args = Args::try_parse_from(["impg", "gfa-to-vcf", "-g", "-", "-o", "-"]).unwrap();
+        assert!(matches!(args, Args::Gfa2vcf { .. }));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3602,10 +3602,11 @@ GFA engine shorthand:
         syng_extend_budget: u64,
 
         /// Maximum adaptive minimum anchor count for a syng chain to be
-        /// emitted. The effective threshold scales with query span (roughly
-        /// one anchor per 5 kb, capped by this value). The default cap 20
-        /// requires support from multiple bounded GBWT-walk seed islands for
-        /// locus-scale queries without making short queries satisfy 20 anchors.
+        /// emitted. The effective threshold is estimated from query span,
+        /// syncmer density, and 95% identity, then capped by this value. The
+        /// default is a high ceiling, not a fixed floor, so short queries keep
+        /// a small support requirement while long repeat-dense loci require
+        /// multiple bounded GBWT-walk seed islands.
         /// Set 0 to disable anchor-count filtering.
         #[arg(help_heading = "Syng input")]
         #[clap(long, value_parser, default_value_t = impg::syng_transitive::DEFAULT_MIN_CHAIN_ANCHORS)]
@@ -4037,7 +4038,7 @@ GFA engine shorthand:
         #[clap(long, value_parser = parse_usize_size, default_value = "10k")]
         max_traversals: usize,
 
-        /// Small-tangle SPOA polish rounds after BiWFA/seqwish induction; 0 disables
+        /// Small-tangle SPOA polish rounds after BiWFA in-memory induction; 0 disables
         #[clap(long, alias = "polish-iterations", value_parser = parse_usize_size, default_value = "1")]
         polish_rounds: usize,
 

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -14,7 +14,6 @@ use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
 use std::io;
-use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 /// Configuration for exact path-preserving bubble resolution.
@@ -37,7 +36,7 @@ pub struct ResolutionConfig {
     pub max_total_sequence: usize,
     /// Maximum number of path-supported traversals through one replacement.
     pub max_traversals: usize,
-    /// One-pass small-tangle polish rounds after BiWFA/seqwish induction.
+    /// One-pass small-tangle polish rounds after BiWFA in-memory induction.
     ///
     /// This pass is deliberately scale-limited: small STR / indel tangles are
     /// implementation artifacts, while larger VNTR / recombination structures
@@ -66,7 +65,7 @@ impl ResolutionMethod {
             "auto" => Some(Self::Auto),
             "poa" | "spoa" => Some(Self::Poa),
             "poasta" => Some(Self::Poasta),
-            "biwfa" | "wfa" | "seqwish" | "biwfa-seqwish" | "allwave" => Some(Self::Biwfa),
+            "biwfa" | "wfa" => Some(Self::Biwfa),
             _ => None,
         }
     }
@@ -89,8 +88,6 @@ pub const DEFAULT_POLISH_MAX_TRAVERSAL_LEN: usize = 2_000;
 pub const DEFAULT_POLISH_MAX_MEDIAN_TRAVERSAL_LEN: usize = 256;
 pub const DEFAULT_POLISH_MAX_TOTAL_SEQUENCE: usize = 1_000_000;
 pub const DEFAULT_POLISH_MAX_TRAVERSALS: usize = 10_000;
-
-static SEQWISH_REPLACEMENT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 impl Default for ResolutionConfig {
     fn default() -> Self {
@@ -1087,7 +1084,7 @@ fn build_replacement(candidate: &BubbleCandidate, config: &ResolutionConfig) -> 
             log::debug!("POASTA replacement failed; falling back to SPOA: {err}");
             build_poa_replacement(candidate, config)
         }),
-        ResolutionMethod::Biwfa => build_biwfa_seqwish_replacement(candidate, config),
+        ResolutionMethod::Biwfa => build_biwfa_inmemory_replacement(candidate, config),
     }
 }
 
@@ -1215,7 +1212,13 @@ fn build_poasta_replacement(
     Ok(replacement)
 }
 
-fn build_biwfa_seqwish_replacement(
+#[derive(Clone, Debug)]
+struct StarAlignmentRow {
+    inserts: Vec<Vec<u8>>,
+    bases: Vec<Option<u8>>,
+}
+
+fn build_biwfa_inmemory_replacement(
     candidate: &BubbleCandidate,
     config: &ResolutionConfig,
 ) -> io::Result<Graph> {
@@ -1225,37 +1228,211 @@ fn build_biwfa_seqwish_replacement(
         .enumerate()
         .map(|(i, range)| format!("__impg_bubble_path{}_{}", range.path_idx, i))
         .collect();
-    let sequences = headers
+    let root_idx = candidate
+        .ranges
         .iter()
-        .cloned()
-        .zip(candidate.ranges.iter().map(|range| range.sequence.clone()))
-        .collect::<Vec<_>>();
+        .enumerate()
+        .max_by_key(|(_, range)| range.sequence.len())
+        .map(|(idx, _)| idx)
+        .ok_or_else(|| io::Error::other("BiWFA replacement has no traversals"))?;
+    let root = &candidate.ranges[root_idx].sequence;
+    let root_len = root.len();
 
-    let mut graph_config = crate::commands::graph::GraphBuildConfig::default();
-    graph_config.num_threads = rayon::current_num_threads().max(1);
-    graph_config.show_progress = false;
-    graph_config.no_filter = true;
-    graph_config.min_match_len = 1;
-    graph_config.repeat_max = 0;
-    graph_config.min_repeat_dist = 0;
-    graph_config.transclose_batch = 1_000_000;
+    let rows = candidate
+        .ranges
+        .iter()
+        .enumerate()
+        .map(|(idx, range)| {
+            if idx == root_idx {
+                Ok(root_alignment_row(root))
+            } else {
+                align_to_root_row(&headers[idx], &range.sequence, &headers[root_idx], root)
+            }
+        })
+        .collect::<io::Result<Vec<_>>>()?;
 
-    // seqwish keeps process-global tempfile state, so replacement graph
-    // induction must be serialized even while candidate discovery/materialize
-    // remains parallel. The expensive BiWFA pair alignment inside the helper is
-    // still rayon-parallel.
-    let lock = SEQWISH_REPLACEMENT_LOCK.get_or_init(|| Mutex::new(()));
-    let _guard = lock
-        .lock()
-        .map_err(|_| io::Error::other("seqwish replacement lock is poisoned"))?;
-    let gfa = crate::syng_graph::build_gfa_syng_native_from_sequences(&sequences, &graph_config)?;
-    drop(_guard);
+    let mut replacement = build_star_column_graph(&headers, &rows, root_len);
+    let has_empty_path = replacement.paths.iter().any(|path| path.steps.is_empty());
+    if !has_empty_path {
+        let compacted = unchop_gfa(&render_graph(&replacement))?;
+        replacement = parse_gfa(&compacted)?;
+        order_replacement_paths(&mut replacement, &headers)?;
+    }
 
-    let polished = polish_replacement_gfa(&gfa, config)?;
-    let mut replacement = parse_gfa(&polished)?;
-    order_replacement_paths(&mut replacement, &headers)?;
-    validate_replacement_paths(&replacement, candidate, "BiWFA/seqwish")?;
+    if !has_empty_path {
+        let polished = polish_replacement_gfa(&render_graph(&replacement), config)?;
+        replacement = parse_gfa(&polished)?;
+        order_replacement_paths(&mut replacement, &headers)?;
+    }
+    validate_replacement_paths(&replacement, candidate, "BiWFA/in-memory")?;
     Ok(replacement)
+}
+
+fn root_alignment_row(root: &[u8]) -> StarAlignmentRow {
+    StarAlignmentRow {
+        inserts: vec![Vec::new(); root.len() + 1],
+        bases: root.iter().map(|&base| Some(base)).collect(),
+    }
+}
+
+fn align_to_root_row(
+    query_name: &str,
+    query: &[u8],
+    root_name: &str,
+    root: &[u8],
+) -> io::Result<StarAlignmentRow> {
+    if root.is_empty() {
+        return Ok(StarAlignmentRow {
+            inserts: vec![query.to_vec()],
+            bases: Vec::new(),
+        });
+    }
+
+    if query.is_empty() {
+        return Ok(StarAlignmentRow {
+            inserts: vec![Vec::new(); root.len() + 1],
+            bases: vec![None; root.len()],
+        });
+    }
+
+    let paf = crate::syng_graph::pairwise_biwfa_paf(query_name, query, root_name, root)
+        .ok_or_else(|| io::Error::other("BiWFA root alignment failed"))?;
+    let cigar = paf_cigar(&paf)
+        .ok_or_else(|| io::Error::other("BiWFA root alignment did not emit cg:Z CIGAR"))?;
+    row_from_query_root_cigar(query, root.len(), cigar)
+}
+
+fn paf_cigar(paf: &str) -> Option<&str> {
+    paf.trim_end()
+        .split('\t')
+        .find_map(|field| field.strip_prefix("cg:Z:"))
+}
+
+fn row_from_query_root_cigar(
+    query: &[u8],
+    root_len: usize,
+    cigar: &str,
+) -> io::Result<StarAlignmentRow> {
+    let mut row = StarAlignmentRow {
+        inserts: vec![Vec::new(); root_len + 1],
+        bases: vec![None; root_len],
+    };
+    let mut q = 0usize;
+    let mut r = 0usize;
+    let mut len = 0usize;
+
+    for ch in cigar.bytes() {
+        if ch.is_ascii_digit() {
+            len = len
+                .checked_mul(10)
+                .and_then(|v| v.checked_add((ch - b'0') as usize))
+                .ok_or_else(|| io::Error::other("BiWFA CIGAR run length overflow"))?;
+            continue;
+        }
+        if len == 0 {
+            return Err(io::Error::other("BiWFA CIGAR has zero-length operation"));
+        }
+        match ch {
+            b'M' | b'=' | b'X' => {
+                if q + len > query.len() || r + len > root_len {
+                    return Err(io::Error::other("BiWFA CIGAR match overconsumes sequence"));
+                }
+                for _ in 0..len {
+                    row.bases[r] = Some(query[q]);
+                    q += 1;
+                    r += 1;
+                }
+            }
+            b'I' => {
+                if q + len > query.len() || r > root_len {
+                    return Err(io::Error::other("BiWFA CIGAR insertion overconsumes query"));
+                }
+                row.inserts[r].extend_from_slice(&query[q..q + len]);
+                q += len;
+            }
+            b'D' => {
+                if r + len > root_len {
+                    return Err(io::Error::other("BiWFA CIGAR deletion overconsumes root"));
+                }
+                r += len;
+            }
+            other => {
+                return Err(io::Error::other(format!(
+                    "BiWFA CIGAR contains unsupported op '{}'",
+                    other as char
+                )));
+            }
+        }
+        len = 0;
+    }
+
+    if len != 0 {
+        return Err(io::Error::other("BiWFA CIGAR ended before operation"));
+    }
+    if q != query.len() || r != root_len {
+        return Err(io::Error::other(format!(
+            "BiWFA CIGAR consumed query/root {q}/{r}, expected {}/{}",
+            query.len(),
+            root_len
+        )));
+    }
+    Ok(row)
+}
+
+fn build_star_column_graph(
+    headers: &[String],
+    rows: &[StarAlignmentRow],
+    root_len: usize,
+) -> Graph {
+    let mut segments = Vec::new();
+    let mut node_by_site_allele: FxHashMap<(usize, Vec<u8>), usize> = FxHashMap::default();
+    let get_node =
+        |site: usize,
+         seq: &[u8],
+         segments: &mut Vec<Segment>,
+         node_by_site_allele: &mut FxHashMap<(usize, Vec<u8>), usize>| {
+            let key = (site, seq.to_vec());
+            if let Some(&node) = node_by_site_allele.get(&key) {
+                return node;
+            }
+            let node = segments.len();
+            segments.push(Segment {
+                id: (node + 1).to_string(),
+                seq: seq.to_vec(),
+            });
+            node_by_site_allele.insert(key, node);
+            node
+        };
+
+    let mut paths = Vec::with_capacity(rows.len());
+    for (idx, row) in rows.iter().enumerate() {
+        let mut steps = Vec::new();
+        for pos in 0..=root_len {
+            if !row.inserts[pos].is_empty() {
+                let site = pos * 2;
+                let node = get_node(
+                    site,
+                    &row.inserts[pos],
+                    &mut segments,
+                    &mut node_by_site_allele,
+                );
+                steps.push(Step { node, rev: false });
+            }
+            if pos < root_len {
+                if let Some(base) = row.bases[pos] {
+                    let site = pos * 2 + 1;
+                    let node = get_node(site, &[base], &mut segments, &mut node_by_site_allele);
+                    steps.push(Step { node, rev: false });
+                }
+            }
+        }
+        paths.push(Path {
+            name: headers[idx].clone(),
+            steps,
+        });
+    }
+
+    Graph { segments, paths }
 }
 
 fn polish_replacement_gfa(gfa: &str, config: &ResolutionConfig) -> io::Result<String> {
@@ -1593,7 +1770,7 @@ P\tins\t1+,2+,3+\t*
     }
 
     #[test]
-    fn resolves_insertion_bubble_with_biwfa_seqwish_without_changing_path_sequences() {
+    fn resolves_insertion_bubble_with_biwfa_inmemory_without_changing_path_sequences() {
         let gfa = "\
 H\tVN:Z:1.0
 S\t1\tAC

--- a/src/syng_transitive.rs
+++ b/src/syng_transitive.rs
@@ -760,52 +760,63 @@ fn dedupe_strand_overlaps(
 
 /// Default cap on the adaptive minimum anchor count per chain for emission.
 ///
-/// Bounded GBWT-walk seeds already carry several consecutive syncmers (the CLI
-/// default is 5), so a threshold of 2 lets one weak exact island through. The
-/// default cap of 20 requires multiple seed islands for locus-scale queries,
-/// which suppresses paralog/repeat noise in loci such as AMY. The effective
-/// threshold is scaled by the query span in [`effective_min_chain_anchors`], so
-/// short queries do not have to satisfy a fixed 20-anchor floor.
-pub const DEFAULT_MIN_CHAIN_ANCHORS: usize = 20;
+/// This is deliberately a high ceiling, not a floor. The actual threshold is
+/// derived from query length, syncmer density, and an assumed identity in
+/// [`effective_min_chain_anchors_for_syncmer`]. Short queries therefore keep a
+/// small support requirement, while long repeat-dense loci can require many
+/// independent seed islands.
+pub const DEFAULT_MIN_CHAIN_ANCHORS: usize = 1_000;
 
-/// Target scale for adaptive syng chain support.
+/// Default identity used to estimate how many exact syncmers should survive in
+/// a true homologous chain.
+pub const DEFAULT_MIN_CHAIN_IDENTITY: f64 = 0.95;
+
+/// Fraction of expected exact shared syncmers required for emission.
 ///
-/// The default support threshold grows by roughly one anchor per 5 kb until it
-/// reaches [`DEFAULT_MIN_CHAIN_ANCHORS`]. This keeps small queries usable while
-/// still requiring several bounded exact-walk seed islands for large local
-/// graph queries.
-pub const DEFAULT_MIN_CHAIN_ANCHOR_SPACING_BP: u64 = 5_000;
+/// We do not require the full expectation because SNP clustering, local
+/// divergence, structural variation, and syncmer-selection edge effects all
+/// lower observed anchor counts. The value is high enough to reject weak
+/// paralog/repeat chains in AMY-scale loci while preserving short-query
+/// sensitivity.
+pub const DEFAULT_MIN_CHAIN_EXPECTED_FRACTION: f64 = 0.10;
 
 /// Effective syng chain anchor threshold for a specific query span.
 ///
 /// `requested_min` is treated as a user/CLI cap. The returned value scales with
-/// the query span and is additionally capped by a conservative estimate of how
-/// many 63 bp-style syncmer-width anchors can fit in the query. `0` disables
-/// the anchor-count filter.
-pub fn effective_min_chain_anchors(
+/// the query span and the expected exact-syncmer survival at 95% identity. `0`
+/// disables the anchor-count filter.
+pub fn effective_min_chain_anchors_for_syncmer(
     query_range_len: u64,
     syncmer_len: u64,
+    smer_len: u64,
     requested_min: usize,
 ) -> usize {
     if requested_min == 0 {
         return 0;
     }
 
-    let span_scaled = query_range_len
-        .saturating_add(DEFAULT_MIN_CHAIN_ANCHOR_SPACING_BP - 1)
-        / DEFAULT_MIN_CHAIN_ANCHOR_SPACING_BP;
-    let span_scaled = (span_scaled as usize).max(1);
+    let density = closed_syncmer_density(syncmer_len, smer_len);
+    let exact_survival = DEFAULT_MIN_CHAIN_IDENTITY.powf(syncmer_len as f64);
+    let expected_shared =
+        query_range_len as f64 * density * exact_survival * DEFAULT_MIN_CHAIN_EXPECTED_FRACTION;
+    let required = expected_shared.ceil() as usize;
+    requested_min.min(required.max(1))
+}
 
-    let syncmer_width_cap = if syncmer_len == 0 {
-        requested_min
-    } else {
-        let cap = query_range_len
-            .saturating_add(syncmer_len - 1)
-            / syncmer_len;
-        (cap as usize).max(1)
-    };
+pub fn effective_min_chain_anchors(
+    query_range_len: u64,
+    syncmer_len: u64,
+    requested_min: usize,
+) -> usize {
+    effective_min_chain_anchors_for_syncmer(query_range_len, syncmer_len, 8, requested_min)
+}
 
-    requested_min.min(span_scaled).min(syncmer_width_cap).max(1)
+fn closed_syncmer_density(syncmer_len: u64, smer_len: u64) -> f64 {
+    if syncmer_len == 0 || smer_len == 0 || smer_len > syncmer_len {
+        return 1.0;
+    }
+    let window_count = syncmer_len - smer_len + 1;
+    2.0 / (window_count as f64 + 1.0)
 }
 
 /// Run one hop of syng-seeded homology query.
@@ -949,13 +960,16 @@ pub fn one_hop_ext_visited_with_seed_filter(
         target_span_cap,
     );
     let pre_filter = hits.len();
-    // Filter chains by anchor count. The default requires support from
-    // multiple bounded GBWT-walk seed islands, not just a single weak
-    // island in a repeat-dense region. Users who want exploratory local
-    // chains or singletons can lower --syng-min-chain-anchors.
-    //
-    let effective_min =
-        effective_min_chain_anchors(query_range_len, syncmer_len, min_chain_anchors);
+    // Filter chains by a length-scaled anchor-count model. The default
+    // estimates how many exact syncmers should survive at high identity and
+    // requires a fraction of that, so short queries stay sensitive while
+    // long repeat-dense loci need multiple bounded GBWT-walk seed islands.
+    let effective_min = effective_min_chain_anchors_for_syncmer(
+        query_range_len,
+        syncmer_len,
+        syng_index.params.k as u64,
+        min_chain_anchors,
+    );
     // Chain query-extent = a_last.query_pos + syncmer_len - a_first.query_pos.
     // Threshold in bp; 0 means "no extent filter".
     let min_chain_extent_bp = (query_range_len as f64 * min_chain_fraction.max(0.0)) as u64;
@@ -1627,13 +1641,25 @@ mod tests {
 
     #[test]
     fn effective_min_chain_anchors_scales_with_query_span() {
-        assert_eq!(effective_min_chain_anchors(0, TEST_SYNCMER_LEN, 20), 1);
-        assert_eq!(effective_min_chain_anchors(63, TEST_SYNCMER_LEN, 20), 1);
-        assert_eq!(effective_min_chain_anchors(1_000, TEST_SYNCMER_LEN, 20), 1);
-        assert_eq!(effective_min_chain_anchors(10_000, TEST_SYNCMER_LEN, 20), 2);
-        assert_eq!(effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 20), 10);
-        assert_eq!(effective_min_chain_anchors(100_000, TEST_SYNCMER_LEN, 20), 20);
-        assert_eq!(effective_min_chain_anchors(400_000, TEST_SYNCMER_LEN, 20), 20);
+        assert_eq!(effective_min_chain_anchors(0, TEST_SYNCMER_LEN, 1_000), 1);
+        assert_eq!(effective_min_chain_anchors(63, TEST_SYNCMER_LEN, 1_000), 1);
+        assert_eq!(effective_min_chain_anchors(1_000, TEST_SYNCMER_LEN, 1_000), 1);
+        assert_eq!(
+            effective_min_chain_anchors(10_000, TEST_SYNCMER_LEN, 1_000),
+            2
+        );
+        assert_eq!(
+            effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 1_000),
+            7
+        );
+        assert_eq!(
+            effective_min_chain_anchors(100_000, TEST_SYNCMER_LEN, 1_000),
+            14
+        );
+        assert_eq!(
+            effective_min_chain_anchors(400_000, TEST_SYNCMER_LEN, 1_000),
+            56
+        );
         assert_eq!(effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 3), 3);
         assert_eq!(effective_min_chain_anchors(50_000, TEST_SYNCMER_LEN, 0), 0);
     }


### PR DESCRIPTION
## Summary
- replace the fixed syng chain anchor floor with a query-length/syncmer-density/95%-identity expected-support model
- keep `--syng-min-chain-anchors` as a cap, so short regions stay sensitive and long repeat-dense loci require more independent seed support
- switch BiWFA crush replacement away from seqwish transclosure to path-preserving in-memory induction and update docs/help text

## Validation
- `cargo check`
- `cargo test syng_transitive::tests --lib -- --nocapture`
- `cargo test test_gfa_output_format_syng_crush_uses_safe_defaults --bin impg -- --nocapture`
- `cargo test resolution::tests --lib -- --nocapture`
- `cargo test biwfa --lib -- --nocapture`
- `cargo test test_crush_cli_resolves_blunt_gfa --test test_syng_integration -- --nocapture`
- HPRCv2 AMY BED query now returns 467 intervals and removes the 3 chrX weak-chain intervals seen before
- HPRCv2 AMY `gfa:syng:crush:nosort` returns 467 paths with no chrX-classified paths; total wall 3:51.60, post-load query/GFA/crush 48.396s