### PR TITLE
Update WFA2 dependency stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,13 +39,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "allwave"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/allwave?rev=dd939bfcf57f99031325979425a303b853692988#dd939bfcf57f99031325979425a303b853692988"
+source = "git+https://github.com/pangenome/allwave?rev=6b2798aa9fd405abe680cfb1e644331eff9d58e0#6b2798aa9fd405abe680cfb1e644331eff9d58e0"
 dependencies = [
  "atty",
  "bio",
  "clap",
  "indicatif 0.17.11",
- "lib_wfa2 0.1.0 (git+https://github.com/ekg/lib_wfa2?rev=28f4c67ed93979c9114b55dc7ebc58376af09c04)",
+ "lib_wfa2",
  "noodles 0.94.0",
  "rand 0.8.5",
  "rayon",
@@ -1553,7 +1553,7 @@ dependencies = [
  "handlegraph",
  "indexmap",
  "indicatif 0.18.4",
- "lib_wfa2 0.1.0 (git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0)",
+ "lib_wfa2",
  "libc",
  "log",
  "memmap2",
@@ -1749,12 +1749,7 @@ dependencies = [
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?rev=28f4c67ed93979c9114b55dc7ebc58376af09c04#28f4c67ed93979c9114b55dc7ebc58376af09c04"
-
-[[package]]
-name = "lib_wfa2"
-version = "0.1.0"
-source = "git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0#8859b6a214141968f37d9bcb22552408318adda0"
+source = "git+https://github.com/ekg/lib_wfa2?rev=2f9d9a48addee5185d8ff6ed0594182558d60818#2f9d9a48addee5185d8ff6ed0594182558d60818"
 
 [[package]]
 name = "libc"
@@ -3359,7 +3354,7 @@ dependencies = [
  "bgzip",
  "env_logger",
  "flate2",
- "lib_wfa2 0.1.0 (git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0)",
+ "lib_wfa2",
  "log",
  "noodles 0.100.0",
  "rayon",
@@ -3372,7 +3367,7 @@ name = "tracepoints"
 version = "0.1.0"
 source = "git+https://github.com/AndreaGuarracino/tracepoints?rev=66a5511b0b84d8502f9d7c99efd150616ff2cae3#66a5511b0b84d8502f9d7c99efd150616ff2cae3"
 dependencies = [
- "lib_wfa2 0.1.0 (git+https://github.com/AndreaGuarracino/lib_wfa2?rev=8859b6a214141968f37d9bcb22552408318adda0)",
+ "lib_wfa2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "38182c7acf7c
 #tpa = { path = "/home/guarracino/git/tpa" }
 tpa = { git = "https://github.com/AndreaGuarracino/tpa", rev = "49f1801f9e0108c211571fa2614e517009446afe" }
 # Dependencies for 1ALN and TPA formats (for alignments) support
-lib_wfa2 = { git = "https://github.com/AndreaGuarracino/lib_wfa2", rev = "8859b6a214141968f37d9bcb22552408318adda0" }
+lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "2f9d9a48addee5185d8ff6ed0594182558d60818" }
 #lib_wfa2 = { path = "/home/guarracino/Dropbox/git//lib_wfa2"}
 #tracepoints = { path = "/home/guarracino/Dropbox/git/tracepoints"}
 tracepoints = { git = "https://github.com/AndreaGuarracino/tracepoints", rev = "66a5511b0b84d8502f9d7c99efd150616ff2cae3" }
@@ -72,7 +72,7 @@ gzp = "1.0.1"
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "ddd31d39b6a68fc972025b048076032341b66835", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-2" }
-allwave = { git = "https://github.com/pangenome/allwave", rev = "dd939bfcf57f99031325979425a303b853692988", default-features = false }
+allwave = { git = "https://github.com/pangenome/allwave", rev = "6b2798aa9fd405abe680cfb1e644331eff9d58e0", default-features = false }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
@@ -81,6 +81,9 @@ povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "
 
 [build-dependencies]
 cc = "1"
+
+[patch."https://github.com/AndreaGuarracino/lib_wfa2"]
+lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "2f9d9a48addee5185d8ff6ed0594182558d60818" }
 
 [dev-dependencies]
 ahash = "0.8"


### PR DESCRIPTION
Updates `impg` onto the current WFA2 stack:

- points direct `lib_wfa2` usage at `ekg/lib_wfa2@2f9d9a48`, which vendors upstream `WFA2-lib` v2.3.6 with BiWFA
- updates AllWave to `pangenome/allwave@6b2798aa`, including the WFA cache fix and native CI target-cache fix
- patches the old `AndreaGuarracino/lib_wfa2` source so `tpa` and `tracepoints` resolve to the same updated wrapper

Local validation:

- `cargo check`
- `cargo test --lib`
- `cargo test`