### PR TITLE
release: 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "impg"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ahash",
  "allwave",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impg"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Andrea Guarracino <aguarracino@tgen.org>"]
 


### PR DESCRIPTION
Ships the aarch64 and macOS fixes from #232. v0.5.1 built only on linux-64.