### PR TITLE
Revert temporary local_compression testbed diagnostics

### DIFF
--- a/scripts/local_compression_testbed.py
+++ b/scripts/local_compression_testbed.py
@@ -1476,15 +1476,6 @@ def write_command_logs(
         pass
     (method_dir / "stdout.log").write_text(stdout, encoding="utf-8")
     (method_dir / "stderr.log").write_text(stderr, encoding="utf-8")
-    if status == "error":
-        tail = "\n".join(stderr.splitlines()[-80:])
-        print(
-            f"\n[CONTROL-DIAG] command failed (exit={exit_code}) in {method_dir}\n"
-            f"[CONTROL-DIAG] command: {command}\n"
-            f"[CONTROL-DIAG] stderr tail:\n{tail}\n",
-            file=sys.stderr,
-            flush=True,
-        )
 
 
 def skip_row(

--- a/tests/test_local_compression_testbed.rs
+++ b/tests/test_local_compression_testbed.rs
@@ -347,13 +347,6 @@ fn local_compression_fast_runner_supports_filtered_control_methods() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Diagnostic: surface the control command output so CI shows why it errors.
-    eprintln!(
-        "[testbed-diag] runner stdout:\n{}\n[testbed-diag] runner stderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
     let rows = read_json(out_dir.join("scoreboard.json"));
     let rows = rows.as_array().unwrap();
     assert_eq!(rows.len(), 1);
@@ -549,14 +542,6 @@ fn local_compression_chunk_window_sweepga_seqwish_nested_top_level_wrong() {
     assert_eq!(chunk["bubble_count"].as_u64(), Some(2));
     assert_eq!(chunk["flubble_count"].as_u64(), Some(2));
     assert!(chunk["path_replay_compression_ratio"].as_f64().unwrap() > 1.0);
-
-    // Diagnostic: surface the control command output (captured by the runner) so
-    // CI shows why a control errors on a given platform.
-    eprintln!(
-        "[testbed-diag] runner stdout:\n{}\n[testbed-diag] runner stderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
 
     for control_id in [
         "pggb_control",


### PR DESCRIPTION
Reverts the temporary diagnostics from #226 (commit 46b0fa1) that surfaced the failing macOS control-command stderr. Their purpose is served: the root cause was the missing GNU `gtime`, fixed by installing `coreutils`+`gnu-time`, and macOS CI is green. This removes the [CONTROL-DIAG]/[testbed-diag] prints; the coreutils/gnu-time fix stays.