### PR TITLE
Add AllWave and SweepGA crush backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,13 +39,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "allwave"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/allwave?branch=eg%2Fremove-edlib-orientation#8734cbfadfcf6011c963e2cb6bfe827978e9ce12"
+source = "git+https://github.com/pangenome/allwave?rev=dd939bfcf57f99031325979425a303b853692988#dd939bfcf57f99031325979425a303b853692988"
 dependencies = [
  "atty",
  "bio",
  "clap",
  "indicatif 0.17.11",
- "lib_wfa2 0.1.0 (git+https://github.com/ekg/lib_wfa2?branch=eg%2Flibrary-only-build)",
+ "lib_wfa2 0.1.0 (git+https://github.com/ekg/lib_wfa2?rev=28f4c67ed93979c9114b55dc7ebc58376af09c04)",
  "noodles 0.94.0",
  "rand 0.8.5",
  "rayon",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?branch=eg%2Flibrary-only-build#435901c88704a68a80a476b07667579f16360df9"
+source = "git+https://github.com/ekg/lib_wfa2?rev=28f4c67ed93979c9114b55dc7ebc58376af09c04#28f4c67ed93979c9114b55dc7ebc58376af09c04"
 
 [[package]]
 name = "lib_wfa2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allwave"
+version = "0.1.0"
+source = "git+https://github.com/pangenome/allwave?branch=eg%2Foptional-edlib-orientation#e8e51745633d272a4d8339debb9bbff91f17e3db"
+dependencies = [
+ "atty",
+ "bio",
+ "clap",
+ "indicatif 0.17.11",
+ "lib_wfa2 0.1.0 (git+https://github.com/ekg/lib_wfa2?rev=819b82cd842aabedcb962fd5b82380fe454234f6)",
+ "noodles 0.94.0",
+ "rand 0.8.5",
+ "rayon",
+ "tempfile",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -98,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -127,6 +143,17 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -192,7 +219,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -212,7 +239,46 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bio"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a72cb93babf08c85b375c2938ac678cc637936b3ebb72266d433cec2577f6c2"
+dependencies = [
+ "anyhow",
+ "approx",
+ "bio-types",
+ "bit-set",
+ "bv",
+ "bytecount",
+ "csv",
+ "custom_derive",
+ "editdistancek",
+ "enum-map",
+ "fxhash",
+ "itertools 0.10.5",
+ "itertools-num",
+ "lazy_static",
+ "multimap",
+ "ndarray",
+ "newtype_derive",
+ "num-integer",
+ "num-traits",
+ "ordered-float 3.9.2",
+ "petgraph 0.6.5",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_derive",
+ "statrs",
+ "strum",
+ "strum_macros 0.25.3",
+ "thiserror 1.0.69",
+ "triple_accel",
+ "vec_map",
 ]
 
 [[package]]
@@ -224,9 +290,24 @@ dependencies = [
  "derive-new 0.6.0",
  "lazy_static",
  "regex",
- "strum_macros",
+ "strum_macros 0.26.4",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -319,6 +400,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
+dependencies = [
+ "feature-probe",
+ "serde",
+]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,7 +432,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -389,7 +486,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml",
 ]
@@ -513,7 +610,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -556,6 +653,19 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -563,7 +673,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -763,7 +873,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -777,7 +887,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -795,7 +905,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -820,7 +930,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -831,7 +941,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -852,8 +962,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "editdistancek"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e02df23d5b1c6f9e69fa603b890378123b93073df998a21e6e33b9db0a32613"
 
 [[package]]
 name = "either"
@@ -866,6 +982,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "env_filter"
@@ -903,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -929,10 +1065,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "feature-probe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -1031,6 +1179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,7 +1258,7 @@ source = "git+https://github.com/pangenome/gfasort?rev=f15d8ebfdc632af2333f277cb
 dependencies = [
  "clap",
  "rand 0.9.4",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rand_xoshiro",
  "sha2",
 ]
@@ -1193,6 +1350,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1370,6 +1536,7 @@ name = "impg"
 version = "0.4.1"
 dependencies = [
  "ahash",
+ "allwave",
  "bincode 2.0.1",
  "bitvec",
  "bluntg",
@@ -1385,12 +1552,12 @@ dependencies = [
  "gzp",
  "handlegraph",
  "indexmap",
- "indicatif",
- "lib_wfa2",
+ "indicatif 0.18.4",
+ "lib_wfa2 0.1.0 (git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0)",
  "libc",
  "log",
  "memmap2",
- "nalgebra",
+ "nalgebra 0.33.3",
  "natord",
  "niffler",
  "noodles 0.100.0",
@@ -1429,11 +1596,25 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "rayon",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1446,9 +1627,9 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1473,6 +1654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itertools-num"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1502,7 +1692,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1555,6 +1745,11 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "lib_wfa2"
+version = "0.1.0"
+source = "git+https://github.com/ekg/lib_wfa2?rev=819b82cd842aabedcb962fd5b82380fe454234f6#819b82cd842aabedcb962fd5b82380fe454234f6"
 
 [[package]]
 name = "lib_wfa2"
@@ -1738,6 +1933,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a5d38b9b352dbd913288736af36af41c48d61b1a8cd34bcecd727561b7d511"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros 0.1.0",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "simba 0.6.0",
+ "typenum",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,12 +1967,23 @@ checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
+ "nalgebra-macros 0.2.2",
  "num-complex",
  "num-rational",
  "num-traits",
- "simba",
+ "simba 0.9.1",
  "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1761,7 +1994,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1784,6 +2017,19 @@ name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
 
 [[package]]
 name = "newtype_derive"
@@ -1849,11 +2095,21 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "noodles"
+version = "0.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b48cf7584b1a4c8efaa99796eca1b2cde5efc2c6c4b6680fe23ed3403bd77ea"
+dependencies = [
+ "noodles-bgzf 0.37.0",
+ "noodles-fasta 0.50.0",
+]
+
+[[package]]
+name = "noodles"
 version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "110e4a86fc1551a6480a47c7ff52176dc314b3f20355550bd542f05bce65ead2"
 dependencies = [
- "noodles-fasta",
+ "noodles-fasta 0.54.0",
  "noodles-fastq",
 ]
 
@@ -1864,6 +2120,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5d9c17e7b3fd97eee958bfba83522d3da540c395f7ae071a8fa4bb7e85969e"
 dependencies = [
  "noodles-bgzf 0.42.0",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4a45ef5a49e622bcd33cbf9a8323ad3c2b8dd2395526354bc901983295fcf8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
 ]
 
 [[package]]
@@ -1896,6 +2164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce89752158657dd1d7195061e9d9190e2d3bb594eb71086762163d4a430b0b4b"
 dependencies = [
  "bstr 1.12.1",
+]
+
+[[package]]
+name = "noodles-fasta"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70fcad7421d77cc23062a7e26b08933d1eeb471cd91318be1a7c3398bd835f45"
+dependencies = [
+ "bstr 1.12.1",
+ "bytes",
+ "memchr",
+ "noodles-bgzf 0.37.0",
+ "noodles-core",
 ]
 
 [[package]]
@@ -2001,9 +2282,15 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -2050,6 +2337,15 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -2103,11 +2399,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
@@ -2164,7 +2470,7 @@ dependencies = [
  "nonmax",
  "noodles 0.99.0",
  "num",
- "petgraph",
+ "petgraph 0.8.3",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -2223,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2365,6 +2671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2524,7 +2840,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2631,7 +2947,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2672,6 +2988,19 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simba"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
 
 [[package]]
 name = "simba"
@@ -2733,10 +3062,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
+dependencies = [
+ "approx",
+ "lazy_static",
+ "nalgebra 0.29.0",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "strum_macros"
@@ -2748,7 +3109,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2789,13 +3150,24 @@ dependencies = [
  "nom 7.1.3",
  "noodles 0.100.0",
  "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34)",
- "ordered-float",
+ "ordered-float 4.6.0",
  "ragc-core",
  "rand 0.8.5",
  "rayon",
  "rust-htslib",
  "tempfile",
  "wfmash-rs",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2817,7 +3189,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2836,7 +3208,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2855,7 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2884,7 +3256,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2895,7 +3267,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2987,7 +3359,7 @@ dependencies = [
  "bgzip",
  "env_logger",
  "flate2",
- "lib_wfa2",
+ "lib_wfa2 0.1.0 (git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0)",
  "log",
  "noodles 0.100.0",
  "rayon",
@@ -3000,8 +3372,14 @@ name = "tracepoints"
 version = "0.1.0"
 source = "git+https://github.com/AndreaGuarracino/tracepoints?rev=66a5511b0b84d8502f9d7c99efd150616ff2cae3#66a5511b0b84d8502f9d7c99efd150616ff2cae3"
 dependencies = [
- "lib_wfa2",
+ "lib_wfa2 0.1.0 (git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0)",
 ]
+
+[[package]]
+name = "triple_accel"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22048bc95dfb2ffd05b1ff9a756290a009224b60b2f0e7525faeee7603851e63"
 
 [[package]]
 name = "typenum"
@@ -3074,6 +3452,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vers-vecs"
@@ -3171,7 +3558,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3281,7 +3668,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3311,7 +3698,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3322,7 +3709,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3351,12 +3738,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3397,7 +3857,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3413,7 +3873,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3498,7 +3958,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3519,7 +3979,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3539,7 +3999,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3573,7 +4033,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "allwave"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/allwave?branch=eg%2Foptional-edlib-orientation#e8e51745633d272a4d8339debb9bbff91f17e3db"
+source = "git+https://github.com/pangenome/allwave?branch=eg%2Fremove-edlib-orientation#b85ed9d9df3f84e9cc768fee2d13384085fd9756"
 dependencies = [
  "atty",
  "bio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,13 +39,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "allwave"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/allwave?branch=eg%2Fremove-edlib-orientation#b85ed9d9df3f84e9cc768fee2d13384085fd9756"
+source = "git+https://github.com/pangenome/allwave?branch=eg%2Fremove-edlib-orientation#8734cbfadfcf6011c963e2cb6bfe827978e9ce12"
 dependencies = [
  "atty",
  "bio",
  "clap",
  "indicatif 0.17.11",
- "lib_wfa2 0.1.0 (git+https://github.com/ekg/lib_wfa2?rev=819b82cd842aabedcb962fd5b82380fe454234f6)",
+ "lib_wfa2 0.1.0 (git+https://github.com/ekg/lib_wfa2?branch=eg%2Flibrary-only-build)",
  "noodles 0.94.0",
  "rand 0.8.5",
  "rayon",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?rev=819b82cd842aabedcb962fd5b82380fe454234f6#819b82cd842aabedcb962fd5b82380fe454234f6"
+source = "git+https://github.com/ekg/lib_wfa2?branch=eg%2Flibrary-only-build#435901c88704a68a80a476b07667579f16360df9"
 
 [[package]]
 name = "lib_wfa2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ gzp = "1.0.1"
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "ddd31d39b6a68fc972025b048076032341b66835", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
-allwave = { git = "https://github.com/pangenome/allwave", branch = "eg/remove-edlib-orientation", default-features = false }
+allwave = { git = "https://github.com/pangenome/allwave", rev = "dd939bfcf57f99031325979425a303b853692988", default-features = false }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ gzp = "1.0.1"
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "ddd31d39b6a68fc972025b048076032341b66835", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
-allwave = { git = "https://github.com/pangenome/allwave", branch = "eg/optional-edlib-orientation", default-features = false }
+allwave = { git = "https://github.com/pangenome/allwave", branch = "eg/remove-edlib-orientation", default-features = false }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ gzp = "1.0.1"
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "ddd31d39b6a68fc972025b048076032341b66835", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
+allwave = { git = "https://github.com/pangenome/allwave", branch = "eg/optional-edlib-orientation", default-features = false }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }

--- a/docs/graph-pipeline-dsl.md
+++ b/docs/graph-pipeline-dsl.md
@@ -111,6 +111,8 @@ seqwish,min-match-len=70,sparse-factor=0.001
 pggb,window=20k
 crush,method=auto,max-median-traversal-len=1k,max-traversal-len=10k
 crush,method=biwfa,max-median-traversal-len=10k,polish-max-median-traversal-len=256
+crush,method=allwave,k-nearest=5,k-farthest=2,random-fraction=0.05,mash-k=17
+crush,method=sweepga,aligner=fastga,kmer-frequency=42,no-filter=true
 ```
 
 Unknown parameters should be errors, not warnings. Silent ignoring would make
@@ -168,3 +170,18 @@ scales are intentionally separate: `max-median-traversal-len` controls which
 biological bubble traversals may be induced by BiWFA, while
 `polish-max-median-traversal-len` controls the tiny STR/indel tangles we are
 willing to clean inside that induced graph.
+
+`method=allwave` is the many-sequence BiWFA path. It gives every selected
+POVU bubble traversal to AllWave at once, uses AllWave's tree/kNN pair
+selection and strand-specific Mash orientation detection, emits oriented PAF,
+and induces the replacement graph through seqwish. This is useful when a bubble
+has many homologous traversals and root-star alignment is too biased. The
+replacement is still exact-path validated after graph induction.
+
+`method=sweepga` uses SweepGA as the replaceable alignment provider before the
+same seqwish induction and validation step. It is intentionally separate from
+`method=allwave`: SweepGA has different filtering/scaling semantics, and its
+knobs can be used to leave harder bubbles in the graph for a later small SPOA
+crush pass. The shared pair-sampling knobs are `k-nearest`, `k-farthest`,
+`random-fraction`, and `mash-k`; SweepGA-specific knobs include `aligner`,
+`kmer-frequency`, `min-aln-length`, `map-pct-identity`, and `no-filter`.

--- a/docs/syng-gfa-query.md
+++ b/docs/syng-gfa-query.md
@@ -207,6 +207,10 @@ same staged syntax.
 `gfa:syng:crush,method=auto,max-median-traversal-len=1k` emits blunt syng GFA
 and then runs exact path-preserving bubble resolution; see
 `docs/graph-pipeline-dsl.md`.
+Crush methods include `poa`, `biwfa`, `allwave`, and `sweepga`; for example,
+`gfa:syng:crush,method=allwave,k-nearest=5,k-farthest=2` uses AllWave's
+many-sequence pair selection and Mash orientation detection inside each
+selected POVU bubble.
 For syng GFA output, `impg` then runs an internal gfasort pass by default using
 pipeline `Ygs` (path-guided SGD, grooming, topological ordering). The pipeline
 can be changed with a sort stage, for example

--- a/src/main.rs
+++ b/src/main.rs
@@ -2256,6 +2256,20 @@ fn parse_usize_size_engine_param(raw: &str, key: &str, value: &str) -> io::Resul
     })
 }
 
+fn parse_bool_engine_param(raw: &str, key: &str, value: &str) -> io::Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid --gfa-engine '{}': {}='{}' is not a boolean",
+                raw, key, value
+            ),
+        )),
+    }
+}
+
 fn parse_crush_stage(
     raw: &str,
     stage: &GraphPipelineStage,
@@ -2312,13 +2326,53 @@ fn parse_crush_stage(
                 config.polish_max_traversals =
                     parse_usize_size_engine_param(raw, &param.key, &param.value)?;
             }
+            "k-nearest" | "k-near" | "near" | "tree-near" => {
+                config.pair_k_nearest =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "k-farthest" | "k-far" | "far" | "tree-far" => {
+                config.pair_k_farthest =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "random-fraction" | "random" | "tree-random" => {
+                config.pair_random_fraction = param.value.parse().map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Invalid --gfa-engine '{}': {}='{}' is not a valid fraction",
+                            raw, param.key, param.value
+                        ),
+                    )
+                })?;
+            }
+            "mash-k" | "mash-kmer" | "kmer-size" => {
+                config.pair_mash_k =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "sweepga-aligner" | "aligner" => {
+                config.sweepga_aligner = param.value.clone();
+            }
+            "sweepga-kmer-frequency" | "kmer-frequency" | "fastga-frequency" => {
+                config.sweepga_kmer_frequency =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)?;
+            }
+            "sweepga-min-aln-length" | "min-aln-length" => {
+                config.sweepga_min_aln_length =
+                    parse_usize_size_engine_param(raw, &param.key, &param.value)? as u64;
+            }
+            "sweepga-map-pct-identity" | "map-pct-identity" => {
+                config.sweepga_map_pct_identity = Some(param.value.clone());
+            }
+            "sweepga-no-filter" | "no-filter" => {
+                config.sweepga_no_filter = parse_bool_engine_param(raw, &param.key, &param.value)?;
+            }
             "method" => {
                 let Some(method) = impg::resolution::ResolutionMethod::parse_name(&param.value)
                 else {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!(
-                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected auto, poa, poasta, or biwfa)",
+                            "Invalid --gfa-engine '{}': crush method '{}' is unsupported (expected auto, poa, poasta, biwfa, allwave, or sweepga)",
                             raw, param.value
                         ),
                     ));
@@ -2350,6 +2404,33 @@ fn parse_crush_stage(
                 "Invalid --gfa-engine '{}': crush max-traversals must be > 0",
                 raw
             ),
+        ));
+    }
+    if config.pair_k_nearest == 0
+        && config.pair_k_farthest == 0
+        && config.pair_random_fraction <= 0.0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid --gfa-engine '{}': crush pair sampling would select no pairs",
+                raw
+            ),
+        ));
+    }
+    if !(0.0..=1.0).contains(&config.pair_random_fraction) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid --gfa-engine '{}': random-fraction must be between 0 and 1",
+                raw
+            ),
+        ));
+    }
+    if !(3..=31).contains(&config.pair_mash_k) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid --gfa-engine '{}': mash-k must be between 3 and 31", raw),
         ));
     }
     Ok(config)
@@ -3616,6 +3697,8 @@ GFA engine shorthand:
   name the aligner prefix, e.g. `-o gfa:wfmash:seqwish`,
   `-o gfa:fastga:pggb`, or `-o gfa:sweepga:seqwish`. Add `:crush` to run
   exact path-preserving blunt-graph resolution, e.g. `-o gfa:syng:crush`.
+  Crush methods include poa, biwfa, allwave, and sweepga; e.g.
+  `-o gfa:syng:crush,method=allwave,k-nearest=5,k-farthest=2`.
 ")]
     Query {
         // --- Input ---
@@ -4113,9 +4196,45 @@ GFA engine shorthand:
         #[clap(long, value_parser = parse_usize_size, default_value = "10k")]
         polish_max_traversals: usize,
 
-        /// Resolver method: auto, poa, poasta, or biwfa
+        /// Resolver method: auto, poa, poasta, biwfa, allwave, or sweepga
         #[clap(long, value_parser, default_value = "auto")]
         method: String,
+
+        /// Pair-sampling nearest-neighbor count for allwave/sweepga crush
+        #[clap(long, value_parser = parse_usize_size, default_value = "3")]
+        k_nearest: usize,
+
+        /// Pair-sampling farthest-neighbor count for allwave/sweepga crush
+        #[clap(long, value_parser = parse_usize_size, default_value = "1")]
+        k_farthest: usize,
+
+        /// Deterministic random pair fraction for allwave/sweepga crush
+        #[clap(long, value_parser, default_value = "0.01")]
+        random_fraction: f64,
+
+        /// Mash k-mer size for allwave/sweepga pair selection
+        #[clap(long, value_parser = parse_usize_size, default_value = "15")]
+        mash_k: usize,
+
+        /// SweepGA aligner backend for --method sweepga: fastga or wfmash
+        #[clap(long, value_parser, default_value = "fastga")]
+        sweepga_aligner: String,
+
+        /// SweepGA/FastGA k-mer frequency for --method sweepga
+        #[clap(long, value_parser = parse_usize_size, default_value = "10")]
+        sweepga_kmer_frequency: usize,
+
+        /// SweepGA minimum alignment length for --method sweepga
+        #[clap(long, value_parser = parse_usize_size, default_value = "0")]
+        sweepga_min_aln_length: usize,
+
+        /// SweepGA wfmash percent identity for --method sweepga
+        #[clap(long, value_parser)]
+        sweepga_map_pct_identity: Option<String>,
+
+        /// Skip SweepGA post-alignment filtering for --method sweepga
+        #[clap(long, value_parser, default_value_t = true)]
+        sweepga_no_filter: bool,
 
         #[clap(flatten)]
         common: CommonOpts,
@@ -6813,6 +6932,15 @@ fn run() -> io::Result<()> {
             polish_max_total_sequence,
             polish_max_traversals,
             method,
+            k_nearest,
+            k_farthest,
+            random_fraction,
+            mash_k,
+            sweepga_aligner,
+            sweepga_kmer_frequency,
+            sweepga_min_aln_length,
+            sweepga_map_pct_identity,
+            sweepga_no_filter,
             common,
         } => {
             initialize_threads_and_log(&common);
@@ -6837,9 +6965,27 @@ fn run() -> io::Result<()> {
             let Some(method) = impg::resolution::ResolutionMethod::parse_name(&method) else {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "--method must be one of: auto, poa, poasta, biwfa",
+                    "--method must be one of: auto, poa, poasta, biwfa, allwave, sweepga",
                 ));
             };
+            if k_nearest == 0 && k_farthest == 0 && random_fraction <= 0.0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--k-nearest/--k-farthest/--random-fraction would select no pairs",
+                ));
+            }
+            if !(0.0..=1.0).contains(&random_fraction) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--random-fraction must be between 0 and 1",
+                ));
+            }
+            if !(3..=31).contains(&mash_k) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--mash-k must be between 3 and 31",
+                ));
+            }
 
             let mut gfa_text = String::new();
             if gfa == "-" {
@@ -6861,6 +7007,15 @@ fn run() -> io::Result<()> {
                 polish_max_median_traversal_len,
                 polish_max_total_sequence,
                 polish_max_traversals,
+                pair_k_nearest: k_nearest,
+                pair_k_farthest: k_farthest,
+                pair_random_fraction: random_fraction,
+                pair_mash_k: mash_k,
+                sweepga_aligner,
+                sweepga_kmer_frequency,
+                sweepga_min_aln_length: sweepga_min_aln_length as u64,
+                sweepga_map_pct_identity,
+                sweepga_no_filter,
                 ..Default::default()
             };
             let resolved = impg::resolution::resolve_gfa_bubbles(&gfa_text, &config)?;
@@ -11037,6 +11192,7 @@ mod tests {
             "-o gfa:syng:crush:sort,pipeline=Yg",
             "-o vcf:syng",
             "-o gfa:wfmash:seqwish",
+            "Crush methods include poa, biwfa, allwave, and sweepga",
             "`impg syng2gfa` to dump the whole syng syncmer graph",
         ] {
             assert!(
@@ -11215,6 +11371,71 @@ mod tests {
                 assert_eq!(crush.max_iterations, 7);
                 assert_eq!(crush.polish_max_median_traversal_len, 128);
                 assert_eq!(crush.polish_iterations, 1);
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_accepts_allwave_crush_params() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:crush,method=allwave,k-nearest=5,k-farthest=2,random-fraction=0.05,mash-k=17",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                let parsed = engine_cli.parse_engine().unwrap();
+                let crush = parsed.crush_config.unwrap();
+                assert_eq!(crush.method, impg::resolution::ResolutionMethod::Allwave);
+                assert_eq!(crush.pair_k_nearest, 5);
+                assert_eq!(crush.pair_k_farthest, 2);
+                assert!((crush.pair_random_fraction - 0.05).abs() < f64::EPSILON);
+                assert_eq!(crush.pair_mash_k, 17);
+            }
+            _ => panic!("expected query command"),
+        }
+    }
+
+    #[test]
+    fn test_gfa_output_format_accepts_sweepga_crush_params() {
+        let args = Args::try_parse_from([
+            "impg",
+            "query",
+            "-d",
+            "0",
+            "-o",
+            "gfa:syng:crush,method=sweepga,aligner=wfmash,kmer-frequency=42,min-aln-length=1k,map-pct-identity=90,no-filter=false",
+        ])
+        .unwrap();
+        match args {
+            Args::Query {
+                output_format,
+                mut engine_cli,
+                ..
+            } => {
+                let output_format =
+                    apply_gfa_output_engine_shorthand(output_format, &mut engine_cli).unwrap();
+                assert_eq!(output_format, "gfa");
+                let parsed = engine_cli.parse_engine().unwrap();
+                let crush = parsed.crush_config.unwrap();
+                assert_eq!(crush.method, impg::resolution::ResolutionMethod::Sweepga);
+                assert_eq!(crush.sweepga_aligner, "wfmash");
+                assert_eq!(crush.sweepga_kmer_frequency, 42);
+                assert_eq!(crush.sweepga_min_aln_length, 1_000);
+                assert_eq!(crush.sweepga_map_pct_identity.as_deref(), Some("90"));
+                assert!(!crush.sweepga_no_filter);
             }
             _ => panic!("expected query command"),
         }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -13,7 +13,7 @@ use povu::native_gfa::{Step as PovuStep, Strand as PovuStrand};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
-use std::io;
+use std::io::{self, Read};
 use std::time::Instant;
 
 /// Configuration for exact path-preserving bubble resolution.
@@ -47,6 +47,24 @@ pub struct ResolutionConfig {
     pub polish_max_median_traversal_len: usize,
     pub polish_max_total_sequence: usize,
     pub polish_max_traversals: usize,
+    /// Pair-sampling nearest-neighbor count for many-sequence pairwise engines.
+    pub pair_k_nearest: usize,
+    /// Pair-sampling farthest-neighbor count for diversity/stranger joins.
+    pub pair_k_farthest: usize,
+    /// Deterministic random pair fraction added after tree/kNN sampling.
+    pub pair_random_fraction: f64,
+    /// Mash k-mer size for pair selection.
+    pub pair_mash_k: usize,
+    /// SweepGA aligner backend used by `method=sweepga`.
+    pub sweepga_aligner: String,
+    /// SweepGA/FastGA k-mer frequency.
+    pub sweepga_kmer_frequency: usize,
+    /// SweepGA minimum alignment length.
+    pub sweepga_min_aln_length: u64,
+    /// SweepGA wfmash percent identity. `None` lets wfmash auto-estimate.
+    pub sweepga_map_pct_identity: Option<String>,
+    /// Skip SweepGA post-alignment filtering and feed selected pair alignments directly.
+    pub sweepga_no_filter: bool,
     /// SPOA scoring parameters: (match, mismatch, gap_open, gap_ext, gap_open2, gap_ext2).
     pub scoring_params: (u8, u8, u8, u8, u8, u8),
 }
@@ -57,6 +75,8 @@ pub enum ResolutionMethod {
     Poa,
     Poasta,
     Biwfa,
+    Allwave,
+    Sweepga,
 }
 
 impl ResolutionMethod {
@@ -66,6 +86,8 @@ impl ResolutionMethod {
             "poa" | "spoa" => Some(Self::Poa),
             "poasta" => Some(Self::Poasta),
             "biwfa" | "wfa" => Some(Self::Biwfa),
+            "allwave" | "aw" => Some(Self::Allwave),
+            "sweepga" | "sw" => Some(Self::Sweepga),
             _ => None,
         }
     }
@@ -88,6 +110,12 @@ pub const DEFAULT_POLISH_MAX_TRAVERSAL_LEN: usize = 2_000;
 pub const DEFAULT_POLISH_MAX_MEDIAN_TRAVERSAL_LEN: usize = 256;
 pub const DEFAULT_POLISH_MAX_TOTAL_SEQUENCE: usize = 1_000_000;
 pub const DEFAULT_POLISH_MAX_TRAVERSALS: usize = 10_000;
+pub const DEFAULT_PAIR_K_NEAREST: usize = 3;
+pub const DEFAULT_PAIR_K_FARTHEST: usize = 1;
+pub const DEFAULT_PAIR_RANDOM_FRACTION: f64 = 0.01;
+pub const DEFAULT_PAIR_MASH_K: usize = 15;
+pub const DEFAULT_SWEEPGA_KMER_FREQUENCY: usize = 10;
+pub const DEFAULT_SWEEPGA_MIN_ALN_LENGTH: u64 = 0;
 
 impl Default for ResolutionConfig {
     fn default() -> Self {
@@ -104,6 +132,15 @@ impl Default for ResolutionConfig {
             polish_max_median_traversal_len: DEFAULT_POLISH_MAX_MEDIAN_TRAVERSAL_LEN,
             polish_max_total_sequence: DEFAULT_POLISH_MAX_TOTAL_SEQUENCE,
             polish_max_traversals: DEFAULT_POLISH_MAX_TRAVERSALS,
+            pair_k_nearest: DEFAULT_PAIR_K_NEAREST,
+            pair_k_farthest: DEFAULT_PAIR_K_FARTHEST,
+            pair_random_fraction: DEFAULT_PAIR_RANDOM_FRACTION,
+            pair_mash_k: DEFAULT_PAIR_MASH_K,
+            sweepga_aligner: "fastga".to_string(),
+            sweepga_kmer_frequency: DEFAULT_SWEEPGA_KMER_FREQUENCY,
+            sweepga_min_aln_length: DEFAULT_SWEEPGA_MIN_ALN_LENGTH,
+            sweepga_map_pct_identity: None,
+            sweepga_no_filter: true,
             scoring_params: (1, 4, 6, 2, 26, 1),
         }
     }
@@ -1085,7 +1122,157 @@ fn build_replacement(candidate: &BubbleCandidate, config: &ResolutionConfig) -> 
             build_poa_replacement(candidate, config)
         }),
         ResolutionMethod::Biwfa => build_biwfa_inmemory_replacement(candidate, config),
+        ResolutionMethod::Allwave => build_allwave_seqwish_replacement(candidate, config),
+        ResolutionMethod::Sweepga => build_sweepga_seqwish_replacement(candidate, config),
     }
+}
+
+fn candidate_named_sequences(candidate: &BubbleCandidate) -> (Vec<String>, Vec<(String, Vec<u8>)>) {
+    let headers: Vec<String> = candidate
+        .ranges
+        .iter()
+        .enumerate()
+        .map(|(i, range)| format!("__impg_bubble_path{}_{}", range.path_idx, i))
+        .collect();
+    let seqs = headers
+        .iter()
+        .cloned()
+        .zip(candidate.ranges.iter().map(|range| range.sequence.clone()))
+        .collect();
+    (headers, seqs)
+}
+
+fn seqwish_replacement_config(
+    _config: &ResolutionConfig,
+) -> crate::commands::graph::GraphBuildConfig {
+    crate::commands::graph::GraphBuildConfig {
+        num_threads: rayon::current_num_threads().max(1),
+        show_progress: false,
+        min_aln_length: 0,
+        input_paf: None,
+        no_filter: true,
+        sparsify: sweepga::knn_graph::SparsificationStrategy::None,
+        ..crate::commands::graph::GraphBuildConfig::default()
+    }
+}
+
+fn finalize_pairwise_induced_replacement(
+    gfa: String,
+    headers: &[String],
+    candidate: &BubbleCandidate,
+    config: &ResolutionConfig,
+    method: &str,
+) -> io::Result<Graph> {
+    let compacted = unchop_gfa(&gfa)?;
+    let mut replacement = parse_gfa(&compacted)?;
+    order_replacement_paths(&mut replacement, headers)?;
+    if config.polish_iterations > 0 {
+        let polished = polish_replacement_gfa(&render_graph(&replacement), config)?;
+        replacement = parse_gfa(&polished)?;
+        order_replacement_paths(&mut replacement, headers)?;
+    }
+    validate_replacement_paths(&replacement, candidate, method)?;
+    Ok(replacement)
+}
+
+fn build_allwave_seqwish_replacement(
+    candidate: &BubbleCandidate,
+    config: &ResolutionConfig,
+) -> io::Result<Graph> {
+    let (headers, seqs) = candidate_named_sequences(candidate);
+    let sequences: Vec<allwave::Sequence> = seqs
+        .iter()
+        .map(|(id, seq)| allwave::Sequence {
+            id: id.clone(),
+            seq: seq.clone(),
+        })
+        .collect();
+
+    let (_, mismatch, gap_open, gap_extend, gap_open2, gap_extend2) = config.scoring_params;
+    let params = allwave::AlignmentParams {
+        match_score: 0,
+        mismatch_penalty: mismatch as i32,
+        gap_open: gap_open as i32,
+        gap_extend: gap_extend as i32,
+        gap2_open: Some(gap_open2 as i32),
+        gap2_extend: Some(gap_extend2 as i32),
+        max_divergence: None,
+    };
+    let sparsification = allwave::SparsificationStrategy::TreeSampling(
+        config.pair_k_nearest,
+        config.pair_k_farthest,
+        config.pair_random_fraction,
+        Some(config.pair_mash_k),
+    );
+    let aligner =
+        allwave::AllPairIterator::with_options(&sequences, params, true, true, sparsification);
+    let pair_count = aligner.pair_count();
+    let mut lines: Vec<String> = aligner
+        .into_par_iter()
+        .map(|alignment| allwave::alignment_to_paf(&alignment, &sequences))
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    lines.sort_unstable();
+    let paf = if lines.is_empty() {
+        String::new()
+    } else {
+        let mut out = lines.join("\n");
+        out.push('\n');
+        out
+    };
+    log::debug!(
+        "crush allwave: {} traversal(s), {} selected pair alignment(s), {} PAF byte(s)",
+        sequences.len(),
+        pair_count,
+        paf.len()
+    );
+
+    let graph_config = seqwish_replacement_config(config);
+    let gfa = crate::syng_graph::build_gfa_from_paf_and_sequences(&seqs, &paf, &graph_config)?;
+    finalize_pairwise_induced_replacement(gfa, &headers, candidate, config, "AllWave/seqwish")
+}
+
+fn build_sweepga_seqwish_replacement(
+    candidate: &BubbleCandidate,
+    config: &ResolutionConfig,
+) -> io::Result<Graph> {
+    let (headers, seqs) = candidate_named_sequences(candidate);
+    let named: Vec<(String, &[u8])> = seqs
+        .iter()
+        .map(|(name, seq)| (name.clone(), seq.as_slice()))
+        .collect();
+    let align_config = sweepga::library_api::SweepgaAlignConfig {
+        num_threads: rayon::current_num_threads().max(1),
+        kmer_frequency: config.sweepga_kmer_frequency,
+        min_aln_length: config.sweepga_min_aln_length,
+        no_filter: config.sweepga_no_filter,
+        sparsify: sweepga::knn_graph::SparsificationStrategy::TreeSampling(
+            config.pair_k_nearest,
+            config.pair_k_farthest,
+            config.pair_random_fraction,
+        ),
+        mash_params: sweepga::knn_graph::MashParams {
+            kmer_size: config.pair_mash_k,
+            ..sweepga::knn_graph::MashParams::default()
+        },
+        aligner: config.sweepga_aligner.clone(),
+        map_pct_identity: config.sweepga_map_pct_identity.clone(),
+        ..sweepga::library_api::SweepgaAlignConfig::default()
+    };
+    let paf_file = sweepga::library_api::sweepga_align(&named, &align_config)
+        .map_err(|err| io::Error::other(format!("SweepGA replacement alignment failed: {err}")))?;
+    let mut paf = String::new();
+    std::fs::File::open(paf_file.path())?.read_to_string(&mut paf)?;
+    log::debug!(
+        "crush sweepga: {} traversal(s), {} PAF byte(s) from {} backend",
+        seqs.len(),
+        paf.len(),
+        config.sweepga_aligner
+    );
+
+    let graph_config = seqwish_replacement_config(config);
+    let gfa = crate::syng_graph::build_gfa_from_paf_and_sequences(&seqs, &paf, &graph_config)?;
+    finalize_pairwise_induced_replacement(gfa, &headers, candidate, config, "SweepGA/seqwish")
 }
 
 fn build_poa_replacement(
@@ -1453,6 +1640,7 @@ fn polish_replacement_gfa(gfa: &str, config: &ResolutionConfig) -> io::Result<St
         polish_max_total_sequence: config.polish_max_total_sequence,
         polish_max_traversals: config.polish_max_traversals,
         scoring_params: config.scoring_params,
+        ..ResolutionConfig::default()
     };
     resolve_gfa_bubbles_quiet(gfa, &polish_config).map(|resolved| resolved.gfa)
 }
@@ -1787,6 +1975,33 @@ P\tins\t1+,2+,3+\t*
             gfa,
             &ResolutionConfig {
                 method: ResolutionMethod::Biwfa,
+                max_median_traversal_len: 10_000,
+                ..ResolutionConfig::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(before, seq_map(&resolved.gfa));
+        assert_eq!(resolved.stats.resolved, 1);
+    }
+
+    #[test]
+    fn resolves_insertion_bubble_with_allwave_without_changing_path_sequences() {
+        let gfa = "\
+H\tVN:Z:1.0
+S\t1\tAC
+S\t2\tGGG
+S\t3\tTA
+L\t1\t+\t3\t+\t0M
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+P\tref\t1+,3+\t*
+P\tins\t1+,2+,3+\t*
+";
+        let before = seq_map(gfa);
+        let resolved = resolve_gfa_bubbles(
+            gfa,
+            &ResolutionConfig {
+                method: ResolutionMethod::Allwave,
                 max_median_traversal_len: 10_000,
                 ..ResolutionConfig::default()
             },


### PR DESCRIPTION
## Summary

- Add method=allwave and method=sweepga as POVU bubble crush backends
- Route both backends through the same seqwish induction, path ordering, optional SPOA polish, and exact path-sequence validation path
- Expose shared pair sampling knobs: k-nearest, k-farthest, random-fraction, mash-k
- Expose SweepGA-specific knobs: aligner, kmer-frequency, min-aln-length, map-pct-identity, no-filter
- Document the graph pipeline DSL and syng GFA query usage

## Notes

AllWave is pinned to merged pangenome/allwave commit dd939bfcf57f99031325979425a303b853692988. That path has edlib removed entirely: impg uses AllWave as an in-process many-sequence BiWFA backend; the fast orientation path is Mash and the exact fallback in AllWave is WFA edit distance.

The macOS WFA2 build issue was fixed and merged in ekg/lib_wfa2 commit 28f4c67ed93979c9114b55dc7ebc58376af09c04, so AllWave builds only libwfa.a instead of OpenMP-dependent WFA2 tools/examples.

## Validation

- cargo check
- cargo test resolves_insertion_bubble_with_allwave_without_changing_path_sequences --lib -- --nocapture
- cargo test crush_params --bin impg -- --nocapture
- cargo test --lib -- --nocapture
- cargo test --bin impg -- --nocapture
- cargo test --tests -- --nocapture
