### PR TITLE
deps: drop the macOS 10.15 requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=fb2d9aae9cc83e1e198bb7b64cbbdfa7b7c33683#fb2d9aae9cc83e1e198bb7b64cbbdfa7b7c33683"
+source = "git+https://github.com/pangenome/sweepga?rev=a5c3c14d47c35b81081c2ab90b18bdad255bd9e2#a5c3c14d47c35b81081c2ab90b18bdad255bd9e2"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "wfmash-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/wfmash-rs?rev=91d24d26be32fbac351fcc66a259461333693e09#91d24d26be32fbac351fcc66a259461333693e09"
+source = "git+https://github.com/pangenome/wfmash-rs?rev=34339a7f5ead1c5f20ce5226bd5cc9c284d68a30#34339a7f5ead1c5f20ce5226bd5cc9c284d68a30"
 dependencies = [
  "anyhow",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ gzp = "1.0.1"
 # 04f9edb = ddd31d3 (pansn-sparsification) + wfmash-rs 3cc6677 (vendored wfmash v0.14.1).
 # PanSN haplotype grouping + wfmash-per-hap-pair joblist live upstream;
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "fb2d9aae9cc83e1e198bb7b64cbbdfa7b7c33683", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "a5c3c14d47c35b81081c2ab90b18bdad255bd9e2", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
 allwave = { git = "https://github.com/pangenome/allwave", rev = "87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4", default-features = false }
 
@@ -86,7 +86,7 @@ cc = "1"
 # own build-dependencies, so declare these here even though the code is unused.
 # Without them build.rs can run first and copy nothing. Revisions must match the
 # ones sweepga pins, otherwise cargo builds each crate twice.
-wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "91d24d26be32fbac351fcc66a259461333693e09" }
+wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "34339a7f5ead1c5f20ce5226bd5cc9c284d68a30" }
 fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "5216a157f761545c9c3160ea1501ef1beab9c663" }
 
 [dev-dependencies]


### PR DESCRIPTION
wfmash used `std::filesystem::path` for its index filename fields, which Apple marks available only from macOS 10.15. The conda osx-64 build failed with `'path' is unavailable`, and the alternative was pinning the deployment target.

pangenome/wfmash-rs 34339a7 replaces it with `std::string`, so the pin is unnecessary. Same change merged upstream into the v0.14.1 branch as waveygang/wfmash#404.

572 tests pass.