### PR TITLE
release: back to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "impg"
-version = "0.5.1"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "allwave",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impg"
-version = "0.5.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Andrea Guarracino <aguarracino@tgen.org>"]
 


### PR DESCRIPTION
0.5.0 and 0.5.1 built only on linux-64, and neither was ever published to bioconda. Re-cutting 0.5.0 as the first release that works on all four platforms.