### PR TITLE
release: 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "impg"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "allwave",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impg"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Andrea Guarracino <aguarracino@tgen.org>"]
 


### PR DESCRIPTION
Ships the aarch64 and conda build fixes from #230.

v0.5.0 could not build on aarch64, and could not build under conda at all, so bioconda never produced a package for it.