### PR TITLE
deps: fix aarch64 and macOS builds

### DIFF
--- a/.github/workflows/rust_build_test.yml
+++ b/.github/workflows/rust_build_test.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # ubuntu-24.04-arm catches aarch64-linux bugs that no other runner sees.
+        # c_char is unsigned there and signed on x86-64 and on Apple ARM, so a
+        # cast to a concrete i8 compiles everywhere else and fails only here.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,14 +1045,14 @@ dependencies = [
 [[package]]
 name = "fastga-rs"
 version = "0.1.2"
-source = "git+https://github.com/pangenome/fastga-rs?rev=2da9567#2da95679886f8d5674406ae444494ac3022afda1"
+source = "git+https://github.com/pangenome/fastga-rs?rev=b8efc7f8886c9772b6a4d4f22c642807cb43da01#b8efc7f8886c9772b6a4d4f22c642807cb43da01"
 dependencies = [
  "anyhow",
  "cc",
  "libc",
  "nix",
  "num_cpus",
- "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs)",
+ "onecode",
  "pkg-config",
  "tempfile",
  "thiserror 1.0.69",
@@ -1564,7 +1564,7 @@ dependencies = [
  "niffler",
  "noodles 0.100.0",
  "num_cpus",
- "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34)",
+ "onecode",
  "poasta",
  "povu-rs",
  "ragc-core",
@@ -2305,16 +2305,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onecode"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/onecode-rs?rev=f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34#f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "onecode"
-version = "0.1.0"
-source = "git+https://github.com/pangenome/onecode-rs#f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34"
+source = "git+https://github.com/pangenome/onecode-rs?rev=5fa1e9333f18b311580f1346751c630c626d8342#5fa1e9333f18b311580f1346751c630c626d8342"
 dependencies = [
  "cc",
  "libc",
@@ -3110,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=14f3eeb#14f3eeb6d36d179fb7a9d682f8ae556875d4c747"
+source = "git+https://github.com/pangenome/sweepga?rev=f409ab36f6039abd57cec456db6be2cccd1abd40#f409ab36f6039abd57cec456db6be2cccd1abd40"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3124,7 +3115,7 @@ dependencies = [
  "log",
  "nom 7.1.3",
  "noodles 0.100.0",
- "onecode 0.1.0 (git+https://github.com/pangenome/onecode-rs?rev=f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34)",
+ "onecode",
  "ordered-float 4.6.0",
  "ragc-core",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "fastga-rs"
 version = "0.1.2"
-source = "git+https://github.com/pangenome/fastga-rs?rev=b8efc7f8886c9772b6a4d4f22c642807cb43da01#b8efc7f8886c9772b6a4d4f22c642807cb43da01"
+source = "git+https://github.com/pangenome/fastga-rs?rev=5216a157f761545c9c3160ea1501ef1beab9c663#5216a157f761545c9c3160ea1501ef1beab9c663"
 dependencies = [
  "anyhow",
  "cc",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=ae966f3e9977178349a6cff3b238535c99e675ca#ae966f3e9977178349a6cff3b238535c99e675ca"
+source = "git+https://github.com/pangenome/sweepga?rev=fb2d9aae9cc83e1e198bb7b64cbbdfa7b7c33683#fb2d9aae9cc83e1e198bb7b64cbbdfa7b7c33683"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=f409ab36f6039abd57cec456db6be2cccd1abd40#f409ab36f6039abd57cec456db6be2cccd1abd40"
+source = "git+https://github.com/pangenome/sweepga?rev=ae966f3e9977178349a6cff3b238535c99e675ca#ae966f3e9977178349a6cff3b238535c99e675ca"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "wfmash-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/wfmash-rs?rev=3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6#3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6"
+source = "git+https://github.com/pangenome/wfmash-rs?rev=91d24d26be32fbac351fcc66a259461333693e09#91d24d26be32fbac351fcc66a259461333693e09"
 dependencies = [
  "anyhow",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ gzp = "1.0.1"
 # 04f9edb = ddd31d3 (pansn-sparsification) + wfmash-rs 3cc6677 (vendored wfmash v0.14.1).
 # PanSN haplotype grouping + wfmash-per-hap-pair joblist live upstream;
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "ae966f3e9977178349a6cff3b238535c99e675ca", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "fb2d9aae9cc83e1e198bb7b64cbbdfa7b7c33683", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
 allwave = { git = "https://github.com/pangenome/allwave", rev = "87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4", default-features = false }
 
@@ -87,7 +87,7 @@ cc = "1"
 # Without them build.rs can run first and copy nothing. Revisions must match the
 # ones sweepga pins, otherwise cargo builds each crate twice.
 wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "91d24d26be32fbac351fcc66a259461333693e09" }
-fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "b8efc7f8886c9772b6a4d4f22c642807cb43da01" }
+fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "5216a157f761545c9c3160ea1501ef1beab9c663" }
 
 [dev-dependencies]
 ahash = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ragc-core = { git = "https://github.com/AndreaGuarracino/ragc", rev = "ebfa5eb24
 
 # Dependencies for 1ALN format (for alignments) support
 #onecode = { path = "/home/guarracino/git/onecode-rs" }
-onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34" }
+onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "5fa1e9333f18b311580f1346751c630c626d8342" }
 # Dependencies for TPA format (for alignments) support
 #tpa = { path = "/home/guarracino/git/tpa" }
 tpa = { git = "https://github.com/AndreaGuarracino/tpa", rev = "989ca3b7a3ffa9bb26708b17ef5cf093a22a5163" }
@@ -70,7 +70,7 @@ gzp = "1.0.1"
 # 04f9edb = ddd31d3 (pansn-sparsification) + wfmash-rs 3cc6677 (vendored wfmash v0.14.1).
 # PanSN haplotype grouping + wfmash-per-hap-pair joblist live upstream;
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "14f3eeb", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "f409ab36f6039abd57cec456db6be2cccd1abd40", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
 allwave = { git = "https://github.com/pangenome/allwave", rev = "87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4", default-features = false }
 
@@ -87,7 +87,7 @@ cc = "1"
 # Without them build.rs can run first and copy nothing. Revisions must match the
 # ones sweepga pins, otherwise cargo builds each crate twice.
 wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
-fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "2da9567" }
+fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "b8efc7f8886c9772b6a4d4f22c642807cb43da01" }
 
 [dev-dependencies]
 ahash = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ gzp = "1.0.1"
 # 04f9edb = ddd31d3 (pansn-sparsification) + wfmash-rs 3cc6677 (vendored wfmash v0.14.1).
 # PanSN haplotype grouping + wfmash-per-hap-pair joblist live upstream;
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "f409ab36f6039abd57cec456db6be2cccd1abd40", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "ae966f3e9977178349a6cff3b238535c99e675ca", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
 allwave = { git = "https://github.com/pangenome/allwave", rev = "87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4", default-features = false }
 
@@ -86,7 +86,7 @@ cc = "1"
 # own build-dependencies, so declare these here even though the code is unused.
 # Without them build.rs can run first and copy nothing. Revisions must match the
 # ones sweepga pins, otherwise cargo builds each crate twice.
-wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
+wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "91d24d26be32fbac351fcc66a259461333693e09" }
 fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "b8efc7f8886c9772b6a4d4f22c642807cb43da01" }
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -208,6 +208,9 @@ fn compile_syng() {
         .include(&syng_dir)
         .opt_level(3)
         .define("ONEIO", None)
+        // syng was written where char is signed. It is unsigned on aarch64, and
+        // there syngBWTadvanceRank walked to a negative node and aborted.
+        .flag_if_supported("-fsigned-char")
         .warnings(false);
 
     for file in &c_files {

--- a/examples/syng_probe.rs
+++ b/examples/syng_probe.rs
@@ -37,7 +37,7 @@ fn raw_syncmer_positions(seq: &[u8], params: SyncmerParams) -> Vec<i32> {
     unsafe {
         let sh =
             syng_ffi::impg_seqhashCreateSafe(params.k as i32, params.w as i32, params.seed as i32);
-        let sit = syng_ffi::syncmerIterator(sh, seq_buf.as_mut_ptr() as *mut i8, seq_len as i32);
+        let sit = syng_ffi::syncmerIterator(sh, seq_buf.as_mut_ptr() as *mut std::os::raw::c_char, seq_len as i32);
         let mut pos: i32 = 0;
         while syng_ffi::syncmerNext(sit, std::ptr::null_mut(), &mut pos, std::ptr::null_mut()) {
             positions.push(pos);

--- a/src/syng.rs
+++ b/src/syng.rs
@@ -2004,7 +2004,7 @@ fn matched_syncmers_in_sequence_impl(
     unsafe {
         let sit = syng_ffi::syncmerIterator(
             seqhash,
-            seq_buf.as_mut_ptr() as *mut i8,
+            seq_buf.as_mut_ptr() as *mut std::os::raw::c_char,
             query_seq.len() as i32,
         );
         let mut pos: i32 = 0;
@@ -2023,7 +2023,7 @@ fn matched_syncmers_in_sequence_impl(
             let mut kmer_index: i64 = 0;
             if syng_ffi::kmerHashFindThreadSafe(
                 kmer_hash,
-                seq_buf.as_mut_ptr().add(start) as *mut i8,
+                seq_buf.as_mut_ptr().add(start) as *mut std::os::raw::c_char,
                 &mut kmer_index,
                 kmer_buf.as_mut_ptr(),
             ) {
@@ -2549,14 +2549,14 @@ impl SyngIndex {
         unsafe {
             let sit = syng_ffi::syncmerIterator(
                 self.seqhash,
-                seq_buf.as_mut_ptr() as *mut i8,
+                seq_buf.as_mut_ptr() as *mut std::os::raw::c_char,
                 seq_len as i32,
             );
 
             let mut pos: i32 = 0;
             while syng_ffi::syncmerNext(sit, std::ptr::null_mut(), &mut pos, std::ptr::null_mut()) {
                 let mut kmer_index: i64 = 0;
-                let syncmer_ptr = seq_buf.as_mut_ptr().add(pos as usize) as *mut i8;
+                let syncmer_ptr = seq_buf.as_mut_ptr().add(pos as usize) as *mut std::os::raw::c_char;
                 match lookup_mode {
                     SyncmerLookupMode::AddMissing => {
                         syng_ffi::kmerHashAdd(self.kmer_hash, syncmer_ptr, &mut kmer_index);

--- a/src/syng_parallel.rs
+++ b/src/syng_parallel.rs
@@ -97,7 +97,7 @@ pub fn extract_packed_syncmers(
         }
 
         let sit =
-            syng_ffi::syncmerIterator(seqhash, seq_buf.as_mut_ptr() as *mut i8, seq.len() as i32);
+            syng_ffi::syncmerIterator(seqhash, seq_buf.as_mut_ptr() as *mut std::os::raw::c_char, seq.len() as i32);
         if sit.is_null() {
             syng_ffi::impg_seqhashDestroy(seqhash);
             return Err(io::Error::other("syncmerIterator returned null"));


### PR DESCRIPTION
Fixes the three platforms that v0.5.1 still could not build. linux-64 already passes on bioconda.

**linux-aarch64.** `onecode` cast line types and string pointers to a concrete `i8`, the same `c_char` width bug as lib_wfa2: `i8` on x86-64, `u8` on aarch64-linux. 19 type errors. Fixed upstream in onecode-rs `5fa1e93`.

**osx-64.** `wfmash-rs` forced Homebrew GCC even when `CC` and `CXX` were already set. Under conda that GCC cannot parse the Xcode SDK headers and fails with `unknown type name 'FILE'`. The environment now wins.

**osx-arm64.** With no Homebrew GCC it fell back to clang 19, which rejects `Base::template do_pop_any(...)` in the vendored `atomic_queue.h`, since there is no template argument list. GCC accepts it. Removed in 4 places.

`onecode` and `fastga-rs` were pinned in several crates and every copy gets compiled, so all were bumped. The lock file now holds one copy each of onecode, fastga-rs, wfmash-rs, lib_wfa2 and sweepga.

572 tests pass.