### PR TITLE
deps: re-vendor wfmash to v0.14.1 head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "sweepga"
 version = "0.1.1"
-source = "git+https://github.com/pangenome/sweepga?rev=a5c3c14d47c35b81081c2ab90b18bdad255bd9e2#a5c3c14d47c35b81081c2ab90b18bdad255bd9e2"
+source = "git+https://github.com/pangenome/sweepga?rev=6cf4a35b4b913233664fd299b8141e95b0ef6959#6cf4a35b4b913233664fd299b8141e95b0ef6959"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "wfmash-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/wfmash-rs?rev=34339a7f5ead1c5f20ce5226bd5cc9c284d68a30#34339a7f5ead1c5f20ce5226bd5cc9c284d68a30"
+source = "git+https://github.com/pangenome/wfmash-rs?rev=b55cf75a29c4570702675c7f4d67e99936de5fb7#b55cf75a29c4570702675c7f4d67e99936de5fb7"
 dependencies = [
  "anyhow",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ gzp = "1.0.1"
 # 04f9edb = ddd31d3 (pansn-sparsification) + wfmash-rs 3cc6677 (vendored wfmash v0.14.1).
 # PanSN haplotype grouping + wfmash-per-hap-pair joblist live upstream;
 # this impg tree just calls them. Handles 1 _or many_ input FASTAs.
-sweepga = { git = "https://github.com/pangenome/sweepga", rev = "a5c3c14d47c35b81081c2ab90b18bdad255bd9e2", default-features = false }
+sweepga = { git = "https://github.com/pangenome/sweepga", rev = "6cf4a35b4b913233664fd299b8141e95b0ef6959", default-features = false }
 seqwish = { git = "https://github.com/pangenome/seqwish", branch = "rust-3" }
 allwave = { git = "https://github.com/pangenome/allwave", rev = "87fbbb64a388d078e7f6f224e9eb6d5cbfc168f4", default-features = false }
 
@@ -86,7 +86,7 @@ cc = "1"
 # own build-dependencies, so declare these here even though the code is unused.
 # Without them build.rs can run first and copy nothing. Revisions must match the
 # ones sweepga pins, otherwise cargo builds each crate twice.
-wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "34339a7f5ead1c5f20ce5226bd5cc9c284d68a30" }
+wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "b55cf75a29c4570702675c7f4d67e99936de5fb7" }
 fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "5216a157f761545c9c3160ea1501ef1beab9c663" }
 
 [dev-dependencies]


### PR DESCRIPTION
The wfmash copy vendored in wfmash-rs was still at `f1025695` and had drifted five commits behind the v0.14.1 branch, missing wfmash's AGC archive support.

pangenome/wfmash-rs b55cf75 syncs it to v0.14.1 head (`3fb8f6d`), which also carries the `std::filesystem` removal from waveygang/wfmash#404.

Alignment output is unchanged: yeast chrV gives 7 mapped reads and 4,518,438 aligned bp before and after. 572 tests pass.