### PR TITLE
release: 0.5.0 with graph fixes and a packageable layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ demo-results
 .claude/
 perf.data
 perf.data.old
+# release tarballs from scripts/make-release-tarball.sh
+/impg-v*.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,13 +1039,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastga-rs"
 version = "0.1.2"
-source = "git+https://github.com/pangenome/fastga-rs?rev=e5037d5#e5037d5ef818f0ed1eef68e5678324a3b6f9111a"
+source = "git+https://github.com/pangenome/fastga-rs?rev=2da9567#2da95679886f8d5674406ae444494ac3022afda1"
 dependencies = [
  "anyhow",
  "cc",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "impg"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "allwave",
@@ -1547,6 +1547,7 @@ dependencies = [
  "crossbeam-channel",
  "csv",
  "env_logger",
+ "fastga-rs",
  "flate2",
  "gfa",
  "gfasort",
@@ -1579,6 +1580,7 @@ dependencies = [
  "tempfile",
  "tpa",
  "tracepoints",
+ "wfmash-rs",
  "zstd",
 ]
 
@@ -1630,7 +1632,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2836,7 +2838,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3118,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=04f9edb941bacb075020f9007a0b8fffdd418962#04f9edb941bacb075020f9007a0b8fffdd418962"
+source = "git+https://github.com/pangenome/sweepga?rev=14f3eeb#14f3eeb6d36d179fb7a9d682f8ae556875d4c747"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3191,7 +3193,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3210,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3651,7 +3653,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impg"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Andrea Guarracino <aguarracino@tgen.org>"]
 
@@ -70,7 +70,7 @@ gzp = "1.0.1"
 # 04f9edb = ddd31d3 (pansn-sparsification) + wfmash-rs 3cc6677 (vendored wfmash v0.14.1).
 # PanSN haplotype grouping + wfmash-per-hap-pair joblist live upstream;
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "04f9edb941bacb075020f9007a0b8fffdd418962", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "14f3eeb", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
 allwave = { git = "https://github.com/pangenome/allwave", rev = "6b2798aa9fd405abe680cfb1e644331eff9d58e0", default-features = false }
 
@@ -81,6 +81,13 @@ povu = { package = "povu-rs", git = "https://github.com/pangenome/povu", rev = "
 
 [build-dependencies]
 cc = "1"
+# build.rs copies wfmash and the FastGA utilities out of their build directories.
+# Cargo only guarantees that a build script runs after the build scripts of its
+# own build-dependencies, so declare these here even though the code is unused.
+# Without them build.rs can run first and copy nothing. Revisions must match the
+# ones sweepga pins, otherwise cargo builds each crate twice.
+wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
+fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "2da9567" }
 
 [patch."https://github.com/AndreaGuarracino/lib_wfa2"]
 lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "2f9d9a48addee5185d8ff6ed0594182558d60818" }

--- a/README.md
+++ b/README.md
@@ -44,8 +44,14 @@ cd impg
 cargo install --force --path .
 ```
 
+`--recursive` is required. `vendor/gfaffix` and `vendor/syng` are git
+submodules, and the build fails without them. The GitHub tag tarball does not
+contain them either, so use the `impg-vX.Y.Z.tar.gz` asset attached to each
+[release](https://github.com/pangenome/impg/releases) if you cannot clone.
+
 The source install places `impg`, `gfaffix`, and the companion aligner
-binaries (`wfmash`, `FastGA`) into `~/.cargo/bin/`.
+binaries (`wfmash`, `FastGA`) into `~/.cargo/bin/`, and the shared libraries
+they need into `~/.cargo/lib/`.
 
 ### Docker
 

--- a/build.rs
+++ b/build.rs
@@ -40,17 +40,16 @@ fn copy_dep_binary(build_dir: &Path, prefix: &str, binary_name: &str, dest_dir: 
         return; // silently skip if not found
     };
 
-    // Copy to profile dir (e.g. target/release/)
+    // Copy to profile dir (e.g. target/release/). Always overwrite: a stale
+    // copy from an older dependency revision must not survive a version bump.
     let dest = dest_dir.join(binary_name);
-    if !dest.exists() {
-        if let Err(e) = fs::copy(&src, &dest) {
-            eprintln!(
-                "cargo:warning=Failed to copy {binary_name} to {}: {e}",
-                dest.display()
-            );
-        } else {
-            set_executable(&dest);
-        }
+    if let Err(e) = fs::copy(&src, &dest) {
+        eprintln!(
+            "cargo:warning=Failed to copy {binary_name} to {}: {e}",
+            dest.display()
+        );
+    } else {
+        set_executable(&dest);
     }
 
     // Copy to CARGO_HOME/bin/ if it exists (for `cargo install`)
@@ -71,19 +70,31 @@ fn copy_dep_binary(build_dir: &Path, prefix: &str, binary_name: &str, dest_dir: 
 }
 
 /// Search `build_dir` for `<prefix><hash>/out/<binary_name>`.
+///
+/// Several hash directories can coexist, one per dependency revision. Take the
+/// most recently modified one, otherwise a bumped revision keeps losing to a
+/// leftover build of the old one.
 fn find_binary_in_build(build_dir: &Path, prefix: &str, binary_name: &str) -> Option<PathBuf> {
     let entries = fs::read_dir(build_dir).ok()?;
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
-        if name_str.starts_with(prefix) {
-            let candidate = entry.path().join("out").join(binary_name);
-            if candidate.is_file() {
-                return Some(candidate);
-            }
+        if !name_str.starts_with(prefix) {
+            continue;
+        }
+        let candidate = entry.path().join("out").join(binary_name);
+        if !candidate.is_file() {
+            continue;
+        }
+        let mtime = fs::metadata(&candidate)
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        if newest.as_ref().is_none_or(|(best, _)| mtime > *best) {
+            newest = Some((mtime, candidate));
         }
     }
-    None
+    newest.map(|(_, path)| path)
 }
 
 /// Copy shared libraries (*.so*, *.dylib) from `<prefix><hash>/out/` subdirectories
@@ -134,16 +145,14 @@ fn collect_shared_libs(dir: &Path, dest_dir: &Path) {
             continue;
         }
 
-        // Copy to profile dir
+        // Copy to profile dir, overwriting any stale copy
         let dest = dest_dir.join(&fname);
-        if !dest.exists() {
-            if let Err(e) = fs::copy(&path, &dest) {
-                eprintln!(
-                    "cargo:warning=Failed to copy {} to {}: {e}",
-                    fname_str,
-                    dest.display()
-                );
-            }
+        if let Err(e) = fs::copy(&path, &dest) {
+            eprintln!(
+                "cargo:warning=Failed to copy {} to {}: {e}",
+                fname_str,
+                dest.display()
+            );
         }
 
         // Copy to CARGO_HOME/lib/ if it exists

--- a/scripts/make-release-tarball.sh
+++ b/scripts/make-release-tarball.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Build a source tarball that contains the git submodules.
+#
+# GitHub's auto-generated tag tarballs omit submodules, so they cannot build
+# impg (vendor/gfaffix is a binary target, vendor/syng is compiled by build.rs).
+# Upload the tarball this script writes as a release asset, and point the
+# bioconda recipe at it.
+#
+# Usage: scripts/make-release-tarball.sh v0.5.0
+
+set -euxo pipefail
+
+TAG="${1:?usage: $0 <tag>   e.g. $0 v0.5.0}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+PREFIX="impg-${TAG}"
+OUT="${REPO_ROOT}/${PREFIX}.tar.gz"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "[tarball] staging ${PREFIX} from $(git rev-parse --short HEAD)"
+git archive --prefix="${PREFIX}/" HEAD | tar -x -C "$STAGE"
+
+echo "[tarball] adding submodules"
+git submodule update --init --recursive
+while read -r sm_path; do
+  echo "[tarball]   ${sm_path}"
+  git -C "$sm_path" archive --prefix="${PREFIX}/${sm_path}/" HEAD | tar -x -C "$STAGE"
+done < <(git submodule status --recursive | awk '{print $2}')
+
+echo "[tarball] verifying submodule contents landed"
+test -f "${STAGE}/${PREFIX}/vendor/gfaffix/src/main.rs"
+test -f "${STAGE}/${PREFIX}/vendor/syng/syngbwt3.c"
+test -f "${STAGE}/${PREFIX}/Cargo.lock"
+
+echo "[tarball] writing ${OUT}"
+rm -f "$OUT"
+tar -czf "$OUT" -C "$STAGE" "$PREFIX"
+
+set +x
+echo
+echo "wrote  $OUT"
+echo "size   $(du -h "$OUT" | cut -f1)"
+echo "sha256 $(sha256sum "$OUT" | cut -d' ' -f1)"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -965,26 +965,48 @@ pub fn sort_gfa_yg(gfa_content: &str, num_threads: usize) -> io::Result<String> 
     sort_gfa_pipeline(gfa_content, "Yg", num_threads)
 }
 
+/// Private install directory next to the running executable:
+/// `<exe_dir>/../libexec/<exe_stem>/`.
+///
+/// Package managers use this to keep bundled binaries out of `bin/`, where
+/// they would overwrite the separately packaged versions.
+pub fn libexec_dir() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe
+        .parent()?
+        .parent()?
+        .join("libexec")
+        .join(exe.file_stem()?);
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
 /// Run gfaffix graph normalization on a GFA string.
 ///
-/// Searches for the `gfaffix` binary next to the current executable
-/// (so it works when both are built together in `target/release/`).
+/// Searches for the `gfaffix` binary next to the current executable (so it
+/// works when both are built together in `target/release/`), then in
+/// `<exe_dir>/../libexec/<exe_stem>/` for packaged installs.
 /// The system PATH is intentionally NOT searched to avoid version mismatches.
 /// Returns an error if the binary is not found or fails.
 pub fn run_gfaffix(gfa_content: &str, _num_threads: usize) -> io::Result<String> {
     use std::process::Command;
 
-    // Resolve binary: sibling of current exe (e.g. target/release/gfaffix).
+    // Resolve binary: sibling of current exe (e.g. target/release/gfaffix),
+    // then the private install directory used by packagers.
     // The system PATH is intentionally NOT searched to avoid version mismatches.
     let gfaffix_bin = std::env::current_exe()
         .ok()
         .map(|exe| exe.with_file_name("gfaffix"))
         .filter(|p| p.exists())
+        .or_else(|| libexec_dir().map(|d| d.join("gfaffix")).filter(|p| p.exists()))
         .ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
-                "gfaffix binary not found next to impg executable. \
-                 It should have been built as a workspace member. \
+                "gfaffix binary not found next to the impg executable, nor in \
+                 ../libexec/impg/. It should have been built as a workspace member. \
                  Try rebuilding with `cargo build --release`.",
             )
         })?;


### PR DESCRIPTION
## 1. `impg graph` and `impg query -o gfa` failed in most directories

Both commands aborted with:

```
FAtoGDB failed with code None
stderr: *** buffer overflow detected ***: terminated
```

impg sets `TMPDIR` to its temp directory (`src/main.rs`), and that defaults to the current directory. `fastga-rs` had patched ONElib to honour `$TMPDIR`, but left the destination buffer at 64 bytes, while `/OneSchema.XXXXXX` plus the terminator needs 18. Any working directory longer than 46 characters therefore smashed the stack.

Bisected on 7 yeast chrV genomes:

| `$TMPDIR` length | before | after |
|---|---|---|
| 25, 45 | ok | ok |
| 55 - 205 | `*** buffer overflow detected ***` | ok |
| 505 | crash | clean `FATAL ERROR ... errno 36` |

Fixed in pangenome/fastga-rs#11 with a regression test, and pulled in here through sweepga `14f3eeb`.

## 2. Bundled tools can now live outside `bin/`

impg bundles `wfmash`, `gfaffix` and 7 FastGA utilities, and finds them next to its own executable rather than through `PATH`. A packager therefore had to install them into `bin/`, where they overwrite the separate `wfmash`, `gfaffix` and `fastga` conda packages. bioconda ships wfmash 0.24.2 while impg bundles 0.14.1, so installing impg silently downgraded a user's wfmash.

`impg`, `fastga-rs` (pangenome/fastga-rs#13) and `sweepga` (pangenome/sweepga#30) now also search `<exe_dir>/../libexec/<exe_stem>/`. Source installs are unaffected, because that directory does not exist for them.

Verified with a fake prefix: `impg` in `bin/`, the 9 tools in `libexec/impg/`, libraries in `lib/`, `PATH` cut down to `/usr/bin:/bin`, and a 68-character working directory. `impg graph` finished in 298 s and produced 51,726 segments.

## 3. `build.rs` never refreshed stale companion binaries

`find_binary_in_build` returned the **first** `fastga-rs-*` build directory it found, and the copy was skipped when the destination already existed. After a dependency bump, `target/release/FAtoGDB` therefore kept the old binary. This bit during testing: the layout test still crashed until I noticed it was running a `FAtoGDB` from 24 July. Now it takes the newest directory and always overwrites.

## 4. `build.rs` could copy nothing at all

Cargo only guarantees that a build script runs after the build scripts of its own **build**-dependencies. impg's `build.rs` only build-depends on `cc`, so cargo was free to run it before `wfmash-rs` had produced its binary. Measured in a clean build: `build.rs` copied `libwfa2.so` at 14:46:09, and `out/wfmash` only appeared at 14:46:24. The result was a `target/release/` with no `wfmash`, `FastGA` or `FAtoGDB`.

It normally goes unnoticed, because a second build finds the binaries already in place, and CI restores them from cache. A clean machine does not.

`wfmash-rs` and `fastga-rs` are now declared as build-dependencies, pinned to the same revisions sweepga uses so nothing is built twice.

## 5. Release tarball

`scripts/make-release-tarball.sh` produces a source tarball that contains `vendor/gfaffix` and `vendor/syng`. The GitHub tag tarballs do not, so they cannot build. The bioconda recipe will point at this asset.