### PR TITLE
deps: one lib_wfa2 everywhere, fix aarch64 and the conda build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "allwave"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/allwave?rev=6b2798aa9fd405abe680cfb1e644331eff9d58e0#6b2798aa9fd405abe680cfb1e644331eff9d58e0"
+source = "git+https://github.com/pangenome/allwave?rev=3050f6a457abcee24ce9a31a69c36ccb64744f54#3050f6a457abcee24ce9a31a69c36ccb64744f54"
 dependencies = [
  "atty",
  "bio",
@@ -1039,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1632,7 +1632,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/ekg/lib_wfa2?rev=2f9d9a48addee5185d8ff6ed0594182558d60818#2f9d9a48addee5185d8ff6ed0594182558d60818"
+source = "git+https://github.com/AndreaGuarracino/lib_wfa2?rev=fe882ce5f6d4aafc8078a3cdf4b7e69f050b5ef2#fe882ce5f6d4aafc8078a3cdf4b7e69f050b5ef2"
 
 [[package]]
 name = "libc"
@@ -2838,7 +2838,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3212,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3339,7 +3339,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "tpa"
 version = "0.1.0"
-source = "git+https://github.com/AndreaGuarracino/tpa?rev=49f1801f9e0108c211571fa2614e517009446afe#49f1801f9e0108c211571fa2614e517009446afe"
+source = "git+https://github.com/AndreaGuarracino/tpa?rev=439d2786fd221b95b77b1f7dabb9d2b51d617435#439d2786fd221b95b77b1f7dabb9d2b51d617435"
 dependencies = [
  "bgzip",
  "env_logger",
@@ -3355,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "tracepoints"
 version = "0.1.0"
-source = "git+https://github.com/AndreaGuarracino/tracepoints?rev=66a5511b0b84d8502f9d7c99efd150616ff2cae3#66a5511b0b84d8502f9d7c99efd150616ff2cae3"
+source = "git+https://github.com/AndreaGuarracino/tracepoints?rev=46ca24b0f2f33e36129dfccd50d4d86b8c63fb09#46ca24b0f2f33e36129dfccd50d4d86b8c63fb09"
 dependencies = [
  "lib_wfa2",
 ]
@@ -3653,7 +3653,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "allwave"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/allwave?rev=3050f6a457abcee24ce9a31a69c36ccb64744f54#3050f6a457abcee24ce9a31a69c36ccb64744f54"
+source = "git+https://github.com/pangenome/allwave?rev=87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4#87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4"
 dependencies = [
  "atty",
  "bio",
@@ -1564,7 +1564,7 @@ dependencies = [
  "niffler",
  "noodles 0.100.0",
  "num_cpus",
- "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=38182c7acf7cccc53509176b1d11001ae6ff2642)",
+ "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34)",
  "poasta",
  "povu-rs",
  "ragc-core",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "lib_wfa2"
 version = "0.1.0"
-source = "git+https://github.com/AndreaGuarracino/lib_wfa2?rev=fe882ce5f6d4aafc8078a3cdf4b7e69f050b5ef2#fe882ce5f6d4aafc8078a3cdf4b7e69f050b5ef2"
+source = "git+https://github.com/AndreaGuarracino/lib_wfa2?rev=32ad5bb4442df4a5782b35bf024a319ba0676f50#32ad5bb4442df4a5782b35bf024a319ba0676f50"
 
 [[package]]
 name = "libc"
@@ -2301,16 +2301,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "onecode"
-version = "0.1.0"
-source = "git+https://github.com/pangenome/onecode-rs?rev=38182c7acf7cccc53509176b1d11001ae6ff2642#38182c7acf7cccc53509176b1d11001ae6ff2642"
-dependencies = [
- "bindgen 0.70.1",
- "cc",
- "libc",
-]
 
 [[package]]
 name = "onecode"
@@ -3339,7 +3329,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "tpa"
 version = "0.1.0"
-source = "git+https://github.com/AndreaGuarracino/tpa?rev=439d2786fd221b95b77b1f7dabb9d2b51d617435#439d2786fd221b95b77b1f7dabb9d2b51d617435"
+source = "git+https://github.com/AndreaGuarracino/tpa?rev=989ca3b7a3ffa9bb26708b17ef5cf093a22a5163#989ca3b7a3ffa9bb26708b17ef5cf093a22a5163"
 dependencies = [
  "bgzip",
  "env_logger",
@@ -3355,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "tracepoints"
 version = "0.1.0"
-source = "git+https://github.com/AndreaGuarracino/tracepoints?rev=46ca24b0f2f33e36129dfccd50d4d86b8c63fb09#46ca24b0f2f33e36129dfccd50d4d86b8c63fb09"
+source = "git+https://github.com/AndreaGuarracino/tracepoints?rev=5303cde5359ffd9c54234a825d1923d26a2a0b20#5303cde5359ffd9c54234a825d1923d26a2a0b20"
 dependencies = [
  "lib_wfa2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,15 +48,15 @@ ragc-core = { git = "https://github.com/AndreaGuarracino/ragc", rev = "ebfa5eb24
 
 # Dependencies for 1ALN format (for alignments) support
 #onecode = { path = "/home/guarracino/git/onecode-rs" }
-onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "38182c7acf7cccc53509176b1d11001ae6ff2642"}
+onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34" }
 # Dependencies for TPA format (for alignments) support
 #tpa = { path = "/home/guarracino/git/tpa" }
-tpa = { git = "https://github.com/AndreaGuarracino/tpa", rev = "439d2786fd221b95b77b1f7dabb9d2b51d617435" }
+tpa = { git = "https://github.com/AndreaGuarracino/tpa", rev = "989ca3b7a3ffa9bb26708b17ef5cf093a22a5163" }
 # Dependencies for 1ALN and TPA formats (for alignments) support
-lib_wfa2 = { git = "https://github.com/AndreaGuarracino/lib_wfa2", rev = "fe882ce5f6d4aafc8078a3cdf4b7e69f050b5ef2" }
+lib_wfa2 = { git = "https://github.com/AndreaGuarracino/lib_wfa2", rev = "32ad5bb4442df4a5782b35bf024a319ba0676f50" }
 #lib_wfa2 = { path = "/home/guarracino/Dropbox/git//lib_wfa2"}
 #tracepoints = { path = "/home/guarracino/Dropbox/git/tracepoints"}
-tracepoints = { git = "https://github.com/AndreaGuarracino/tracepoints", rev = "46ca24b0f2f33e36129dfccd50d4d86b8c63fb09" }
+tracepoints = { git = "https://github.com/AndreaGuarracino/tracepoints", rev = "5303cde5359ffd9c54234a825d1923d26a2a0b20" }
 
 # Dependencies for lace functionality
 handlegraph = { git = "https://github.com/chfi/rs-handlegraph", rev = "3ac575e4216ce16a16667503a8875e469a40a97a" }
@@ -72,7 +72,7 @@ gzp = "1.0.1"
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "14f3eeb", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
-allwave = { git = "https://github.com/pangenome/allwave", rev = "3050f6a457abcee24ce9a31a69c36ccb64744f54", default-features = false }
+allwave = { git = "https://github.com/pangenome/allwave", rev = "87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4", default-features = false }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,12 @@ ragc-core = { git = "https://github.com/AndreaGuarracino/ragc", rev = "ebfa5eb24
 onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "38182c7acf7cccc53509176b1d11001ae6ff2642"}
 # Dependencies for TPA format (for alignments) support
 #tpa = { path = "/home/guarracino/git/tpa" }
-tpa = { git = "https://github.com/AndreaGuarracino/tpa", rev = "49f1801f9e0108c211571fa2614e517009446afe" }
+tpa = { git = "https://github.com/AndreaGuarracino/tpa", rev = "439d2786fd221b95b77b1f7dabb9d2b51d617435" }
 # Dependencies for 1ALN and TPA formats (for alignments) support
-lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "2f9d9a48addee5185d8ff6ed0594182558d60818" }
+lib_wfa2 = { git = "https://github.com/AndreaGuarracino/lib_wfa2", rev = "fe882ce5f6d4aafc8078a3cdf4b7e69f050b5ef2" }
 #lib_wfa2 = { path = "/home/guarracino/Dropbox/git//lib_wfa2"}
 #tracepoints = { path = "/home/guarracino/Dropbox/git/tracepoints"}
-tracepoints = { git = "https://github.com/AndreaGuarracino/tracepoints", rev = "66a5511b0b84d8502f9d7c99efd150616ff2cae3" }
+tracepoints = { git = "https://github.com/AndreaGuarracino/tracepoints", rev = "46ca24b0f2f33e36129dfccd50d4d86b8c63fb09" }
 
 # Dependencies for lace functionality
 handlegraph = { git = "https://github.com/chfi/rs-handlegraph", rev = "3ac575e4216ce16a16667503a8875e469a40a97a" }
@@ -72,7 +72,7 @@ gzp = "1.0.1"
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
 sweepga = { git = "https://github.com/pangenome/sweepga", rev = "14f3eeb", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
-allwave = { git = "https://github.com/pangenome/allwave", rev = "6b2798aa9fd405abe680cfb1e644331eff9d58e0", default-features = false }
+allwave = { git = "https://github.com/pangenome/allwave", rev = "3050f6a457abcee24ce9a31a69c36ccb64744f54", default-features = false }
 
 # Dependencies for graph sorting
 gfasort = { git = "https://github.com/pangenome/gfasort", rev = "f15d8ebfdc632af2333f277cb9da0748d8fba7aa" }
@@ -88,9 +88,6 @@ cc = "1"
 # ones sweepga pins, otherwise cargo builds each crate twice.
 wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
 fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "2da9567" }
-
-[patch."https://github.com/AndreaGuarracino/lib_wfa2"]
-lib_wfa2 = { git = "https://github.com/ekg/lib_wfa2", rev = "2f9d9a48addee5185d8ff6ed0594182558d60818" }
 
 [dev-dependencies]
 ahash = "0.8"

--- a/src/tpa_parser.rs
+++ b/src/tpa_parser.rs
@@ -199,6 +199,15 @@ impl TpaParser {
                     }
                 }
             }
+            TracepointData::FastgaNoDiff(target_deltas) => {
+                // Same as Fastga with the diff counts dropped. Reconstruction
+                // re-aligns each segment, so a zero diff only costs the identity
+                // estimate, which reports no mismatches for these alignments.
+                for target_delta in target_deltas {
+                    tracepoints.push(target_delta as i64);
+                    trace_diffs.push(0);
+                }
+            }
         }
 
         let mode_data = if matches!(tp_type, tpa::TracepointType::Fastga) {


### PR DESCRIPTION
Fixes two build failures found by bioconda CI for v0.5.0.

**aarch64 did not compile.** `lib_wfa2::align` cast its input to a concrete `*const i8`. `c_char` is `u8` on aarch64-linux, so that only matched on x86-64. It now casts to `c_char` by name.

**The conda build died in bindgen.** `onecode` emitted `_IO_FILE` as an empty struct while asserting its real 216-byte size. It moves to `f531f5b`, which ships pre-generated bindings.

**One lib_wfa2.** The `ekg` and `AndreaGuarracino` forks had diverged, and impg reconciled them with two `[patch]` entries. Everything now uses `AndreaGuarracino/lib_wfa2` `32ad5bb`, and both patches are gone. That repo gained the scope and span setters plus the `with_penalties_*` constructors allwave needs, so allwave keeps its match penalty instead of dropping it.

Also handles the new `TracepointData::FastgaNoDiff`: same target deltas as `Fastga` without diff counts. Reconstruction re-aligns each segment, so only the identity estimate is affected.

572 tests pass. This pulls in a different WFA2-lib submodule and 27 new tpa / 32 new tracepoints commits.